### PR TITLE
Make sure a token secret always has a non-None name

### DIFF
--- a/changelog.d/20220818_082902_michael.hanke_bf_97.md
+++ b/changelog.d/20220818_082902_michael.hanke_bf_97.md
@@ -1,0 +1,8 @@
+### 🐛 Bug Fixes
+
+- Token secrets entered for GitHub-like sibling creation are now stored by
+  default under a name matching the API endpoint hostname (e.g.
+  'api.github.com'), rather than a confusion and conflict-prone 'None'.
+  Using the `--credential` option, an alternative name can be given, as before.
+  Fixes https://github.com/datalad/datalad-next/issues/97 via
+  https://github.com/datalad/datalad-next/pull/98 (by @mih)

--- a/datalad_next/patches/create_sibling_ghlike.py
+++ b/datalad_next/patches/create_sibling_ghlike.py
@@ -41,14 +41,16 @@ def _set_request_headers(self, credential_name, auth_info, require_token):
             # it below
             credential_name, credential = creds[0]
             from_query = True
+    if not credential_name:
+        # if we have no name given, fall back on a generated one
+        # that may exist from times before realms were recorded
+        # properly, otherwise we would not be here
+        credential_name = urlparse(self.api_url).netloc
     if not credential:
         # no credential yet
         try:
             credential = credman.get(
-                # if we have no name given, fall back on a generated one
-                # that may exist from times before realms were recorded
-                # properly, otherwise we would not be here
-                credential_name or urlparse(self.api_url).netloc,
+                credential_name,
                 _prompt=auth_info,
                 type='token',
                 realm=self.api_url,


### PR DESCRIPTION
Otherwise a freshly entered token would have a proper realm configured
(and work smoothly), but be prone to naming conflicts.

Fixes datalad/datalad-next#97