### PR TITLE
Re-trigger doc building after patching push

### DIFF
--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -266,5 +266,8 @@ push.Push._params_["force"] = Parameter(
         'all', 'gitpush', 'checkdatapresent', 'export', None))
 
 
+from datalad.interface.base import build_doc
+push.Push = build_doc(push.Push)
+
 lgr.debug("Patching datalad.support.AnnexRepo.get_export_records (new method)")
 AnnexRepo.get_export_records = get_export_records


### PR DESCRIPTION
`datalad.api` didn't pickup the patched docstring of `Push`, since the
building by the `build_doc` decorator was triggered before the patch
applied. Rerun it explicitly after patching.

Closes #46