### PR TITLE
Preset WebDAV Git sibling to 'annex-ignore'

### DIFF
--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -470,9 +470,17 @@ def _create_git_sibling(
         # e.g., it is not uncommon for credentials to be named after URLs
         remote_url += f'&dlacredential={urlquote(credential_name)}'
 
+    # announce the sibling to not have an annex (we have a dedicated
+    # storage sibling for that) to avoid needless annex-related processing
+    # and speculative whining by `siblings()`
+    ds.config.set(f'remote.{name}.annex-ignore', 'true', scope='local')
+
     yield from ds.siblings(
-        # TODO set vs add, consider `existing`
-        action="add",
+        # action must always be 'configure' (not 'add'), because above we just
+        # made a remote {name} known, which is detected by `sibling()`. Any
+        # conflict detection must have taken place separately before this call
+        # https://github.com/datalad/datalad/issues/6649
+        action="configure",
         name=name,
         url=remote_url,
         # TODO probably needed when reconfiguring, but needs credential patch

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -104,7 +104,7 @@ def check_common_workflow(
 
     assert_in_results(
         res,
-        action='add-sibling',
+        action='configure-sibling',
         status='ok',
         path=ds.path,
         name='127.0.0.1',


### PR DESCRIPTION
This turns

```
% datalad create-sibling-webdav 'https://fz-juelich.sciebo.de/remote.php/dav/files/m.hanke%40fz-juelich.de/dummy'
create_sibling_webdav.storage(ok): /tmp/dummy (dataset)
[INFO   ] Configure additional publication dependency on "fz-juelich.sciebo.de-storage"
[INFO   ] Could not enable annex remote fz-juelich.sciebo.de. This is expected if fz-juelich.sciebo.de is a pure Git remote, or happens if it is not accessible.
[WARNING] Could not detect whether fz-juelich.sciebo.de carries an annex. If fz-juelich.sciebo.de is a pure Git remote, this is expected. Remote was marked by annex as annex-ignore. Edit .git/config to reset if you think that was done by mistake due to absent connection etc
...
```

into

```
% datalad create-sibling-webdav 'https://fz-juelich.sciebo.de/remote.php/dav/files/m.hanke%40fz-juelich.de/dummy'
create_sibling_webdav.storage(ok): /tmp/dummy (dataset)
[INFO   ] Configure additional publication dependency on "fz-juelich.sciebo.de-storage"
...
```

Fixes #30 