### PR TITLE
Add a first version of create-sibling-webdav

### DIFF
--- a/datalad_next/__init__.py
+++ b/datalad_next/__init__.py
@@ -19,6 +19,12 @@ command_suite = (
             # name of the command class implementation in above module
             'Credentials',
         ),
+        (
+            # importable module that contains the command implementation
+            'datalad_next.create_sibling_webdav',
+            # name of the command class implementation in above module
+            'CreateSiblingWebDAV',
+        ),
     ]
 )
 

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -204,6 +204,7 @@ class CreateSiblingWebDAV(Interface):
             if failed:
                 return
 
+        return
         # TODO the rest should be wrapped into a helper function and be executed with
         # foreach-dataset
 

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -1,0 +1,157 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the datalad package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""High-level interface for creating a combi-target on a WebDAV capable server
+ """
+import logging
+import os
+from typing import (
+    Optional,
+    Union,
+)
+from urllib.parse import urlparse
+
+from datalad.distribution.dataset import (
+    Dataset,
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.downloaders.credentials import UserPassword
+from datalad.interface.base import Interface
+from datalad.interface.utils import eval_results
+from datalad.support.param import Parameter
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.constraints import (
+    EnsureNone,
+    EnsureStr,
+)
+
+
+__docformat__ = "restructuredtext"
+
+lgr = logging.getLogger('datalad_next.create_sibling_webdav')
+
+
+class CreateSiblingWebDAV(Interface):
+    """
+
+    """
+    _examples_ = [
+    ]
+
+    _params_ = dict(
+        url=Parameter(
+            args=("url",),
+            metavar="https://<host>[:<port>]/<local part>",
+            doc="URL identifying the target WebDAV server",
+            constraints=EnsureStr()),
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to process.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        name=Parameter(
+            args=('-s', '--name',),
+            metavar='NAME',
+            doc="Name of the sibling.",
+            constraints=EnsureStr() | EnsureNone(),
+            required=True),
+        credential=Parameter(
+            args=("--credential",),
+            doc="""Name of the credentials that should be used to access
+            the WebDAV server.""",
+        )
+    )
+
+    @staticmethod
+    @datasetmethod(name='create_sibling_webdav')
+    @eval_results
+    def __call__(
+            url: str,
+            *,
+            dataset: Optional[Union[str, Dataset]] = None,
+            name: Optional[str] = None,
+            credential: Optional[str] = None):
+        """
+
+        :param url:
+        :param dataset:
+        :param name:
+        :param credential:
+        :return: a generator yielding result records
+        """
+
+        ds = require_dataset(
+            dataset or ".",
+            check_installed=True,
+            purpose=f'create WebDAV sibling(s)')
+
+        res_kwargs = dict(
+            action=f'create_sibling_webdav',
+            logger=lgr,
+            refds=ds.path,
+        )
+
+        if not isinstance(ds.repo, AnnexRepo):
+            yield {
+                **res_kwargs,
+                "status": "error",
+                "msg": "require annex repo to create WebDAV sibling"
+            }
+            return
+
+        parser_url = urlparse(url)
+        if parser_url.query:
+            yield {
+                **res_kwargs,
+                "status": "error",
+                "msg": "URLs with query are not yet supported"
+            }
+            return
+
+        name_base = name or parser_url.hostname
+        git_name = name_base + "-wd-vcs"
+        annex_name = name_base + "-wd-tree"
+
+        datalad_annex_url = (
+            "datalad_annex::"
+            + url
+            + "?type=webdav&url={noquery}&encryption=none&exporttree=yes"
+            + "" if credential is None else f"&dlacredential={credential}"
+        )
+
+        # Add the datalad_annex:: sibling to datalad
+        from datalad.api import siblings
+
+        siblings(
+            action="add",
+            dataset=ds,
+            name=git_name,
+            url=datalad_annex_url)
+
+        # Add a git-annex webdav special remote. This might requires to set
+        # the webdav environment variables accordingly.
+
+        credential_holder = UserPassword(name=credential)()
+        os.environ["WEBDAV_USERNAME"] = credential_holder["user"]
+        os.environ["WEBDAV_PASSWORD"] = credential_holder["password"]
+        ds.repo.call_annex([
+            "initremote",
+            annex_name,
+            "type=webdav",
+            f"url={url}",
+            "exporttree=yes",
+            "encryption=none"
+        ])
+
+        yield {
+            **res_kwargs,
+            "status": "ok"
+        }

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -34,6 +34,7 @@ from datalad.interface.common_opts import (
 )
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import eval_results
+from datalad.log import log_progress
 from datalad.support.param import Parameter
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.constraints import (

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -301,7 +301,7 @@ class CreateSiblingWebDAV(Interface):
         except Exception as e:
             # we do not want to crash for any failure to store a
             # credential
-            lgr.warn(
+            lgr.warning(
                 'Exception raised when storing credential %r %r: %s',
                 *cred,
                 CapturedException(e),

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -142,10 +142,10 @@ class CreateSiblingWebDAV(Interface):
             dataset: Optional[Union[str, Dataset]] = None,
             name: Optional[str] = None,
             storage_name: Optional[str] = None,
-            storage_sibling: Optional[str] = 'yes',
+            storage_sibling: str = 'yes',
             credential: Optional[str] = None,
             existing: Optional[str] = None,
-            recursive: Optional[bool] = False,
+            recursive: bool = False,
             recursion_limit: Optional[int] = None):
 
         # TODO catch broken URLs

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -307,13 +307,13 @@ class CreateSiblingWebDAV(Interface):
                 CapturedException(e),
             )
         return
-        # TODO the rest should be wrapped into a helper function and be executed with
-        # foreach-dataset
 
-        name_base = name or parsed_url.hostname
-        git_name = name_base + "-wd-vcs"
-        annex_name = name_base + "-wd-tree"
-
+        # TODO the code below should be wrapped into a helper function and be
+        #  executed with foreach-dataset:
+        #
+        # name_base = name or parsed_url.hostname
+        # git_name = name_base + "-wd-vcs"
+        # annex_name = name_base + "-wd-tree"
 
 
 def _get_url_credential(credential_name, url, credman):

--- a/datalad_next/http_support.py
+++ b/datalad_next/http_support.py
@@ -1,0 +1,73 @@
+import requests
+import www_authenticate
+from datalad.downloaders.http import DEFAULT_USER_AGENT 
+
+
+def probe_url(url, timeout=10.0, headers=None):
+    """Probe a HTTP(S) URL for redirects and authentication needs
+
+    This functions performs a HEAD request against the given URL,
+    while waiting at most for the given timeout duration for
+    a server response.
+
+    Parameters
+    ----------
+    url: str
+      URL to probe
+    timeout: float, optional
+      Maximum time to wait for a server response to the probe
+    headers: dict, optional
+      Any custom headers to use for the probe request. If none are
+      provided, or the provided headers contain no 'user-agent'
+      field, the default DataLad user agent is added automatically.
+
+    Returns
+    -------
+    str or None, dict
+      The first value is the URL against the final request was
+      performed, after following any redirects and applying
+      normalizations.
+
+      The second value is a mapping with a particular set of
+      properties inferred from probing the webserver. The following
+      key-value pairs are supported:
+
+      - 'is_redirect' (bool), True if any redirection occurred. This
+        boolean property is a more accurate test than comparing
+        input and output URL
+      - 'status_code' (int), HTTP response code (of the final request
+        in case of redirection).
+      - 'auth' (dict), present if the final server response contained any
+        'www-authenticate' headers, typically the case for 401 responses.
+        The dict contains a mapping of server-reported authentication
+        scheme names (e.g., 'basic', 'bearer') to their respective
+        properties (dict). These can be any nature and number, depending
+        on the respective authentication scheme. Most notably, they
+        may contain a 'realm' property that can be used to determine
+        suitable credentials for authentication.
+
+    Raises
+    ------
+    requests.RequestException
+      May raise any exception of the `requests` package, most notably
+      `ConnectionError`, `Timeout`, `TooManyRedirects`, etc.
+    """
+    hdrs = {'user-agent': DEFAULT_USER_AGENT}
+    if headers is None:
+        headers = hdrs
+    elif 'user-agent' not in headers:
+        headers.update(hdrs)
+
+    props = {}
+    req = requests.head(
+        url,
+        allow_redirects=True,
+        timeout=timeout,
+        headers=headers,
+    )
+    if 'www-authenticate' in req.headers:
+        props['auth'] = www_authenticate.parse(
+            req.headers['www-authenticate'])
+    props['is_redirect'] = True if req.history else False
+    props['status_code'] = req.status_code
+    return req.url, props

--- a/datalad_next/http_support.py
+++ b/datalad_next/http_support.py
@@ -1,6 +1,9 @@
+from urllib.parse import urlparse
 import requests
 import www_authenticate
 from datalad.downloaders.http import DEFAULT_USER_AGENT 
+
+__all__ = ['probe_url', 'get_auth_realm']
 
 
 def probe_url(url, timeout=10.0, headers=None):
@@ -71,3 +74,67 @@ def probe_url(url, timeout=10.0, headers=None):
     props['is_redirect'] = True if req.history else False
     props['status_code'] = req.status_code
     return req.url, props
+
+
+def get_auth_realm(url, auth_info, scheme=None):
+    """Determine an authentication realm identifier from a HTTP response.
+
+    Examples
+    --------
+    Robustly determine a realm identifier for any URL::
+
+       >>> url, props = probe_url('https://fz-juelich.sciebo.de/...')
+       >>> get_auth_realm(url, props.get('auth'))
+       'https://fz-juelich.sciebo.de/sciebo'
+
+    Parameters
+    ----------
+    url: str
+      A URL as returned by `probe_url()`
+    auth_info: dict
+      A mapping of supported authentication schemes to the properties
+      (i.e., a 'www-authenticate' response header), as returned by
+      `probe_url()`'s 'auth' property.
+    scheme: str, optional
+      Which specific authentication to report a realm for, in case
+      multiple are supported (such as 'basic', or 'token').
+      If not given, the first (if any) reported authentication
+      scheme is reported on.
+
+    Returns
+    -------
+    str
+      A server-specific realm identifier
+    """
+    if not auth_info:
+        # no info from the server on what it needs
+        # out best bet is the URL itself
+        return url
+    if scheme:
+        auth_info = auth_info[scheme]
+    else:
+        scheme, auth_info = auth_info.popitem()
+    # take any, but be satisfied with none too
+    realm = auth_info.get('realm', '')
+    # a realm is supposed to indicate a validity scope of a credential
+    # on a server. so we make sure to have the return realm identifier
+    # actually indicate a server too, in order to make it suitable for
+    # a global credential lookup
+    if _is_valid_url(realm):
+        # the realm is already a valid URL with a server specification.
+        # we can simply relay it as such, following the admins' judgement
+        return realm
+    else:
+        # the realm was just some kind of string. we prefix it with the
+        # netloc of the given URL (ignoring its path) to achieve
+        # the same server-specific realm semantics
+        parsed = urlparse(url)
+        return f'{parsed.scheme}://{parsed.netloc}/{realm}'
+
+
+def _is_valid_url(url):
+    try:
+        parsed = urlparse(url)
+        return all([parsed.scheme, parsed.netloc])
+    except:
+        return False

--- a/datalad_next/http_support.py
+++ b/datalad_next/http_support.py
@@ -85,7 +85,7 @@ def get_auth_realm(url, auth_info, scheme=None):
 
        >>> url, props = probe_url('https://fz-juelich.sciebo.de/...')
        >>> get_auth_realm(url, props.get('auth'))
-       'https://fz-juelich.sciebo.de/sciebo'
+       'https://fz-juelich.sciebo.de/login'
 
     Parameters
     ----------

--- a/datalad_next/http_support.py
+++ b/datalad_next/http_support.py
@@ -129,7 +129,13 @@ def get_auth_realm(url, auth_info, scheme=None):
         # netloc of the given URL (ignoring its path) to achieve
         # the same server-specific realm semantics
         parsed = urlparse(url)
-        return f'{parsed.scheme}://{parsed.netloc}/{realm}'
+        return '{scheme}://{netloc}{slash}{realm}'.format(
+            scheme=parsed.scheme,
+            netloc=parsed.netloc,
+            slash='' if realm.startswith('/') else'/',
+            realm=realm,
+        )
+
 
 
 def _is_valid_url(url):

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -1,0 +1,14 @@
+from datalad.distribution.dataset import Dataset
+from datalad.tests.utils import (
+    with_tempfile,
+)
+from datalad_next.tests.utils import serve_path_via_webdav
+
+
+@with_tempfile
+@with_tempfile
+@serve_path_via_webdav
+def test_mike(localpath, remotepath, url):
+    ca = dict(result_renderer='disabled')
+    ds = Dataset(localpath).create(**ca)
+    ds.create_sibling_webdav(url, **ca)

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -2,13 +2,26 @@ from datalad.distribution.dataset import Dataset
 from datalad.tests.utils import (
     with_tempfile,
 )
+from datalad_next.credman import CredentialManager
 from datalad_next.tests.utils import serve_path_via_webdav
 
 
 @with_tempfile
 @with_tempfile
-@serve_path_via_webdav
+@serve_path_via_webdav(auth=('datalad', 'secure'))
+#@serve_path_via_webdav
 def test_mike(localpath, remotepath, url):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(**ca)
+    ds.credentials(
+        'set',
+        name='mywebdav',
+        spec=dict(
+            # the test webdav webserver uses a realm label '/'
+            realm=url + '/',
+            user='datalad',
+            secret='secure'),
+    )
+
+    print(localpath)
     print(ds.create_sibling_webdav(url, **ca))

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -1,16 +1,28 @@
+from unittest.mock import patch
+
+from nose.tools import (
+    assert_in,
+    assert_raises,
+    assert_raises_regexp,
+    assert_true,
+    eq_,
+)
+
+from datalad.api import create_sibling_webdav
 from datalad.distribution.dataset import Dataset
+from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import (
     with_tempfile,
 )
-from datalad_next.credman import CredentialManager
 from datalad_next.tests.utils import serve_path_via_webdav
+
 
 webdav_cred = ('datalad', 'secure')
 
-@with_tempfile
+
 @with_tempfile
 @serve_path_via_webdav(auth=webdav_cred)
-def test_mike(localpath, remotepath, url):
+def test_mike(localpath, url):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(**ca)
     ds.credentials(
@@ -25,4 +37,133 @@ def test_mike(localpath, remotepath, url):
 
     print(localpath)
     print(ds.create_sibling_webdav(url, storage_sibling='yes', **ca))
-    pass
+
+
+def test_bad_url_catching():
+    # Ensure that bad URLs are detected and handled
+    bad_url = "this:is-not-an-expected-url"
+    assert_raises_regexp(
+        ValueError, f"no sibling name given.*{bad_url}",
+        create_sibling_webdav, url=bad_url)
+
+    bad_url = "http://localhost:33322/abc?a=b"
+    assert_raises_regexp(
+        ValueError, "URLs with a query component are not supported",
+        create_sibling_webdav, url=bad_url)
+
+
+def test_constraints_checking():
+    # Ensure that constraints are checked internally
+    url = "http://localhost:22334/abc"
+    for key in ("existing", "storage_sibling"):
+        assert_raises_regexp(
+            ValueError, "value is not one of",
+            create_sibling_webdav,
+            url=url,
+            **{key: "illegal-value"})
+
+
+def test_credential_handling():
+    url = "http://localhost:22334/abc"
+    with patch("datalad_next.create_sibling_webdav._get_url_credential") as gur_mock, \
+         patch("datalad_next.create_sibling_webdav._create_sibling_webdav") as csw_mock, \
+         patch("datalad_next.create_sibling_webdav.lgr") as lgr_mock, \
+         patch("datalad_next.create_sibling_webdav.CredentialManager") as credman_mock:
+
+        csw_mock.return_value = iter([])
+        credman_mock.return_value = None
+
+        gur_mock.return_value = None
+        assert_raises_regexp(
+            ValueError, "No suitable credential for http://localhost:22334/abc found or specified",
+            create_sibling_webdav,
+            url=url,
+            name="some_name",
+            existing="error")
+
+        gur_mock.reset_mock()
+        gur_mock.return_value = [None, {"some_key": "some_value"}]
+        assert_raises_regexp(
+            ValueError, "No suitable credential for http://localhost:22334/abc found or specified",
+            create_sibling_webdav,
+            url=url,
+            name="some_name",
+            existing="error")
+
+        # Ensure that failed credential storing is handled and logged
+        gur_mock.reset_mock()
+        gur_mock.return_value = [None, {"user": "u", "secret": "s"}]
+        create_sibling_webdav(
+            url=url,
+            name="some_name",
+            existing="error")
+        eq_(lgr_mock.warning.call_count, 1)
+
+
+def test_name_clash_detection():
+    # Ensure that constraints are checked internally
+    url = "http://localhost:22334/abc"
+    for storage_sibling in ("yes", 'export', 'only', 'only-export'):
+        assert_raises_regexp(
+            ValueError, "sibling names must not be equal",
+            create_sibling_webdav,
+            url=url,
+            name="abc",
+            storage_name="abc",
+            storage_sibling=storage_sibling)
+
+
+def test_unused_storage_name_warning():
+    # Ensure that constraints are checked internally
+
+    # We use a URL with query for an early exit form 'create_sibling_webdav'.
+    # This is NOT nice, instead we should either mock out all other calls in
+    # 'create_sibling_webdav', or factor out the parameter check and test it in
+    # isolation.
+    url = "http://localhost:22334/abc?x=1"
+
+    with patch("datalad_next.create_sibling_webdav.lgr") as lgr_mock:
+        storage_sibling_values = ("no", "only", "only-export")
+        for storage_sibling in storage_sibling_values:
+            assert_raises(
+                ValueError,
+                create_sibling_webdav,
+                url=url,
+                name="abc",
+                storage_name="abc",
+                storage_sibling=storage_sibling)
+        eq_(lgr_mock.warning.call_count, len(storage_sibling_values))
+
+
+def test_check_existing_siblings():
+    # Ensure that constraints are checked internally
+    url = "http://localhost:22334/abc"
+
+    with patch("datalad_next.create_sibling_webdav."
+               "_yield_ds_w_matching_siblings") as ms_mock:
+
+        ms_mock.return_value = [
+            ("some_path", "some_name1"),
+            ("some_path", "some_name2")]
+        try:
+            create_sibling_webdav(
+                url=url,
+                name="some_name",
+                existing="error")
+        except IncompleteResultsError as ire:
+            for existing_name in ("some_name1", "some_name2"):
+                assert_in(
+                    {
+                        'action': 'create_sibling_webdav',
+                        'refds': '/home/cristian/Develop/datalad-next',
+                        'status': 'error',
+                        'message': (
+                            'a sibling %r is already configured in dataset %r',
+                            existing_name,
+                            'some_path'
+                        )
+                    },
+                    ire.failed)
+        else:
+            raise ValueError(
+                "expected exception not raised: IncompleteResultsError")

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -5,11 +5,11 @@ from datalad.tests.utils import (
 from datalad_next.credman import CredentialManager
 from datalad_next.tests.utils import serve_path_via_webdav
 
+webdav_cred = ('datalad', 'secure')
 
 @with_tempfile
 @with_tempfile
-@serve_path_via_webdav(auth=('datalad', 'secure'))
-#@serve_path_via_webdav
+@serve_path_via_webdav(auth=webdav_cred)
 def test_mike(localpath, remotepath, url):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(**ca)
@@ -21,7 +21,8 @@ def test_mike(localpath, remotepath, url):
             realm=url + '/',
             user='datalad',
             secret='secure'),
-    )
+        **ca)
 
     print(localpath)
-    print(ds.create_sibling_webdav(url, **ca))
+    print(ds.create_sibling_webdav(url, storage_sibling='yes', **ca))
+    pass

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -11,4 +11,4 @@ from datalad_next.tests.utils import serve_path_via_webdav
 def test_mike(localpath, remotepath, url):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(**ca)
-    ds.create_sibling_webdav(url, **ca)
+    print(ds.create_sibling_webdav(url, **ca))

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -4,12 +4,14 @@ from nose.tools import (
     assert_in,
     assert_raises,
     assert_raises_regexp,
-    assert_true,
     eq_,
 )
 
 from datalad.api import create_sibling_webdav
-from datalad.distribution.dataset import Dataset
+from datalad.distribution.dataset import (
+    Dataset,
+    require_dataset,
+)
 from datalad.support.exceptions import IncompleteResultsError
 from datalad.tests.utils import (
     with_tempfile,
@@ -139,6 +141,11 @@ def test_check_existing_siblings():
     # Ensure that constraints are checked internally
     url = "http://localhost:22334/abc"
 
+    ds = require_dataset(
+        None,
+        check_installed=True,
+        purpose='create WebDAV sibling(s)')
+
     with patch("datalad_next.create_sibling_webdav."
                "_yield_ds_w_matching_siblings") as ms_mock:
 
@@ -155,7 +162,7 @@ def test_check_existing_siblings():
                 assert_in(
                     {
                         'action': 'create_sibling_webdav',
-                        'refds': '/home/cristian/Develop/datalad-next',
+                        'refds': ds.path,
                         'status': 'error',
                         'message': (
                             'a sibling %r is already configured in dataset %r',

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -1,6 +1,5 @@
-import logging
-import logging
 from functools import wraps
+import logging
 from pathlib import Path
 
 from datalad.utils import optional_args
@@ -93,7 +92,7 @@ def serve_path_via_webdav(tfunc, *targs, auth=None):
     """
     @wraps(tfunc)
     @attr('serve_path_via_webdav')
-    def _wrap_serve_path_via_http(*args, **kwargs):
+    def  _wrap_serve_path_via_http(*args, **kwargs):
 
         if len(args) > 1:
             args, path = args[:-1], args[-1]
@@ -102,4 +101,4 @@ def serve_path_via_webdav(tfunc, *targs, auth=None):
 
         with WebDAVPath(path, auth=auth) as url:
             return tfunc(*(args + (path, url)), **kwargs)
-    return _wrap_serve_path_via_http
+    return  _wrap_serve_path_via_http

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -1,4 +1,5 @@
 import logging
+import logging
 from functools import wraps
 from pathlib import Path
 

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -1,5 +1,5 @@
-from functools import wraps
 import logging
+from functools import wraps
 from pathlib import Path
 
 from datalad.utils import optional_args
@@ -92,7 +92,7 @@ def serve_path_via_webdav(tfunc, *targs, auth=None):
     """
     @wraps(tfunc)
     @attr('serve_path_via_webdav')
-    def  _wrap_serve_path_via_http(*args, **kwargs):
+    def _wrap_serve_path_via_http(*args, **kwargs):
 
         if len(args) > 1:
             args, path = args[:-1], args[-1]
@@ -101,4 +101,4 @@ def serve_path_via_webdav(tfunc, *targs, auth=None):
 
         with WebDAVPath(path, auth=auth) as url:
             return tfunc(*(args + (path, url)), **kwargs)
-    return  _wrap_serve_path_via_http
+    return _wrap_serve_path_via_http

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,8 @@ classifiers =
 python_requires = >= 3.6
 install_requires =
     datalad >= 0.16.0
+    www-authenticate
+packages = find:
 include_package_data = True
 
 [options.extras_require]


### PR DESCRIPTION
This PR introduces the command `create-sibling-webdav`, which creates a set of two remotes, one for git annex export and one for datalad push.

- One is called <name>-vcs and is meant to contain the git-repository info.
- The other one is called <name>-tree and is meant to contain the annex-exported tree.

Credential manager is still "datalad.downloaders.credentials.UserPassword".

The siblings are meant to be used with a publish dependency