### PR TITLE
Fix error handling for cat-file on newer Git

### DIFF
--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -102,8 +102,10 @@ def get_export_records(repo: AnnexRepo) -> Generator:
             yield result_dict
     except CommandError as command_error:
         # Some errors indicate that there was no export yet.
+        # May depend on Git version
         expected_errors = (
             "fatal: Not a valid object name git-annex:export.log",
+            "fatal: path 'export.log' does not exist in 'git-annex'", # v2.36
         )
         if command_error.stderr.strip() in expected_errors:
             return


### PR DESCRIPTION
With Git 2.36.0, git-annex 10.20220504, and datalad-next 0.2.2, pushing to an exporttree remote (created with create_sibling_webdav --mode filetree) resulted in:
```
CommandError: 'git -c diff.ignoreSubmodules=none cat-file blob git-annex:export.log' failed with exitcode 128
fatal: path 'export.log' does not exist in 'git-annex'
```
This is because the error message produced by git cat-file changed somewhere between Git 2.30 ("fatal: Not a valid object name git-annex:export.log") and 2.36 ("fatal: path 'export.log' does not exist in 'git-annex'").

Because CI installs new git-annex & Git versions, this error was actually caught in unrelated PRs #58 and #60 but it was not clear from CI output alone. Merging will should make CI go green again on those (after re-running).

Fixes #62