### PR TITLE
Fix TODO-items in `create_sibling_webdav`

### DIFF
--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -160,7 +160,7 @@ class CreateSiblingWebDAV(Interface):
         parsed_url = urlparse(url)
         if parsed_url.query:
             raise ValueError(
-                "URLs with query component are not supported: {url!r}")
+                f"URLs with query component are not supported: {url!r}")
         if parsed_url.fragment:
             raise ValueError(
                 f"URLs with fragment are not supported: {url!r}")
@@ -169,10 +169,10 @@ class CreateSiblingWebDAV(Interface):
                 f"URLs without network location are not supported: {url!r}")
         if parsed_url.scheme not in ("http", "https"):
             raise ValueError(
-                f"Only 'http'- or 'https'-scheme are supported: : {url!r}")
+                f"Only 'http'- or 'https'-scheme are supported: {url!r}")
         if parsed_url.scheme == "http":
             lgr.warning(
-                f"Using 'http:' (: {url!r}) means that WEBDAV credentials might"
+                f"Using 'http:' ({url!r}) means that WEBDAV credentials might"
                 " be sent unencrypted over network links. Consider using "
                 "'https:'.")
 

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -180,12 +180,6 @@ class CreateSiblingWebDAV(Interface):
             # not using .netloc to avoid ports to show up in the name
             name = parsed_url.hostname
 
-        if not name:
-            # could happen with broken URLs (e.g. without //)
-            raise ValueError(
-                f"no sibling name given and none could be derived from the URL:"
-                f" {url!r}")
-
         # ensure values of critical switches. this duplicated the CLI processing, but
         # compliance is critical in a python session too.
         # whe cannot make it conditional to apimode == cmdline, because this command


### PR DESCRIPTION
This commit fixes a number of TODO-items. Some are left to be addressed by the implementation of the `--existing`-
and the `--dry-run`-switches.

- [x] add tests for improved URL checking
- [x] add tests for `_get_url_credential`
