### PR TITLE
Expand testing of (patched) datalad-core

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -86,9 +86,77 @@ environment:
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
 
+    # run a subset of the core tests on the oldest supported Python version
+    - ID: CORE1
+      DTS: >
+        datalad.cli
+        datalad.core
+      # do not run tests that ensure behavior we intentionally changed
+      # - test_gh1811: is included in next in an alternative implementation
+      KEYWORDS: not test_gh1811
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PY: 3.7
+      INSTALL_SYSPKGS: python3-virtualenv
+      # datalad-annex git remote needs something after git-annex_8.20211x
+      INSTALL_GITANNEX: git-annex -m snapshot
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    - ID: CORE2
+      DTS: >
+        datalad.customremotes
+        datalad.dataset
+        datalad.distributed
+        datalad.downloaders
+        datalad.interface
+      # do not run tests that ensure behavior we intentionally changed
+      # - test_gh1811: is included in next in an alternative implementation
+      KEYWORDS: not test_gh1811
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PY: 3.7
+      INSTALL_SYSPKGS: python3-virtualenv
+      # datalad-annex git remote needs something after git-annex_8.20211x
+      INSTALL_GITANNEX: git-annex -m snapshot
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    - ID: CORE3
+      DTS: >
+        datalad.distribution
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PY: 3.7
+      INSTALL_SYSPKGS: python3-virtualenv
+      # datalad-annex git remote needs something after git-annex_8.20211x
+      INSTALL_GITANNEX: git-annex -m snapshot
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    - ID: CORE4
+      DTS: >
+        datalad.local
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PY: 3.7
+      INSTALL_SYSPKGS: python3-virtualenv
+      # datalad-annex git remote needs something after git-annex_8.20211x
+      INSTALL_GITANNEX: git-annex -m snapshot
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    - ID: CORE5
+      DTS: >
+        datalad.runner
+        datalad.support
+        datalad.tests
+        datalad.ui
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PY: 3.7
+      INSTALL_SYSPKGS: python3-virtualenv
+      # datalad-annex git remote needs something after git-annex_8.20211x
+      INSTALL_GITANNEX: git-annex -m snapshot
+      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+
 matrix:
   allow_failures:
     - KNOWN2FAIL: 1
+
+
+# do not run the CI if only documentation changes were made
+# documentation builds are tested elsewhere and cheaper
+skip_commits:
+  files:
+    - docs/
 
 
 # it is OK to specify paths that may not exist for a particular test run
@@ -193,8 +261,9 @@ test_script:
   - sh: mkdir __testhome__
   - cd __testhome__
     # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m pytest -s -v -m "not (turtle)" --cov=datalad_next --pyargs %DTS%
-  - sh:  PATH=$PWD/../tools/coverage-bin:$PATH python -m pytest -s -v -m "not (turtle)" --cov=datalad_next --pyargs ${DTS}
+  - cmd: python -m pytest -s -v -m "not (turtle)" -k "%KEYWORDS%" --cov=datalad_next --pyargs %DTS%
+    # also add --cov datalad, because some core test runs may not touch -next code
+  - sh:  PATH=$PWD/../tools/coverage-bin:$PATH python -m pytest -s -v -m "not (turtle)" -k "$KEYWORDS" --cov=datalad_next --cov datalad --pyargs ${DTS}
 
 
 after_test:

--- a/tools/coverage-bin/datalad
+++ b/tools/coverage-bin/datalad
@@ -1,0 +1,1 @@
+with_coverage

--- a/tools/coverage-bin/git-annex-remote-datalad
+++ b/tools/coverage-bin/git-annex-remote-datalad
@@ -1,0 +1,1 @@
+with_coverage

--- a/tools/coverage-bin/git-annex-remote-datalad-archives
+++ b/tools/coverage-bin/git-annex-remote-datalad-archives
@@ -1,0 +1,1 @@
+with_coverage

--- a/tools/coverage-bin/git-annex-remote-ora
+++ b/tools/coverage-bin/git-annex-remote-ora
@@ -1,0 +1,1 @@
+with_coverage


### PR DESCRIPTION
We arrived at some fairly intrusive patching of datalad-core. We can no longer rely on spot-checking for intentional behavior changes, but must also look for unintentional ones.

This changes adds five appveyor runs (split in order to keep the total runtime low) to cover the datalad-core test suite on the oldest support Python version.

I added support for keyword-based selection/exclusion of tests, because core has some tests which must not run, because the verify broken or intentionally changes behavior.