### PR TITLE
Consolidate mock.patch import to top-level

### DIFF
--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -13,6 +13,7 @@ from typing import (
     Optional,
     Union,
 )
+from unittest.mock import patch
 from urllib.parse import (
     quote as urlquote,
     urlparse,
@@ -636,8 +637,6 @@ def _create_storage_sibling(
         #https://github.com/datalad/datalad/issues/6634
         #"autoenable=true"
     ]
-    # delayed heavy-ish import
-    from unittest.mock import patch
     # Add a git-annex webdav special remote. This requires to set
     # the webdav environment variables accordingly.
     with patch.dict('os.environ', {

--- a/datalad_next/patches/annexrepo.py
+++ b/datalad_next/patches/annexrepo.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from unittest.mock import patch
 
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import (
@@ -80,7 +81,6 @@ def annexRepo__enable_remote(self, name, options=None, env=None):
                 env.update(credpatch)
 
     try:
-        from unittest.mock import patch
         with patch.object(self._git_runner, 'env', env):
             # TODO: outputs are nohow used/displayed. Eventually convert to
             # to a generator style yielding our "dict records"


### PR DESCRIPTION
This is done elsewhere already. There is no point in selective local importing.

Fixes datalad/datalad-next#28