### PR TITLE
(Temporarily?) discontinue probing remotes for XDLRA--refs

### DIFF
--- a/datalad_next/gitremote/datalad_annex.py
+++ b/datalad_next/gitremote/datalad_annex.py
@@ -895,18 +895,38 @@ class RepoAnnexGitRemote(object):
         # remote, but URLs for the two individual keys
         sremotes = ra.get_special_remotes()
 
-        if len(sremotes) == 1 and not call_annex_success(ra, [
-                'fsck', '-f', 'origin', '--fast',
-                '--key', self.refs_key]):
-            # the remote reports nothing, we can exit
-            # we use `fsck`, rather than `whereis` to bypass
-            # the local state tracking
-            return
+        # disable the useless download prevention due to
+        # https://github.com/datalad/datalad-next/issues/72
+        #if len(sremotes) == 1 and not call_annex_success(ra, [
+        #        'fsck', '-f', 'origin', '--fast',
+        #        '--key', self.refs_key]):
+        #    # the remote reports nothing, we can exit
+        #    # we use `fsck`, rather than `whereis` to bypass
+        #    # the local state tracking
+        #    return
+        #
+        # instead pretend that the remote has this key and let things
+        # fail-on-get below if that is not the case
+        if len(sremotes) == 1:
+            # in case of the 'web' special remote, we have no actual special
+            # remote, but URLs for the two individual keys
+            ra.call_annex(['setpresentkey', self.refs_key,
+                           sremotes.popitem()[0], '1'])
+
         # we have to get the key, and report its content
         # force redownload, by dropping the local content first
         ra.call_annex([
             'drop', '--force', '--key', self.refs_key])
-        ra.call_annex(['get', '--key', self.refs_key])
+        # try download -- try, because we fakes availability above -- without
+        # which the `get` would not be attempted
+        try:
+            ra.call_annex(['get', '--key', self.refs_key])
+        except CommandError as e:
+            CapturedException(e)
+            self.log("Remote reports no refs")
+            # download failed, we have no refs
+            return
+
         refskeyloc = ra.call_annex_oneline([
             'contentlocation', self.refs_key])
         # read, cache, return


### PR DESCRIPTION
This is no longer possible with git-annex 10.20220505 and later.

Ideally, we would get this feature back. See
https://git-annex.branchable.com/bugs/10.20220525_cannot_probe_for_untrusted_remote_key/

But for now a forced-download will have to do.

Closes datalad/datalad-next#72