### PR TITLE
Auto-deploy credentials on `AnnexRepo.enable_remote()` (and with it also `siblings enable`)

### DIFF
--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -71,7 +71,8 @@ class CreateSiblingWebDAV(Interface):
 
     _params_ = dict(
         url=Parameter(
-            args=("URL",),
+            args=("url",),
+            metavar='URL',
             doc="URL identifying the sibling root on the target WebDAV server",
             constraints=EnsureStr()),
         dataset=Parameter(

--- a/datalad_next/gitremote/datalad_annex.py
+++ b/datalad_next/gitremote/datalad_annex.py
@@ -196,6 +196,7 @@ from datalad_next.credman import CredentialManager
 from datalad_next.utils import (
     get_specialremote_credential_envpatch,
     get_specialremote_credential_properties,
+    needs_specialremote_credential_envpatch,
     specialremote_credential_envmap,
     update_specialremote_credential,
 )
@@ -325,6 +326,9 @@ class RepoAnnexGitRemote(object):
                 "the remote URL and provide credentials according to the "
                 "documentation of this particular special remote.")
 
+        if not needs_specialremote_credential_envpatch(remote_type):
+            return
+
         cred = self._retrieve_credential(credential_name)
 
         if not cred:
@@ -361,7 +365,7 @@ class RepoAnnexGitRemote(object):
         if not cred:
             # direct lookup failed, try query.
             credprops = get_specialremote_credential_properties(
-                self.initremote_params)
+                self.initremote_params) or {}
             if credprops:
                 creds = self.credman.query(_sortby='last-used', **credprops)
                 if creds:

--- a/datalad_next/gitremote/tests/test_datalad_annex.py
+++ b/datalad_next/gitremote/tests/test_datalad_annex.py
@@ -70,7 +70,7 @@ def test_annex_remote(dspath, remotepath):
         f'datalad-annex::?type=directory&directory={remotepath}&encryption=none' \
         if on_windows else \
         f'datalad-annex::file://{remotepath}?type=directory&directory={{path}}&encryption=none'
-    ds = Dataset(dspath).create(annex=False)
+    ds = Dataset(dspath).create(annex=False, result_renderer='disabled')
     _check_push_fetch_cycle(ds, dlaurl, remotepath)
 
 
@@ -82,7 +82,7 @@ def test_export_remote(dspath, remotepath):
         f'datalad-annex::?type=directory&directory={remotepath}&encryption=none&exporttree=yes' \
         if on_windows else \
         f'datalad-annex::file://{remotepath}?type=directory&directory={{path}}&encryption=none&exporttree=yes'
-    ds = Dataset(dspath).create(annex=False)
+    ds = Dataset(dspath).create(annex=False, result_renderer='disabled')
     _check_push_fetch_cycle(ds, dlaurl, remotepath)
 
 
@@ -200,7 +200,7 @@ def test_annex_remote_autorepush(dspath, remotepath):
         f'datalad-annex::?type=directory&directory={remotepath}&encryption=none' \
         if on_windows else \
         f'datalad-annex::file://{remotepath}?type=directory&directory={{path}}&encryption=none'
-    ds = Dataset(dspath).create(annex=False)
+    ds = Dataset(dspath).create(annex=False, result_renderer='disabled')
     _check_repush_after_vanish(ds, dlaurl, remotepath)
 
 
@@ -212,7 +212,7 @@ def test_export_remote_autorepush(dspath, remotepath):
         f'datalad-annex::?type=directory&directory={remotepath}&encryption=none&exporttree=yes' \
         if on_windows else \
         f'datalad-annex::file://{remotepath}?type=directory&directory={{path}}&encryption=none&exporttree=yes'
-    ds = Dataset(dspath).create(annex=False)
+    ds = Dataset(dspath).create(annex=False, result_renderer='disabled')
     _check_repush_after_vanish(ds, dlaurl, remotepath)
 
 
@@ -296,7 +296,7 @@ def test_typeweb_export():
 @with_tempfile
 @with_tempfile
 def _check_typeweb(pushtmpl, clonetmpl, export, url, preppath, clonepath):
-    ds = Dataset(preppath).create(annex=False)
+    ds = Dataset(preppath).create(annex=False, result_renderer='disabled')
     ds.repo.call_git([
         'remote', 'add',
         'dla',
@@ -322,7 +322,7 @@ def _check_typeweb(pushtmpl, clonetmpl, export, url, preppath, clonepath):
 def test_submodule_url(servepath, url, workdir):
     workdir = Path(workdir)
     # a future subdataset that we want to register under a complex URL
-    tobesubds = Dataset(workdir / 'subdsprep').create(annex=False)
+    tobesubds = Dataset(workdir / 'subdsprep').create(annex=False, result_renderer='disabled')
     # push to test web server, this URL doesn't matter yet
     tobesubds.repo.call_git([
         'remote', 'add', 'dla',
@@ -363,7 +363,7 @@ def test_submodule_url(servepath, url, workdir):
 @serve_path_via_webdav(auth=webdav_cred)
 def test_webdav_auth(preppath, clnpath, remotepath, webdavurl):
     # this is the dataset we want to roundtrip through webdav
-    ds = Dataset(preppath).create(annex=False)
+    ds = Dataset(preppath).create(annex=False, result_renderer='disabled')
 
     remoteurl = \
         f'datalad-annex::{webdavurl}' \

--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -1,1 +1,5 @@
-import datalad_next.patches.create_sibling_ghlike
+from . import (
+    annexrepo,
+    create_sibling_ghlike,
+    siblings,
+)

--- a/datalad_next/patches/annexrepo.py
+++ b/datalad_next/patches/annexrepo.py
@@ -1,0 +1,97 @@
+import logging
+import os
+import re
+
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import (
+    CommandError,
+)
+from datalad.utils import ensure_list
+
+from datalad_next.credman import CredentialManager
+from datalad_next.utils import (
+    get_specialremote_credential_envpatch,
+    get_specialremote_param_dict,
+    get_specialremote_credential_properties,
+)
+
+
+# reuse logger from -core, despite the unconventional name
+lgr = logging.getLogger('datalad.annex')
+
+
+# This function is taken from datalad-core@2ed709613ecde8218a215dcb7d74b4a352825685
+# datalad/support/annexrepo.py:AnnexRepo
+# Changes
+# - raise exceptions carry context of the original command error
+def annexRepo__enable_remote(self, name, options=None, env=None):
+    """Enables use of an existing special remote
+
+    Parameters
+    ----------
+    name: str
+        name, the special remote was created with
+    options: list, optional
+    """
+    # an enableremote can do pretty much anything, including a type change.
+    # in order to be able to determine whether credentials *will* be needed,
+    # we have to look ahead and form the special remote parameters that will
+    # be there at the end -- more or less
+
+    # pull info for present config
+    sp_remotes = {v['name']: dict(v, uuid=k) for k, v in self.get_special_remotes().items()}
+    remote_info = sp_remotes.get(name, {})
+    # TODO if remote_info is empty, we can fail right here
+
+    # and now update with given params
+    if options:
+        remote_info.update(get_specialremote_param_dict(options))
+
+    # see if we can identify any matching credentials
+    credprops = get_specialremote_credential_properties(remote_info)
+    credman = None
+    credspec = None
+    if credprops:
+        credman = CredentialManager(self.config)
+        creds = credman.query(_sortby='last-used', **credprops)
+        if creds:
+            # found one
+            credspec = creds[0]
+    # TODO manual entry could be supported here too! (also see at the end)
+
+    # MIH thinks there should be no `env` argument at all
+    # https://github.com/datalad/datalad/issues/5162
+    # if it would not be there, this whole dance is pretty much
+    # obsolete
+    env = env or self._git_runner.env
+    if env:
+        env.copy()
+
+    if credspec:
+        credpatch = get_specialremote_credential_envpatch(
+            remote_info['type'], credspec[1])
+        if credpatch:
+            if not env:
+                env = os.environ.copy()
+            env.update(credpatch)
+
+    try:
+        from unittest.mock import patch
+        with patch.object(self._git_runner, 'env', env):
+            # TODO: outputs are nohow used/displayed. Eventually convert to
+            # to a generator style yielding our "dict records"
+            self.call_annex(['enableremote', name] + ensure_list(options))
+    except CommandError as e:
+        if re.match(r'.*StatusCodeException.*statusCode = 401', e.stderr):
+            raise AccessDeniedError(e.stderr) from e
+        elif 'FailedConnectionException' in e.stderr:
+            raise AccessFailedError(e.stderr) from e
+        else:
+            raise e
+    self.config.reload()
+    # TODO when manual credential entry is supported,
+    # implement store-after-success here
+
+
+lgr.debug('Apply datalad-next patch to annexrepo.py:AnnexRepo.enable_remote')
+AnnexRepo.enable_remote = annexRepo__enable_remote

--- a/datalad_next/patches/annexrepo.py
+++ b/datalad_next/patches/annexrepo.py
@@ -13,6 +13,7 @@ from datalad_next.utils import (
     get_specialremote_credential_envpatch,
     get_specialremote_param_dict,
     get_specialremote_credential_properties,
+    needs_specialremote_credential_envpatch,
 )
 
 
@@ -33,6 +34,12 @@ def annexRepo__enable_remote(self, name, options=None, env=None):
         name, the special remote was created with
     options: list, optional
     """
+    # MIH thinks there should be no `env` argument at all
+    # https://github.com/datalad/datalad/issues/5162
+    # if it would not be there, this whole dance is pretty much
+    # obsolete
+    env = env or self._git_runner.env
+
     # an enableremote can do pretty much anything, including a type change.
     # in order to be able to determine whether credentials *will* be needed,
     # we have to look ahead and form the special remote parameters that will
@@ -42,38 +49,35 @@ def annexRepo__enable_remote(self, name, options=None, env=None):
     sp_remotes = {v['name']: dict(v, uuid=k) for k, v in self.get_special_remotes().items()}
     remote_info = sp_remotes.get(name, {})
     # TODO if remote_info is empty, we can fail right here
-
-    # and now update with given params
     if options:
+        # and now update with given params
         remote_info.update(get_specialremote_param_dict(options))
 
-    # see if we can identify any matching credentials
-    credprops = get_specialremote_credential_properties(remote_info)
-    credman = None
-    credspec = None
-    if credprops:
-        credman = CredentialManager(self.config)
-        creds = credman.query(_sortby='last-used', **credprops)
-        if creds:
-            # found one
-            credspec = creds[0]
-    # TODO manual entry could be supported here too! (also see at the end)
+    # careful here, `siblings()` also calls this for regular remotes, check
+    # for a known type
+    if 'type' in remote_info \
+            and needs_specialremote_credential_envpatch(remote_info['type']):
+        # see if we can identify any matching credentials
+        credprops = get_specialremote_credential_properties(remote_info)
+        credman = None
+        credspec = None
+        if credprops:
+            credman = CredentialManager(self.config)
+            creds = credman.query(_sortby='last-used', **credprops)
+            if creds:
+                # found one
+                credspec = creds[0]
+        # TODO manual entry could be supported here too! (also see at the end)
+        if env:
+            env.copy()
 
-    # MIH thinks there should be no `env` argument at all
-    # https://github.com/datalad/datalad/issues/5162
-    # if it would not be there, this whole dance is pretty much
-    # obsolete
-    env = env or self._git_runner.env
-    if env:
-        env.copy()
-
-    if credspec:
-        credpatch = get_specialremote_credential_envpatch(
-            remote_info['type'], credspec[1])
-        if credpatch:
-            if not env:
-                env = os.environ.copy()
-            env.update(credpatch)
+        if credspec:
+            credpatch = get_specialremote_credential_envpatch(
+                remote_info['type'], credspec[1])
+            if credpatch:
+                if not env:
+                    env = os.environ.copy()
+                env.update(credpatch)
 
     try:
         from unittest.mock import patch

--- a/datalad_next/patches/create_sibling_ghlike.py
+++ b/datalad_next/patches/create_sibling_ghlike.py
@@ -5,7 +5,8 @@ from datalad.downloaders.http import DEFAULT_USER_AGENT
 from datalad.support.exceptions import CapturedException
 from datalad_next.credman import CredentialManager
 
-lgr = logging.getLogger('datalad_next.create_sibling_ghlike')
+# use same logger as -core
+lgr = logging.getLogger('datalad.distributed.create_sibling_ghlike')
 
 
 def _set_request_headers(self, credential_name, auth_info, require_token):
@@ -99,6 +100,7 @@ def _set_request_headers(self, credential_name, auth_info, require_token):
             )
 
 # patch the core class
+lgr.debug('Apply datalad-next patch to create_sibling_ghlike.py:_GitHubLike._set_request_headers')
 _GitHubLike._set_request_headers = _set_request_headers
 
 # update docs

--- a/datalad_next/patches/siblings.py
+++ b/datalad_next/patches/siblings.py
@@ -1,0 +1,66 @@
+import logging
+
+from datalad.distribution import siblings as mod_siblings
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.exceptions import (
+    AccessDeniedError,
+    AccessFailedError,
+    CapturedException,
+)
+
+# use same logger as -core
+lgr = logging.getLogger('datalad.distribution.siblings')
+
+# This function is taken from datalad-core@2ed709613ecde8218a215dcb7d74b4a352825685
+# datalad/distribution/siblings.py
+# Changes
+# - removed credential lookup for webdav-remotes
+# - exception logging via CapturedException
+def _enable_remote(ds, repo, name, res_kwargs, **unused_kwargs):
+    result_props = dict(
+        action='enable-sibling',
+        path=ds.path,
+        type='sibling',
+        name=name,
+        **res_kwargs)
+
+    if not isinstance(repo, AnnexRepo):
+        yield dict(
+            result_props,
+            status='impossible',
+            message='cannot enable sibling of non-annex dataset')
+        return
+
+    if name is None:
+        yield dict(
+            result_props,
+            status='error',
+            message='require `name` of sibling to enable')
+        return
+
+    # get info on special remote
+    sp_remotes = {v['name']: dict(v, uuid=k) for k, v in repo.get_special_remotes().items()}
+    remote_info = sp_remotes.get(name, None)
+
+    if remote_info is None:
+        yield dict(
+            result_props,
+            status='impossible',
+            message=("cannot enable sibling '%s', not known", name))
+        return
+
+    try:
+        repo.enable_remote(name)
+        result_props['status'] = 'ok'
+    except (AccessDeniedError, AccessFailedError) as e:
+        CapturedException(e)
+        result_props['status'] = 'error'
+        # TODO should use proper way of injecting exceptions in result records
+        result_props['message'] = str(e)
+
+    yield result_props
+
+
+# apply patch
+lgr.debug('Apply datalad-next patch to siblings.py:_enable_remote')
+mod_siblings._enable_remote = _enable_remote

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -59,7 +59,6 @@ def test_common_workflow(clonepath, localpath, remotepath, url):
     targetdir = Path(remotepath) / targetdir_name
     url = f'{url}/{targetdir_name}'
 
-    print(clonepath, localpath, remotepath, url)
     res = ds.create_sibling_webdav(url, storage_sibling='yes', **ca)
     assert_in_results(
         res,

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -5,6 +5,7 @@ from datalad.tests.utils import (
     assert_in,
     assert_in_results,
     assert_raises,
+    assert_status,
     eq_,
     ok_,
 )
@@ -98,8 +99,15 @@ def test_common_workflow(clonepath, localpath, remotepath, url):
     eq_(ds.repo.get_hexsha(ds.repo.get_corresponding_branch()),
         dsclone.repo.get_hexsha(dsclone.repo.get_corresponding_branch()))
 
-    # TODO verify that we can get testfile.dat
-    # -- waiting for siblings to be able to deploy credentials
+    # check that it auto-deploys webdav credentials
+    # at some point, clone should be able to do this internally
+    # https://github.com/datalad/datalad/issues/6634
+    dsclone.siblings('enable', name='127.0.0.1-storage')
+    # verify that we can get testfile.dat
+    # just get the whole damn thing
+    assert_status('ok', dsclone.get('.'))
+    # verify testfile content
+    eq_('dummy', (dsclone.pathobj / 'testfile.dat').read_text())
 
 
 def test_bad_url_catching():

--- a/datalad_next/utils.py
+++ b/datalad_next/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 lgr = logging.getLogger('datalad.utils')
 
@@ -105,3 +106,55 @@ def update_specialremote_credential(
             'Exception raised when storing credential %r %r: %s',
             credname, credprops, CapturedException(e),
         )
+
+
+# mapping for credential properties for specific special remote
+# types. this is unpleasantly non-generic, but only a small
+# subset of git-annex special remotes require credentials to be
+# given via ENV vars, and all of rclone's handle it internally
+specialremote_credential_envmap = dict(
+    # it makes no sense to pull a short-lived access token from
+    # a credential store, it can be given via AWS_SESSION_TOKEN
+    # in any case
+    glacier=dict(
+        user='AWS_ACCESS_KEY_ID',  # nosec
+        secret='AWS_SECRET_ACCESS_KEY'),  # nosec
+    s3=dict(
+        user='AWS_ACCESS_KEY_ID',  # nosec
+        secret='AWS_SECRET_ACCESS_KEY'),  # nosec
+    webdav=dict(
+        user='WEBDAV_USERNAME',  # nosec
+        secret='WEBDAV_PASSWORD'),  # nosec
+)
+
+
+def get_specialremote_credential_envpatch(remote_type, cred):
+    """Create an environment path for a particular remote type and credential
+
+    Returns
+    -------
+    dict or None
+      A dict with all required items to patch the environment, or None
+      if not enough information is available, or nothing needs to be patched.
+    """
+    if remote_type not in specialremote_credential_envmap:
+        lgr.debug('Special remote type %r not supported for credential setup',
+                  remote_type)
+        return
+
+    # retrieve deployment mapping
+    env_map = specialremote_credential_envmap[remote_type]
+    if all(k in os.environ for k in env_map.values()):
+        # the ENV is fully set up
+        # let's prefer the environment to behave like git-annex
+        lgr.debug(
+            'Not deploying credentials for special remote type %r, '
+            'already present in environment', remote_type)
+        return
+
+    return {
+        # take whatever partial setup the ENV has already
+        v: cred[k]
+        for k, v in env_map.items()
+        if v not in os.environ
+    }


### PR DESCRIPTION
Does not yet allow for manual credential entry on `enable_remote()`