### PR TITLE
Implement --existing for create-sibling-webdav

### DIFF
--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -330,7 +330,7 @@ class CreateSiblingWebDAV(Interface):
             else:
                 dsurl = url
 
-            yield from _create_sibling_webdav(
+            return _create_sibling_webdav(
                 ds,
                 dsurl,
                 # we pass the given, not the discovered, credential name!
@@ -442,7 +442,7 @@ def _create_sibling_webdav(
                                           storage_name, storage_sibling,
                                           url, 'storage')
         else:
-            yield _create_storage_sibling(
+            yield from _create_storage_sibling(
                     ds,
                     url,
                     storage_name,
@@ -458,7 +458,7 @@ def _create_sibling_webdav(
                                           storage_name, storage_sibling,
                                           url, 'git')
         else:
-            yield _create_git_sibling(
+            yield from _create_git_sibling(
                     ds,
                     url,
                     name,
@@ -489,7 +489,7 @@ def maybe_skip_sibling(credential, credential_name, ds, existing,
                     f"{name if sibling_type == 'git' else storage_name}")
     elif existing == 'reconfigure':
         if sibling_type == 'git':
-            yield _create_git_sibling(
+            yield from _create_git_sibling(
                 ds,
                 url,
                 name,
@@ -501,7 +501,7 @@ def maybe_skip_sibling(credential, credential_name, ds, existing,
                                 if storage_sibling != 'no' else None
             )
         elif sibling_type == 'storage':
-            yield _create_storage_sibling(
+            yield from _create_storage_sibling(
                 ds,
                 url,
                 storage_name,
@@ -557,7 +557,7 @@ def _create_git_sibling(
         name=name,
         url=remote_url,
         publish_depends=publish_depends,
-        return_type='item-or-list',
+        return_type='generator',
         result_renderer='disabled')
 
 
@@ -591,7 +591,7 @@ def _create_storage_sibling(ds, url, name, credential, export, reconfigure):
             'WEBDAV_PASSWORD': credential[1],
     }):
         ds.repo.call_annex(cmd_args)
-    return get_status_dict(
+    yield get_status_dict(
         ds=ds,
         status='ok',
         action='create_sibling_webdav.storage',

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -616,39 +616,39 @@ def _yield_ds_w_matching_siblings(
         for name in _discover_all_remotes(ds, ds):
             if name in names:
                 yield ds.path, name
+        return
 
-    else:
-        # in recursive mode this check could take a substantial amount of
-        # time: employ a progress bar (or rather a counter, because we don't
-        # know the total in advance
-        pbar_id = 'check-siblings-{}'.format(id(ds))
-        log_progress(
-            lgr.info, pbar_id,
-            'Start checking pre-existing sibling configuration %s', ds,
-            label='Query siblings',
-            unit=' Siblings',
-        )
+    # in recursive mode this check could take a substantial amount of
+    # time: employ a progress bar (or rather a counter, because we don't
+    # know the total in advance
+    pbar_id = 'check-siblings-{}'.format(id(ds))
+    log_progress(
+        lgr.info, pbar_id,
+        'Start checking pre-existing sibling configuration %s', ds,
+        label='Query siblings',
+        unit=' Siblings',
+    )
 
-        for res in ds.foreach_dataset(
-                _discover_all_remotes,
-                recursive=recursive,
-                recursion_limit=recursion_limit,
-                return_type='generator',
-                result_renderer='disabled',
-        ):
-            # unwind result generator
-            if 'result' in res:
-                for name in res['result']:
-                    log_progress(
-                        lgr.info, pbar_id,
-                        'Discovered sibling %s in dataset at %s',
-                        name, res['path'],
-                        update=1,
-                        increment=True)
-                    if name in names:
-                        yield res['path'], name
+    for res in ds.foreach_dataset(
+            _discover_all_remotes,
+            recursive=recursive,
+            recursion_limit=recursion_limit,
+            return_type='generator',
+            result_renderer='disabled',
+    ):
+        # unwind result generator
+        if 'result' in res:
+            for name in res['result']:
+                log_progress(
+                    lgr.info, pbar_id,
+                    'Discovered sibling %s in dataset at %s',
+                    name, res['path'],
+                    update=1,
+                    increment=True)
+                if name in names:
+                    yield res['path'], name
 
-        log_progress(
-            lgr.info, pbar_id,
-            'Finished checking pre-existing sibling configuration %s', ds,
-        )
+    log_progress(
+        lgr.info, pbar_id,
+        'Finished checking pre-existing sibling configuration %s', ds,
+    )

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -70,6 +70,9 @@ class CreateSiblingWebDAV(Interface):
     server needs to be specified for creating a sibling. However, the sibling
     setup can be flexibly customized (no storage sibling, or only a storage
     sibling, multi-version storage, or human-browsable single-version storage).
+    The target location is currently expected by this command to have no
+    potentially conflicting content. Please make sure of that beforehand!
+    Such content may be overwritten.
 
     When creating siblings recursively for a dataset hierarchy, subdatasets
     exports are placed at their corresponding relative paths underneath the

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -429,11 +429,12 @@ def _create_sibling_webdav(
     # simplify downstream logic, export yes or no
     export_storage = 'export' in storage_sibling
 
-    existing_siblings = [r[1] for r in
-                         _yield_ds_w_matching_siblings(ds,
-                                                       (name, storage_name),
-                                                       recursive=False)
-                         ]
+    existing_siblings = [
+        r[1] for r in _yield_ds_w_matching_siblings(
+            ds,
+            (name, storage_name),
+            recursive=False)
+    ]
 
     if storage_sibling != 'no':
         if storage_name in existing_siblings:

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -70,9 +70,9 @@ class CreateSiblingWebDAV(Interface):
     server needs to be specified for creating a sibling. However, the sibling
     setup can be flexibly customized (no storage sibling, or only a storage
     sibling, multi-version storage, or human-browsable single-version storage).
-    The target location is currently expected by this command to have no
-    potentially conflicting content. Please make sure of that beforehand!
-    Such content may be overwritten.
+
+    This command does not check for conflicting content on the WebDAV
+    server!
 
     When creating siblings recursively for a dataset hierarchy, subdatasets
     exports are placed at their corresponding relative paths underneath the
@@ -165,9 +165,9 @@ class CreateSiblingWebDAV(Interface):
             constraints=EnsureChoice('skip', 'error', 'reconfigure'),
             doc="""action to perform, if a (storage) sibling is already
             configured under the given name.
-            In this case, a sibling creation can be skipped ('skip') or the
-            sibling (re-)configured ('reconfigure'), or the command be
-            instructed to fail ('error').""", ),
+            In this case, sibling creation can be skipped ('skip') or the
+            sibling (re-)configured ('reconfigure') in the dataset, or the
+            command be instructed to fail ('error').""", ),
         recursive=recursion_flag,
         recursion_limit=recursion_limit,
         storage_sibling=Parameter(

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -347,18 +347,18 @@ class CreateSiblingWebDAV(Interface):
 
         # Generate a sibling for dataset "ds", and for sub-datasets if recursive
         # is True.
-        if not recursive:
-            for partial_result in _dummy(ds, ds):
+        for res in ds.foreach_dataset(
+                _dummy,
+                return_type='generator',
+                result_renderer='disabled',
+                recursive=recursive,
+                # recursive False is not enough to disable recursion
+                # https://github.com/datalad/datalad/issues/6659
+                recursion_limit=0 if not recursive else recursion_limit,
+        ):
+            # unwind result generator
+            for partial_result in res.get('result', []):
                 yield dict(res_kwargs, **partial_result)
-        else:
-            for res in ds.foreach_dataset(_dummy,
-                                          return_type='generator',
-                                          result_renderer='disabled',
-                                          recursive=recursive,
-                                          recursion_limit=recursion_limit):
-                # unwind result generator
-                for partial_result in res.get('result', []):
-                    yield dict(res_kwargs, **partial_result)
 
         # this went well, update the credential
         credname, credprops = cred

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -423,7 +423,7 @@ def test_existing_switch(localpath, remotepath, url):
     )
     assert_in_results(
         res,
-        action='add-sibling',
+        action='configure-sibling',
         status='ok',
         type='sibling',
         path=ds.path,
@@ -455,7 +455,7 @@ def test_existing_switch(localpath, remotepath, url):
     )
     assert_in_results(
         res,
-        action='add-sibling',
+        action='configure-sibling',
         status='ok',
         type='sibling',
         path=sub2.path,

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -386,7 +386,7 @@ def test_existing_switch(localpath, remotepath, url):
     sub = ds.create('sub', force=True, **ca)
     sub2 = ds.create('sub2', force=True, **ca)
     subsub = sub2.create('subsub', force=True, **ca)
-    ds.save(recursive=True)
+    ds.save(recursive=True, **ca)
 
     # need to amend the test credential, can only do after we know the URL
     ds.credentials(

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -381,14 +381,14 @@ def test_get_url_credential():
 
 
 @with_credential(
-    'dltest-mywebdav', user=webdav_cred[0], secret=webdav_cred[1],
+    'dltest-mywebdav', user=webdav_cred[1], secret=webdav_cred[2],
     type='user_password')
 @with_tree(tree={'sub': {'f0': '0'},
                  'sub2': {'subsub': {'f1': '1'},
                           'f2': '2'},
                  'f3': '3'})
 @with_tempfile
-@serve_path_via_webdav(auth=webdav_cred)
+@serve_path_via_webdav(auth=webdav_cred[1:])
 def test_existing_switch(localpath, remotepath, url):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(force=True, **ca)
@@ -414,7 +414,6 @@ def test_existing_switch(localpath, remotepath, url):
                                    existing='skip',
                                    recursive=True, **ca)
     dlaurl='datalad-annex::?type=webdav&encryption=none&exporttree=no&' \
-           'dlacredential=dltest-mywebdav&' \
            'url=http%3A//127.0.0.1%3A43612/'
 
     # results per dataset:

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -383,7 +383,9 @@ def test_get_url_credential():
 def test_existing_switch(localpath, remotepath, url):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(force=True, **ca)
-    sub = ds.create('sub', force=True, **ca)
+    # use a tricky name: '3f7' will be the hashdir of the XDLRA
+    # key containing the superdataset's datalad-annex archive after a push
+    sub = ds.create('3f7', force=True, **ca)
     sub2 = ds.create('sub2', force=True, **ca)
     subsub = sub2.create('subsub', force=True, **ca)
     ds.save(recursive=True, **ca)
@@ -399,7 +401,7 @@ def test_existing_switch(localpath, remotepath, url):
     subsub.create_sibling_webdav(f'{url}/sub2/subsub', storage_sibling='yes',
                                  **ca)
     sub2.create_sibling_webdav(f'{url}/sub2', storage_sibling='only', **ca)
-    sub.create_sibling_webdav(f'{url}/sub', storage_sibling='no', **ca)
+    sub.create_sibling_webdav(f'{url}/3f7', storage_sibling='no', **ca)
 
     res = ds.create_sibling_webdav(f'{url}', storage_sibling='yes',
                                    existing='skip',
@@ -484,7 +486,7 @@ def test_existing_switch(localpath, remotepath, url):
     )
 
     srv_rt = Path(remotepath)
-    (srv_rt / 'sub').rmdir()
+    (srv_rt / '3f7').rmdir()
     (srv_rt / 'sub2' / 'subsub').rmdir()
     (srv_rt / 'sub2').rmdir()
 
@@ -505,6 +507,6 @@ def test_existing_switch(localpath, remotepath, url):
                                    recursive=True, **ca)
     assert_result_count(res, 8, status='ok')
     remote_content = list(new_root.glob('**'))
-    assert_in(new_root / 'sub', remote_content)
+    assert_in(new_root / '3f7', remote_content)
     assert_in(new_root / 'sub2', remote_content)
     assert_in(new_root / 'sub2' / 'subsub', remote_content)


### PR DESCRIPTION
- Changes default for `--existing` to `error`
- Adds discovery of not yet enabled special remotes with conflicting names
- `existing=skip` skips the creation of the "conflicting" remote not the entire dataset. Meaning: A possibly specified storage sibling would be skipped independently on whether or not the git remote is skipped. Not sure whether that is advantageous or not. WDYT on that aspect, @mih, @mslw ?
- the above also somewhat implies that there are up to two results per dataset

- [x] add tests