### PR TITLE
Add --private to datalad-create

### DIFF
--- a/datalad_next/__init__.py
+++ b/datalad_next/__init__.py
@@ -39,6 +39,12 @@ import datalad_next.patches
 from datalad.support.extensions import register_config
 from datalad.support.constraints import EnsureBool
 register_config(
+    'datalad.annex.init.private',
+    "Set up new dataset(s) to operate in git-annex' private mode?",
+    type=EnsureBool(),
+    default=False,
+    dialog='yesno')
+register_config(
     'datalad.credentials.repeat-secret-entry',
     'Require entering secrets twice for interactive specification?',
     type=EnsureBool(),


### PR DESCRIPTION
This provides a patch to add a --private switch to datalad-create, that
would set `annex.private=true` (needs to be done before annex-init) for
the new dataset. With that neither availability nor the existence of
this location will be recorded in the git-annex branch.