### PR TITLE
RF: do not bother with shim for setup_package

### DIFF
--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -1,16 +1,1 @@
-try:
-    from datalad.conftest import setup_package
-except ImportError:
-    # assume old datalad without pytest support introduced in
-    # https://github.com/datalad/datalad/pull/6273
-    import pytest
-    from datalad import setup_package as _setup_package
-    from datalad import teardown_package as _teardown_package
-
-
-    @pytest.fixture(autouse=True, scope="session")
-    def setup_package():
-        _setup_package()
-        yield
-        _teardown_package()
-
+from datalad.conftest import setup_package


### PR DESCRIPTION
DataLad 0.17.0 came with pytest. earlier versions are not maintained.
To avoid needing to troubleshoot why testing works in unexpected ways
(may be import failed for some reason for newer datalad), just use
standard setup_package without try/except

motivator, likely unrelated but who knows -- https://github.com/datalad/datalad-extensions/runs/7775998620?check_suite_focus=true fail with
```
2022-08-10T21:15:20.6557615Z AssertionError: Got 0 instead of 1 expected results matching
2022-08-10T21:15:20.6557848Z   {
2022-08-10T21:15:20.6558033Z    "action": "publish",
2022-08-10T21:15:20.6558322Z    "message": "There is no active branch, cannot determine remote branch",
2022-08-10T21:15:20.6558643Z    "path": "/tmp/datalad_temp_test_gh1811zo1ei755",
2022-08-10T21:15:20.6558892Z    "status": "impossible",
2022-08-10T21:15:20.6559106Z    "type": "dataset"
2022-08-10T21:15:20.6559288Z   }
2022-08-10T21:15:20.6559476Z Inspected 1 record(s):
2022-08-10T21:15:20.6559719Z   [
2022-08-10T21:15:20.6559873Z    {
2022-08-10T21:15:20.6560058Z     "action": "publish",
2022-08-10T21:15:20.6560442Z     "message": "Unknown push target 'dl-test-remote'. Known targets: 'origin'.",
2022-08-10T21:15:20.6560770Z     "path": "/tmp/datalad_temp_test_gh1811zo1ei755",
2022-08-10T21:15:20.6561062Z     "refds": "/tmp/datalad_temp_test_gh1811zo1ei755",
2022-08-10T21:15:20.6561305Z     "status": "error"
2022-08-10T21:15:20.6561490Z    }
``` 
and others alike which suggest that some variables not set as they should be for testing... 