### PR TITLE
Add citation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,4 +1,5 @@
 {
+    "title": "DataLad-next extension",
     "creators": [
         {
             "affiliation": "Dartmouth College, Hanover, NH, United States",
@@ -11,8 +12,8 @@
             "orcid": "0000-0001-6398-6370"
         },
         {
-            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behavior (INM-7), Research Center Jülich, Germany",
-            "name": "Stephan Heunis",
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Heunis, Stephan",
             "orcid": "0000-0003-3503-9872"
         },
         {
@@ -41,7 +42,7 @@
             "orcid": "0000-0003-2917-3450"
         },
         {
-            "name": "Wodder, John T., II"
+            "name": "Wodder II, John T."
         }
     ],
     "keywords": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,23 +1,54 @@
 {
-  "creators": [
-    {
-      "affiliation": "Edit me!",
-      "name": "Edit me!",
-      "orcid": "Edit me!"
-    },
-    {
-      "affiliation": "Edit me!",
-      "name": "Edit me!",
-      "orcid": "Edit me!"
-    }
-  ],
-  "keywords": [
-    "data management",
-    "data distribution",
-    "execution provenance tracking",
-    "version control"
-  ],
-  "access_right": "open",
-  "license": "Edit me!",
-  "upload_type": "software"
+    "creators": [
+        {
+            "affiliation": "Dartmouth College, Hanover, NH, United States",
+            "name": "Halchenko, Yaroslav O.",
+            "orcid": "0000-0003-3456-2493"
+        },
+        {
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany and Institute of Systems Neuroscience, Medical Faculty, Heinrich Heine University Düsseldorf, Düsseldorf, Germany",
+            "name": "Hanke, Michael",
+            "orcid": "0000-0001-6398-6370"
+        },
+        {
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behavior (INM-7), Research Center Jülich, Germany",
+            "name": "Stephan Heunis",
+            "orcid": "0000-0003-3503-9872"
+        },
+        {
+            "affiliation": "Stanford University, Stanford, CA, United States",
+            "name": "Markiewicz, Christopher J.",
+            "orcid": "0000-0002-6533-164X"
+        },
+        {
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Mönch, Christian",
+            "orcid": "0000-0002-3092-0612"
+        },
+        {
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Poldrack, Benjamin",
+            "orcid": "0000-0001-7628-0801"
+        },
+        {
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Szczepanik, Michał",
+            "orcid": "0000-0002-4028-2087"
+        },
+        {
+            "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
+            "name": "Wagner, Adina S.",
+            "orcid": "0000-0003-2917-3450"
+        },
+        {
+            "name": "Wodder, John T., II"
+        }
+    ],
+    "keywords": [
+        "data management",
+        "data distribution"
+    ],
+    "access_right": "open",
+    "license": "MIT",
+    "upload_type": "software"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: >-
   applicable functionality
 type: software
 authors:
-  - given-names: Yaroslav
+  - given-names: Yaroslav O.
     family-names: Halchenko
     affiliation: 'Dartmouth College, Hanover, NH, United States'
     orcid: 'https://orcid.org/0000-0003-3456-2493'
@@ -28,7 +28,7 @@ authors:
       Behaviour (INM-7), Research Centre Jülich,
       Jülich, Germany
     orcid: 'https://orcid.org/0000-0003-3503-9872'
-  - given-names: Christopher
+  - given-names: Christopher J.
     family-names: Markiewicz
     affiliation: >-
       Stanford University, Stanford, CA, United
@@ -55,20 +55,18 @@ authors:
       Behaviour (INM-7), Research Centre Jülich,
       Jülich, Germany
     orcid: 'https://orcid.org/0000-0002-4028-2087'
-  - given-names: Adina
+  - given-names: Adina S.
     family-names: Wagner
     affiliation: >-
       Institute of Neuroscience and Medicine, Brain &
       Behaviour (INM-7), Research Centre Jülich,
       Jülich, Germany
     orcid: 'https://orcid.org/0000-0003-2917-3450'
-  - given-names: John
+  - given-names: John T.
     family-names: Wodder
     name-suffix: II
 keywords:
   - data management
   - data distribution
-  - execution provenance tracking
-  - version control
 repository-code: 'https://github.com/datalad/datalad-next'
 license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,74 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: DataLad-next extension
+message: >-
+  DataLad extension for additional, broadly
+  applicable functionality
+type: software
+authors:
+  - given-names: Yaroslav
+    family-names: Halchenko
+    affiliation: 'Dartmouth College, Hanover, NH, United States'
+    orcid: 'https://orcid.org/0000-0003-3456-2493'
+  - given-names: Michael
+    family-names: Hanke
+    affiliation: >-
+      Institute of Neuroscience and Medicine, Brain &
+      Behaviour (INM-7), Research Centre Jülich,
+      Jülich, Germany and Institute of Systems
+      Neuroscience, Medical Faculty, Heinrich Heine
+      University Düsseldorf, Düsseldorf, Germany
+    orcid: 'https://orcid.org/0000-0001-6398-6370'
+  - given-names: Stephan
+    family-names: Heunis
+    affiliation: >-
+      Institute of Neuroscience and Medicine, Brain &
+      Behaviour (INM-7), Research Centre Jülich,
+      Jülich, Germany
+    orcid: 'https://orcid.org/0000-0003-3503-9872'
+  - given-names: Christopher
+    family-names: Markiewicz
+    affiliation: >-
+      Stanford University, Stanford, CA, United
+      States
+    orcid: 'https://orcid.org/0000-0002-6533-164X'
+  - given-names: Christian
+    family-names: Mönch
+    affiliation: >-
+      Institute of Neuroscience and Medicine, Brain &
+      Behaviour (INM-7), Research Centre Jülich,
+      Jülich, Germany
+    orcid: 'https://orcid.org/0000-0002-3092-0612'
+  - given-names: Benjamin
+    family-names: Poldrack
+    affiliation: >-
+      Institute of Neuroscience and Medicine, Brain &
+      Behaviour (INM-7), Research Centre Jülich,
+      Jülich, Germany
+    orcid: 'https://orcid.org/0000-0001-7628-0801'
+  - given-names: Michał
+    family-names: Szczepanik
+    affiliation: >-
+      Institute of Neuroscience and Medicine, Brain &
+      Behaviour (INM-7), Research Centre Jülich,
+      Jülich, Germany
+    orcid: 'https://orcid.org/0000-0002-4028-2087'
+  - given-names: Adina
+    family-names: Wagner
+    affiliation: >-
+      Institute of Neuroscience and Medicine, Brain &
+      Behaviour (INM-7), Research Centre Jülich,
+      Jülich, Germany
+    orcid: 'https://orcid.org/0000-0003-2917-3450'
+  - given-names: John
+    family-names: Wodder
+    name-suffix: II
+keywords:
+  - data management
+  - data distribution
+  - execution provenance tracking
+  - version control
+repository-code: 'https://github.com/datalad/datalad-next'
+license: MIT


### PR DESCRIPTION
This PR adds `zenodo.json` & `citation.cff` files. Closes #79 

I made several assumptions in compiling the files:
- I included everyone listed by GitHub in the project's contributors page, and used alphabetical order
- I used the corresponding files from datalad repo to get affiliations & orcids, and other datalad projects or GitHub profiles if you weren't there
- ~I only listed first names in `citation.cff`, partially because that's how it's done in datalad repo, partially because I wasn't sure on correct spelling (e.g. comma or no comma between names)~
- I unified the FZJ affiliation (to be spelled "Research Centre Jülich")
- from the tags proposed in extension template, I used the two first, "data management" and "data distribution".

Please correct me if there's something you'd want to change @yarikoptic @mih @jsheunis @effigies @christian-monch @bpoldrack @adswa @jwodder