### PR TITLE
Fix metadata (URL) in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-url = https://github.com/datalad/datalad-extension-template
+url = https://github.com/datalad/datalad-next
 author = The DataLad Team and Contributors
 author_email = team@datalad.org
 description = What is next in DataLad


### PR DESCRIPTION
The URL field in setup.cfg metadata is rendered on PIP as "Homepage". 
This will now point to next's github project instead of extension template.