### PR TITLE
Fix and verify support for credentials with '.' in the name

### DIFF
--- a/datalad_next/credman.py
+++ b/datalad_next/credman.py
@@ -264,10 +264,11 @@ class CredentialManager(object):
         # over time
         type_hint = kwargs.get('type')
         cred = self._get_legacy_field_from_keyring(name, type_hint) or {}
-        if _lastused:
-            cred['last-used'] = datetime.now().isoformat()
         # amend with given properties
         cred.update(**kwargs)
+        # update last-used, if requested
+        if _lastused:
+            cred['last-used'] = datetime.now().isoformat()
 
         # remove props
         #

--- a/datalad_next/credman.py
+++ b/datalad_next/credman.py
@@ -416,7 +416,7 @@ class CredentialManager(object):
         """
         done = set()
         known_credentials = set(
-            (k.split('.')[2], None) for k in self._cfg.keys()
+            ('.'.join(k.split('.')[2:-1]), None) for k in self._cfg.keys()
             if k.startswith('datalad.credential.')
         )
         from itertools import chain
@@ -494,12 +494,14 @@ class CredentialManager(object):
 
     def _ask_property(self, name, prompt=None):
         if not ui.is_interactive:
+            lgr.debug('Cannot ask for credential property %r in non-interactive session', name)
             return
         self._prompt(prompt)
         return ui.question(name, title=None)
 
     def _ask_secret(self, type_hint=None, prompt=None):
         if not ui.is_interactive:
+            lgr.debug('Cannot ask for credential secret in non-interactive session')
             return
         self._prompt(prompt)
         return ui.question(

--- a/datalad_next/tests/test_credman.py
+++ b/datalad_next/tests/test_credman.py
@@ -100,7 +100,7 @@ def check_credmanager():
 
 @with_tempfile
 def test_credman_local(path):
-    ds = Dataset.create(path)
+    ds = Dataset(path).create(result_renderer='disabled')
     credman = CredentialManager(ds.config)
 
     # deposit a credential into the dataset's config, and die trying to
@@ -125,14 +125,14 @@ def check_query():
     # set a bunch of credentials with a common realm AND timestamp
     for i in range(3):
         credman.set(
-            f'cred{i}',
+            f'cred.{i}',
             _lastused=True,
             secret=f'diff{i}',
             realm='http://ex.com/login',
         )
     # now a credential with the common realm, but without a timestamp
     credman.set(
-        'crednotime',
+        'cred.no.time',
         _lastused=False,
         secret='notime',
         realm='http://ex.com/login',
@@ -143,10 +143,10 @@ def check_query():
     # now we want all credentials that match the realm, sorted by
     # last-used timestamp -- most recent first
     slist = credman.query(realm='http://ex.com/login', _sortby='last-used')
-    eq_(['cred2', 'cred1', 'cred0', 'crednotime'],
+    eq_(['cred.2', 'cred.1', 'cred.0', 'cred.no.time'],
         [i[0] for i in slist])
     # same now, but least recent first, importantly no timestamp stays last
     slist = credman.query(realm='http://ex.com/login', _sortby='last-used',
                           _reverse=False)
-    eq_(['cred0', 'cred1', 'cred2', 'crednotime'],
+    eq_(['cred.0', 'cred.1', 'cred.2', 'cred.no.time'],
         [i[0] for i in slist])

--- a/datalad_next/tests/test_credman.py
+++ b/datalad_next/tests/test_credman.py
@@ -23,6 +23,7 @@ from datalad.tests.utils import (
     assert_not_in,
     assert_raises,
     eq_,
+    neq_,
     patch_config,
     with_tempfile,
 )
@@ -51,8 +52,13 @@ def check_credmanager():
     # but the secret was written to the keystore
     eq_(credman.set('mycred', secret='some'), dict(secret='some'))
     # redo but with timestep
-    assert_in('last-used',
-              credman.set('lastusedcred', _lastused=True, secret='some'))
+    setprops = credman.set('lastusedcred', _lastused=True, secret='some')
+    assert_in('last-used', setprops)
+    # now re-set, based on the retrieved info, but update the timestamp
+    setprops_new = credman.set('lastusedcred', _lastused=True,
+                               **credman.get('lastusedcred'))
+    # must have updated 'last-used'
+    neq_(setprops['last-used'], setprops_new['last-used'])
     # first property store attempt
     eq_(credman.set('changed', secret='some', prop='val'),
         dict(secret='some', prop='val'))


### PR DESCRIPTION
Also improve logging, and make sure the 'last-used' timestamp is actually updated (even when already present).