### PR TITLE
Enable full feature-set for `datalad-annex::` on windows

### DIFF
--- a/datalad_next/gitremote/tests/test_datalad_annex.py
+++ b/datalad_next/gitremote/tests/test_datalad_annex.py
@@ -28,8 +28,6 @@ from datalad.tests.utils import (
     neq_,
     rmtree,
     serve_path_via_http,
-    skip_if_on_windows,
-    SkipTest,
     with_tempfile,
 )
 from datalad.utils import on_windows
@@ -60,8 +58,6 @@ def eq_dla_branch_state(state, path, branch=DEFAULT_BRANCH):
     assert None, f'Could not find state for branch {branch} at {path}'
 
 
-# https://git-annex.branchable.com/bugs/Fails_to_drop_key_on_windows___40__Access_denied__41__/?updated
-@skip_if_on_windows
 @with_tempfile
 @with_tempfile(mkdir=True)
 def test_annex_remote(dspath, remotepath):


### PR DESCRIPTION
#26 is still valid with today's git-annex. This PR implements a rather draconian workaround: Instead of dropping the repoannex keys, it wipes out the entire object tree of the local `repoannex` utility repo.

This is possible, because this utility repo is constructed on the fly from the URL specification, and only contains the two keys that need to be dropped. However, given the bluntness of the approach, it is limited to the platform on which the original issue is happening: windows. 