### PR TITLE
Patch core's create-sibling-ghlike to use new credential system

### DIFF
--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -28,10 +28,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Install dependencies
       run: |
         pip install -r requirements-devel.txt

--- a/datalad_next/__init__.py
+++ b/datalad_next/__init__.py
@@ -23,6 +23,10 @@ command_suite = (
 )
 
 
+# patch datalad-core
+import datalad_next.patches
+
+# register additional configuration items in datalad-core
 from datalad.interface.common_cfg import register_config
 from datalad.support.constraints import EnsureBool
 register_config(

--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -1,0 +1,1 @@
+import datalad_next.patches.create_sibling_ghlike

--- a/datalad_next/patches/create_sibling_ghlike.py
+++ b/datalad_next/patches/create_sibling_ghlike.py
@@ -1,0 +1,115 @@
+import logging
+
+from datalad.distributed.create_sibling_ghlike import _GitHubLike
+from datalad.downloaders.http import DEFAULT_USER_AGENT
+from datalad.support.exceptions import CapturedException
+from datalad_next.credman import CredentialManager
+
+lgr = logging.getLogger('datalad_next.create_sibling_ghlike')
+
+
+def _set_request_headers(self, credential_name, auth_info, require_token):
+    """Improve datalad-core's credential handling
+
+    This replacement makes the storage of a newly entered credential
+    conditional on a successful authorization, in the spirit of
+    datalad/datalad#3126.
+
+    Moreover, stored credentials now contain a `realm` property that
+    identified the API endpoint. This makes it possible to identify
+    candidates of suitable credentials without having to specific
+    their name, similar to a request context url used by the old
+    providers setup.
+
+    This automatic realm-based credential lookup is now also implemented.
+    When no credential name is specified, the most recently used
+    credential matching the API realm will be used automatically.
+    If determined like this, it will be tested for successfull
+    authorization, and will then be stored again with an updated
+    'last-used' timestamp.
+    """
+    credman = CredentialManager()
+    from_query = False
+    credential = None
+    if not credential_name:
+        # get the most recent credential by realm, because none was identified
+        creds = credman.query(realm=self.api_url, _sortby='last-used')
+        if creds:
+            # found one, also assign the name to be able to update
+            # it below
+            credential_name, credential  = creds[0]
+            from_query = True
+    if not credential:
+        # no credential yet
+        try:
+            credential = credman.get(
+                # if we have no name given, fall back on a generated one
+                # that may exist from times before realms were recorded
+                # properly, otherwise we would not be here
+                credential_name or urlparse(self.api_url).netloc,
+                _prompt=auth_info,
+                type='token',
+                realm=self.api_url,
+            )
+            if credential is None:
+                raise ValueError('No credential found')
+        except Exception as e:
+            lgr.debug('Token retrieval failed: %s', e)
+            lgr.warning(
+                'Cannot determine authorization token for %s', credential_name)
+            if require_token:
+                raise ValueError(
+                    f'Authorization required for {self.fullname}, '
+                    f'cannot find token for a credential {credential_name}.')
+            else:
+                lgr.warning("No token found for credential '%s'",
+                            credential_name)
+            credential = {}
+
+    self.request_headers = {
+        'user-agent': DEFAULT_USER_AGENT,
+        'authorization':
+        f'token {credential.get("secret", "NO-TOKEN-AVAILABLE")}',
+    }
+
+    if from_query or credential.pop('_edited', None):
+        # if the credential was determined based on the api realm or edited,
+        # test it so we know it (still) works before we save/update it
+        try:
+            self.authenticated_user
+        except Exception as e:
+            raise ValueError(
+                f"Credential {credential_name!r} did not yield successful "
+                "authorization") from e
+        # this went well, store
+        try:
+            credman.set(
+                credential_name,
+                _lastused=True,
+                **credential,
+            )
+        except Exception as e:
+            # we do not want to crash for any failure to store a
+            # credential
+            lgr.warn(
+                'Exception raised when storing credential %r %r: %s',
+                credential_name,
+                credential,
+                CapturedException(e),
+            )
+
+# patch the core class
+_GitHubLike._set_request_headers = _set_request_headers
+
+# update docs
+_GitHubLike.create_sibling_params['credential']._doc = """\
+name of the credential providing a personal access token
+to be used for authorization. The token can be supplied via
+configuration setting 'datalad.credential.<name>.secret', or
+environment variable DATALAD_CREDENTIAL_<NAME>_SECRET, or will
+be queried from the active credential store using the provided
+name. If none is provided, the last-used token for the
+API URL realm will be used. If no matching credential exists,
+a credential named after the hostname part of the API URL is tried
+as a last fallback."""
+

--- a/datalad_next/patches/tests/test_create_sibling_ghlike.py
+++ b/datalad_next/patches/tests/test_create_sibling_ghlike.py
@@ -1,0 +1,39 @@
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Test create publication target on Github-like platforms"""
+
+from datalad.distributed.tests.test_create_sibling_ghlike import *
+from datalad.distributed.tests.test_create_sibling_gin import *
+from datalad.distributed.tests.test_create_sibling_gitea import *
+from datalad.distributed.tests.test_create_sibling_github import *
+from datalad.distributed.tests.test_create_sibling_gogs import *
+
+
+# we overwrite this one from core, because it assumed the old credential
+# system to be used
+@with_tempfile
+def test_invalid_call(path):
+    # no dataset
+    assert_raises(ValueError, create_sibling_gin, 'bogus', dataset=path)
+    ds = Dataset(path).create()
+    # unsupported name
+    assert_raises(
+        ValueError,
+        ds.create_sibling_gin, 'bo  gus', credential='some')
+
+    # conflicting sibling name
+    ds.siblings('add', name='gin', url='http://example.com',
+                result_renderer='disabled')
+    res = ds.create_sibling_gin(
+        'bogus', name='gin', credential='some', on_failure='ignore',
+        dry_run=True)
+    assert_status('error', res)
+    assert_in_results(
+        res,
+        status='error',
+        message=('already has a configured sibling "%s"', 'gin'))


### PR DESCRIPTION
The switch makes the storage of a newly entered credential
conditional on a successful authorization, in the spirit of
datalad/datalad#3126.

Moreover, stored credentials now contain a `realm` property that identified the API endpoint. This makes it possible to identify candidates of suitable credentials without having to specific their name, similar to a request context url used by the old providers setup.

This automatic realm-based credential lookup is now also implemented. When no credential name is specified, the most recently used credential matching the API realm will be used automatically. If determined like this, it will be tested for successfull authorization, and will then be stored again with an updated 'last-used' timestamp.

This is the rest of the functionality from https://github.com/datalad/datalad/pull/6555 that was not yet incorporated in the "next" extension.