### PR TITLE
Fix test stalling

### DIFF
--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -65,7 +65,8 @@ class WebDAVPath(object):
         # hmm, it seems as if this would be the proper way, but the docs are
         # super-terse and it does not work like this
         #self.server_thread = Thread(target=self.server._run_in_thread)
-        self.server_thread = Thread(target=self.server.start)
+        self.server.prepare()
+        self.server_thread = Thread(target=self.server.serve)
         self.server_thread.start()
         lgr.debug('WEBDAV started')
         return f'http://{config["host"]}:{config["port"]}'

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -62,9 +62,6 @@ class WebDAVPath(object):
         )
         lgr.debug('Starting WEBDAV server')
         from threading import Thread
-        # hmm, it seems as if this would be the proper way, but the docs are
-        # super-terse and it does not work like this
-        #self.server_thread = Thread(target=self.server._run_in_thread)
         self.server.prepare()
         self.server_thread = Thread(target=self.server.serve)
         self.server_thread.start()
@@ -75,9 +72,10 @@ class WebDAVPath(object):
         lgr.debug('Stopping WEBDAV server')
         # graceful exit
         self.server.stop()
+        lgr.debug('WEBDAV server stopped, waiting for server thread to exit')
         # wait for shutdown
         self.server_thread.join()
-        lgr.debug('WEBDAV server stopped')
+        lgr.debug('WEBDAV server thread exited')
 
 
 @optional_args


### PR DESCRIPTION
This PR fixes issue #10

The reason for the stalling tests was the main thread could not successfully connect to the WebDAV-server when the server was still in the process of binding the socket address and starting to listen on the socket. The situation could occur when the server-thread was not finished with the socket setup while the main thread already tried to connect to the server.

This is fixed now by performing the server socket setup before starting the server-thread and before returning to the main thread