### PR TITLE
Aid changelog composition via `scriv`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### PR checklist
+
+- [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
+  Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
+- [ ] Provide an overview of the changes you're making and explain why you're proposing them. Ideally, include them as a new file in `changelog.d/`
+- [ ] Include `Fixes #NNN` somewhere in the description if this PR addresses an existing issue.
+- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
+- [ ] **Delete these instructions**. :-)
+
+Thanks for contributing!

--- a/changelog.d/README
+++ b/changelog.d/README
@@ -1,0 +1,6 @@
+This directory contains changelog items for the next release.
+
+The easiest way to add new change log items is to run
+`scriv create`, and edit and commit the generated template.
+
+`scriv` is available at https://pypi.org/project/scriv/

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,6 @@
+[scriv]
+fragment_directory = changelog.d
+entry_title_template = file: templates/entry_title.md.j2
+new_fragment_template = file: templates/new_fragment.md.j2
+format = md
+categories = 🐛 Bug Fixes, 💫 Enhancements and new features, 🪓 Deprecations and removals, 📝 Documentation, 🏠 Internal, 🛡 Tests

--- a/changelog.d/templates/entry_title.md.j2
+++ b/changelog.d/templates/entry_title.md.j2
@@ -1,0 +1,1 @@
+{{ version if version else "VERSION" }} ({{ date.strftime('%%Y-%%m-%%d') }})

--- a/changelog.d/templates/new_fragment.md.j2
+++ b/changelog.d/templates/new_fragment.md.j2
@@ -1,0 +1,10 @@
+<!-- Uncomment the section that is right (remove the HTML comment wrapper).-->
+{% for cat in config.categories -%}
+<!--
+### {{ cat }}
+
+- Describe change, possibly reference closed/related issue/PR.
+  Fixes [#XXX](https://github.com/datalad/datalad-next/issues/XXX)
+  [#XXX](https://github.com/datalad/datalad-next/pull/XXX) (by @GITHUBHANDLE)
+-->
+{% endfor -%}


### PR DESCRIPTION
This change provides everything necessary to allow developers to use
https://github.com/nedbat/scriv to provide changelog items.

In contrast to the practice in datalad-core, this neither means
recycling commit messages, nor C&P from PR descriptions.

The basic goals for an appropriate changelog are:

1. Changelog items target users, not developers, hence should be
   written for this audience specifically
2. A changelog should give any user a reasonably self-contained
   description.

Workflow:

1. A changeset is composed in an arbitrary way, typically posted
   as a PR.
2. At any time before a merge, a developer can run
   `scriv create` to generate a pre-formatted changelog snippet.
3. This snippet can be processed/edited in any way a developer
   sees fit (with scriv --add/edit or without), as long as it is
   included in the changeset as a dedicated file in changelog.d/
4. When preparing a release, the release manager can run
   `scriv collect --version X.X.X` to assemble a changelog for
   a given version. `scriv` will include a present snippet in
   the changelog and deletes the snippets afterwards.

With this approach, a targeted changelog can be generated from any
branch, without having to identify relevant commits or merges. The
mere presence of a changelog snippet documents the need for its
inclusion. Merging a released branch into another branch,
automatically removes changelog items for released changes.

`scriv` is primarily a convenience layer, pretty much all steps can
be performed without it.

Moving changelog composition outside of commit messages and PR
descriptions helps maintain clarity re target audience expectations.

While `scriv` does not support all the little things we tried in the past with changelogs, it also does not get in the way of additional custom processing, either at the level of individual snippet or the entire changelog.