### PR TITLE
Fix create-sibling-webdav results

### DIFF
--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -404,13 +404,13 @@ class CreateSiblingWebDAV(Interface):
             generic_result_renderer(res)
             return
 
-        ui.message('{action}({status}) {path}: {name}{url}'.format(
-                action=res['action'],
-                path=relpath(res['path'], res['refds'])
-                if 'refds' in res else res['path'],
-                name=res.get('name', ''),
-                url=f"({res['url']})" if 'url' in res else '',
-                status=ac.color_status(res['status']),
+        ui.message('{action}({status}): {path} [{name}{url}]'.format(
+            action=ac.color_word(res['action'], ac.BOLD),
+            path=relpath(res['path'], res['refds'])
+            if 'refds' in res else res['path'],
+            name=ac.color_word(res.get('name', ''), ac.MAGENTA),
+            url=f": {res['url']}" if 'url' in res else '',
+            status=ac.color_status(res['status']),
         ))
 
 

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -301,6 +301,9 @@ class CreateSiblingWebDAV(Interface):
                     message=(
                         "a sibling %r is already configured in dataset %r",
                         sname, dpath),
+                    type='sibling',
+                    name=sname,
+                    ds=ds,
                     **res_kwargs,
                 )
                 failed = True
@@ -472,11 +475,14 @@ def _create_sibling_webdav(
 
 def _get_skip_sibling_result(name, ds, type_):
     return get_status_dict(
-        action='create_sibling_webdav',
+        action='create_sibling_webdav{}'.format(
+            '.storage' if type_ == 'storage' else ''),
         ds=ds,
         status='notneeded',
         message=("skipped creating %r sibling %r, already exists",
                  type_, name),
+        name=name,
+        type='sibling',
     )
 
 
@@ -577,6 +583,9 @@ def _create_storage_sibling(
         ds=ds,
         status='ok',
         action='create_sibling_webdav.storage',
+        name=name,
+        type='sibling',
+        url=url,
     )
 
 

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -404,13 +404,11 @@ class CreateSiblingWebDAV(Interface):
             generic_result_renderer(res)
             return
 
-        ui.message('{action}({status}) {path}: {name}{annex}{url}'.format(
+        ui.message('{action}({status}) {path}: {name}{url}'.format(
                 action=res['action'],
                 path=relpath(res['path'], res['refds'])
                 if 'refds' in res else res['path'],
                 name=res.get('name', ''),
-                annex='[{}]'.format('+' if '.storage' in res['action'] else
-                                    '-'),
                 url=f"({res['url']})" if 'url' in res else '',
                 status=ac.color_status(res['status']),
         ))

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -111,7 +111,7 @@ def check_common_workflow(
 
     assert_in_results(
         res,
-        action='configure-sibling',
+        action='create_sibling_webdav',
         status='ok',
         path=ds.path,
         name='127.0.0.1',
@@ -428,7 +428,7 @@ def test_existing_switch(localpath, remotepath, url):
     )
     assert_in_results(
         res,
-        action='configure-sibling',
+        action='create_sibling_webdav',
         status='ok',
         type='sibling',
         path=ds.path,
@@ -464,7 +464,7 @@ def test_existing_switch(localpath, remotepath, url):
     )
     assert_in_results(
         res,
-        action='configure-sibling',
+        action='create_sibling_webdav',
         status='ok',
         type='sibling',
         path=sub2.path,
@@ -519,6 +519,8 @@ def test_existing_switch(localpath, remotepath, url):
                                    existing='reconfigure',
                                    recursive=True, **ca)
     assert_result_count(res, 8, status='ok')
+    assert all(r['action'].startswith('reconfigure_sibling_webdav')
+               for r in res)
     remote_content = list(new_root.glob('**'))
     assert_in(new_root / '3f7', remote_content)
     assert_in(new_root / 'sub2', remote_content)


### PR DESCRIPTION
Unifies and enriches result records of `create-sibling-webdav` and adds a custom result renderer that is roughly resembling the one of `siblings`.

Closes #33
Closes #38


This needs rebasing. Last three commits are relevant ATM.