### PR TITLE
Add patch to `configuration` to report unset configuration item

### DIFF
--- a/changelog.d/20220721_183907_michael.hanke.md
+++ b/changelog.d/20220721_183907_michael.hanke.md
@@ -1,0 +1,9 @@
+### 💫 Enhancements and new features
+
+- The `configuration` command now indicates the absence of a particular
+  configuration setting queried via `get` with a `status='impossible'`
+  result. This change enables the distinction of an unset configuration
+  item from an item set to an empty string possible for the default
+  CLI result renderer.
+  Fixes https://github.com/datalad/datalad/issues/6851 via
+  https://github.com/datalad/datalad-next/pull/87 by @mih


### PR DESCRIPTION
The `configuration` command now indicates the absence of a particular
configuration setting queried via `get` with a `status='impossible'`
result. This change enables the distinction of an unset configuration
item from an item set to an empty string possible for the default
CLI result renderer.

Fixes datalad/datalad#6851