### PR TITLE
Add missing import and log particular exception for credential failure

### DIFF
--- a/changelog.d/20220714_135722_michael.hanke_token.md
+++ b/changelog.d/20220714_135722_michael.hanke_token.md
@@ -1,0 +1,41 @@
+<!-- Uncomment the section that is right (remove the HTML comment wrapper).-->
+### 🐛 Bug Fixes
+
+- Fix a missing import in the credential retrieval for GitHub-like sibling
+  creation, which made it impossible to discover credentials without
+  providing an explicit credential name.
+<!--
+### 💫 Enhancements and new features
+
+- Describe change, possibly reference closed/related issue/PR.
+  Fixes [#XXX](https://github.com/datalad/datalad-next/issues/XXX)
+  [#XXX](https://github.com/datalad/datalad-next/pull/XXX) (by @GITHUBHANDLE)
+-->
+<!--
+### 🪓 Deprecations and removals
+
+- Describe change, possibly reference closed/related issue/PR.
+  Fixes [#XXX](https://github.com/datalad/datalad-next/issues/XXX)
+  [#XXX](https://github.com/datalad/datalad-next/pull/XXX) (by @GITHUBHANDLE)
+-->
+<!--
+### 📝 Documentation
+
+- Describe change, possibly reference closed/related issue/PR.
+  Fixes [#XXX](https://github.com/datalad/datalad-next/issues/XXX)
+  [#XXX](https://github.com/datalad/datalad-next/pull/XXX) (by @GITHUBHANDLE)
+-->
+<!--
+### 🏠 Internal
+
+- Describe change, possibly reference closed/related issue/PR.
+  Fixes [#XXX](https://github.com/datalad/datalad-next/issues/XXX)
+  [#XXX](https://github.com/datalad/datalad-next/pull/XXX) (by @GITHUBHANDLE)
+-->
+<!--
+### 🛡 Tests
+
+- Describe change, possibly reference closed/related issue/PR.
+  Fixes [#XXX](https://github.com/datalad/datalad-next/issues/XXX)
+  [#XXX](https://github.com/datalad/datalad-next/pull/XXX) (by @GITHUBHANDLE)
+-->

--- a/datalad_next/patches/create_sibling_ghlike.py
+++ b/datalad_next/patches/create_sibling_ghlike.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlparse
 
 from datalad.distributed.create_sibling_ghlike import _GitHubLike
 from datalad.downloaders.http import DEFAULT_USER_AGENT
@@ -38,7 +39,7 @@ def _set_request_headers(self, credential_name, auth_info, require_token):
         if creds:
             # found one, also assign the name to be able to update
             # it below
-            credential_name, credential  = creds[0]
+            credential_name, credential = creds[0]
             from_query = True
     if not credential:
         # no credential yet
@@ -55,6 +56,7 @@ def _set_request_headers(self, credential_name, auth_info, require_token):
             if credential is None:
                 raise ValueError('No credential found')
         except Exception as e:
+            CapturedException(e)
             lgr.debug('Token retrieval failed: %s', e)
             lgr.warning(
                 'Cannot determine authorization token for %s', credential_name)


### PR DESCRIPTION
Before there would be no trace of the nature of this error.

The tests don't cover it, because in -core credentials without a name
are not even a thing.
