### PR TITLE
WIP: POC: ALT-2: Support exporttree git annex remotes

### DIFF
--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -1,1 +1,2 @@
 import datalad_next.patches.create_sibling_ghlike
+import datalad_next.patches.push_to_export_remote

--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from typing import (
     Dict,
     Generator,

--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -1,0 +1,73 @@
+import logging
+import sys
+from typing import (
+    Dict,
+    Generator,
+    Iterable,
+    Optional,
+    Union,
+)
+
+import datalad.core.distributed.push as push
+from datalad.distribution.dataset import Dataset
+from datalad.support.annexrepo import AnnexRepo
+from datalad_mihextras.export_to_webdav import ExportToWEBDAV
+
+
+__docformat__ = "restructuredtext"
+
+
+lgr = logging.getLogger('datalad_next.push_to_export_remote')
+
+
+def _is_export_remote_webdav(repo: AnnexRepo,
+                             target: str,
+                             ) -> bool:
+    """Check whether a remote has exporttree set to "yes"
+    :param repo: the repository that contains the remote
+    :param target: name of the remote that should be checked
+    :param res_kwargs: preset kwargs for the result
+    :return: True if git annex reports exporttree is yes, else False
+    """
+    remote_info = [
+        record
+        for record in repo.get_special_remotes().values()
+        if record.get("name") == target and record.get("type") == "webdav"]
+    if len(remote_info) == 1:
+        return remote_info[0].get("exporttree") == "yes"
+    return False
+
+
+def _transfer_data(repo: AnnexRepo,
+                   ds: Dataset,
+                   target: str,
+                   content: Iterable,
+                   data: str,
+                   force: Optional[str],
+                   jobs: Optional[Union[str, int]],
+                   res_kwargs: Dict,
+                   got_path_arg: bool
+                   ) -> Generator:
+
+    if _is_export_remote_webdav(repo, target):
+        yield from ExportToWEBDAV()(
+            dataset=ds,
+            to=target,
+            url=None,
+            mode="auto"
+        )
+    else:
+        yield from push._push_data(
+            ds,
+            target,
+            content,
+            data,
+            force,
+            jobs,
+            res_kwargs.copy(),
+            got_path_arg=got_path_arg,
+        )
+
+
+lgr.debug("Patching datalad.core.distributed.push._transfer_data")
+push._transfer_data = _transfer_data

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ classifiers =
 python_requires = >= 3.6
 install_requires =
     datalad >= 0.15.6
+    datalad-mihextras
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
This PR is an alternative to PR #4 
This PR partially solves issue #3, it does not touch authentication

This PR adds a patch that will patch push in datalad.core.distributed.push, so that it supports "pushing" to a git annex special remote that has exporttree == yes. Instead of using `git push` this code will use `git annex export HEAD --to <remote>`.

- [ ] ensure that all necessary checks are done before and after calling `git annex export ...`
