### PR TITLE
Make `clone_dataset()` patchable

### DIFF
--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -2,6 +2,7 @@ from . import (
     common_cfg,
     annexrepo,
     clone,
+    clone_ria,
     configuration,
     create_sibling_ghlike,
     push_to_export_remote,

--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -1,6 +1,7 @@
 from . import (
     common_cfg,
     annexrepo,
+    clone,
     configuration,
     create_sibling_ghlike,
     push_to_export_remote,

--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -3,6 +3,7 @@ from . import (
     annexrepo,
     clone,
     clone_ria,
+    clone_ephemeral,
     configuration,
     create_sibling_ghlike,
     push_to_export_remote,

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -31,7 +31,7 @@ from .clone_utils import (
     _check_autoenable_special_remotes,
     _get_remote,
     _format_clone_errors,
-    _try_clone,
+    _try_clone_candidates,
     _test_existing_clone_target,
     _generate_candidate_clone_sources,
 )
@@ -85,7 +85,7 @@ def clone_dataset(
         # in a reckless mode, and inherit it for the coming clone
         reckless = cfg.get('datalad.clone.reckless', None)
 
-    last_candidate, error_msgs, stop_props = _try_clone(
+    last_candidate, error_msgs, stop_props = _try_clone_candidates(
         destds,
         candidate_sources,
         clone_opts or [],

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -13,8 +13,6 @@ from datalad.core.distributed.clone import (
     configure_origins,
     postclone_check_head,
     postclone_checkout_commit,
-    postclone_preannex_cfg_ria,
-    postclonecfg_ria,
 )
 from datalad.dochelpers import single_or_plural
 from datalad.interface.results import get_status_dict
@@ -261,10 +259,6 @@ def _post_git_init_processing_(
             destds)
         destds.repo.call_git(['init', '--shared={}'.format(reckless[7:])])
 
-    # In case of RIA stores we need to prepare *before* annex is called at all
-    if gitclonerec['type'] == 'ria':
-        postclone_preannex_cfg_ria(destds, remote=remote)
-
     # trick to have the function behave like a generator, even if it
     # (currently) doesn't actually yield anything.
     # but a patched version might want to...so for uniformity with
@@ -497,12 +491,6 @@ def _pre_final_processing_(
 ):
     """Any post-processing after Git and git-annex pieces are fully initialized
     """
-    # perform any post-processing that needs to know details of the clone
-    # source
-    if gitclonerec['type'] == 'ria':
-        yield from postclonecfg_ria(destds, gitclonerec,
-                                    remote=remote)
-
     if reckless:
         # store the reckless setting in the dataset to make it
         # known to later clones of subdatasets via get()
@@ -516,6 +504,11 @@ def _pre_final_processing_(
         # TODO: might no longer be necessary if 0.14.0 adds reloading upon
         # non-readonly commands invocation
         destds.config.reload()
+
+    # trick to have the function behave like a generator, even if it
+    # (currently) doesn't actually yield anything.
+    if False:
+        yield
 
 
 # apply patch

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -86,10 +86,10 @@ def clone_dataset(
         reckless = cfg.get('datalad.clone.reckless', None)
 
     last_candidate, error_msgs, stop_props = _try_clone_candidates(
-        destds,
-        candidate_sources,
-        clone_opts or [],
-        dest_path_existed,
+        destds=destds,
+        candidate_sources=candidate_sources,
+        clone_opts=clone_opts or [],
+        dest_path_existed=dest_path_existed,
     )
     if stop_props:
         # no luck, report and stop

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -68,12 +68,6 @@ def clone_dataset(
             ds=destds,
         )
 
-    if reckless is None and cfg:
-        # if reckless is not explicitly given, but we operate on a
-        # superdataset, query whether it has been instructed to operate
-        # in a reckless mode, and inherit it for the coming clone
-        reckless = cfg.get('datalad.clone.reckless', None)
-
     dest_path = destds.pathobj
 
     candidate_sources = _generate_candidate_clone_sources(
@@ -243,6 +237,12 @@ def clone_dataset(
 
     if not cand.get("version"):
         postclone_check_head(destds, remote=remote)
+
+    if reckless is None and cfg:
+        # if reckless is not explicitly given, but we operate on a
+        # superdataset, query whether it has been instructed to operate
+        # in a reckless mode, and inherit it for the coming clone
+        reckless = cfg.get('datalad.clone.reckless', None)
 
     # act on --reckless=shared-...
     # must happen prior git-annex-init, where we can cheaply alter the repo

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -132,12 +132,12 @@ def clone_dataset(
     #
     try:
         yield from _post_gitclone_processing_(
-            destds,
-            cfg,
-            last_candidate,
-            reckless,
-            checkout_gitsha,
-            description,
+            destds=destds,
+            cfg=cfg,
+            gitclonerec=last_candidate,
+            reckless=reckless,
+            checkout_gitsha=checkout_gitsha,
+            description=description,
         )
     except Exception as e:
         ce = CapturedException(e)
@@ -161,6 +161,7 @@ def clone_dataset(
 
 
 def _post_gitclone_processing_(
+        *,
         destds: Dataset,
         cfg: ConfigManager,
         gitclonerec: Dict,
@@ -182,35 +183,35 @@ def _post_gitclone_processing_(
     remote = _get_remote(dest_repo)
 
     yield from _post_git_init_processing_(
-        destds,
-        cfg,
-        gitclonerec,
-        remote,
-        reckless,
+        destds=destds,
+        cfg=cfg,
+        gitclonerec=gitclonerec,
+        remote=remote,
+        reckless=reckless,
     )
 
     if knows_annex(destds.path):
         # init annex when traces of a remote annex can be detected
         yield from _pre_annex_init_processing_(
-            destds,
-            cfg,
-            gitclonerec,
-            remote,
-            reckless,
+            destds=destds,
+            cfg=cfg,
+            gitclonerec=gitclonerec,
+            remote=remote,
+            reckless=reckless,
         )
         dest_repo = _annex_init(
-            destds,
-            cfg,
-            gitclonerec,
-            remote,
-            description,
+            destds=destds,
+            cfg=cfg,
+            gitclonerec=gitclonerec,
+            remote=remote,
+            description=description,
         )
         yield from _post_annex_init_processing_(
-            destds,
-            cfg,
-            gitclonerec,
-            remote,
-            reckless,
+            destds=destds,
+            cfg=cfg,
+            gitclonerec=gitclonerec,
+            remote=remote,
+            reckless=reckless,
         )
 
     if checkout_gitsha and \
@@ -230,15 +231,16 @@ def _post_gitclone_processing_(
             raise
 
     yield from _pre_final_processing_(
-        destds,
-        cfg,
-        gitclonerec,
-        remote,
-        reckless,
+        destds=destds,
+        cfg=cfg,
+        gitclonerec=gitclonerec,
+        remote=remote,
+        reckless=reckless,
     )
 
 
 def _post_git_init_processing_(
+        *,
         destds: Dataset,
         cfg: ConfigManager,
         gitclonerec: Dict,
@@ -272,6 +274,7 @@ def _post_git_init_processing_(
 
 
 def _pre_annex_init_processing_(
+        *,
         destds: Dataset,
         cfg: ConfigManager,
         gitclonerec: Dict,
@@ -302,6 +305,7 @@ def _pre_annex_init_processing_(
 
 
 def _annex_init(
+        *,
         destds: Dataset,
         cfg: ConfigManager,
         gitclonerec: Dict,
@@ -324,6 +328,7 @@ def _annex_init(
 
 
 def _post_annex_init_processing_(
+        *,
         destds: Dataset,
         cfg: ConfigManager,
         gitclonerec: Dict,
@@ -483,6 +488,7 @@ def _post_annex_init_processing_(
 
 
 def _pre_final_processing_(
+        *,
         destds: Dataset,
         cfg: ConfigManager,
         gitclonerec: Dict,

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -118,18 +118,7 @@ def clone_dataset(
 
     dest_repo = destds.repo
 
-    remotes = dest_repo.get_remotes(with_urls_only=True)
-    nremotes = len(remotes)
-    if nremotes == 1:
-        remote = remotes[0]
-        lgr.debug("Determined %s to be remote of %s", remote, destds)
-    elif remotes > 1:
-        lgr.warning(
-            "Fresh clone %s unexpected has multiple remotes: %s. Using %s",
-            destds.path, remotes, remotes[0])
-        remote = remotes[0]
-    else:
-        raise RuntimeError("bug: fresh clone has zero remotes")
+    remote = _get_remote(dest_repo)
 
     if not last_candidate.get("version"):
         postclone_check_head(destds, remote=remote)
@@ -401,6 +390,29 @@ def _format_clone_errors(
                     "The 'succesful' source was: %s"
         error_args = (destds.path, last_clone_url)
     return error_msg, error_args
+
+
+def _get_remote(repo: GitRepo) -> str:
+    """Return the name of the remote of a freshly clones repo
+
+    Raises
+    ------
+    RuntimeError
+      In case there is no remote, which should never happen.
+    """
+    remotes = repo.get_remotes(with_urls_only=True)
+    nremotes = len(remotes)
+    if nremotes == 1:
+        remote = remotes[0]
+        lgr.debug("Determined %s to be remote of %s", remote, repo)
+    elif remotes > 1:
+        lgr.warning(
+            "Fresh clone %s unexpected has multiple remotes: %s. Using %s",
+            repo.path, remotes, remotes[0])
+        remote = remotes[0]
+    else:
+        raise RuntimeError("bug: fresh clone has zero remotes")
+    return remote
 
 
 # apply patch

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -146,8 +146,7 @@ def clone_dataset(
         # we are hadly able to distinguish user-error from an other errors
         yield get_status_dict(
             status='error',
-            # TODO is this needed when we add exception=?
-            message=str(ce),
+            error_message=ce.message,
             exception=ce,
             **result_props,
         )

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -78,7 +78,7 @@ def clone_dataset(
         result_props = result_props.copy()
 
     candidate_sources = _generate_candidate_clone_sources(
-        srcs, cfg, destds)
+        destds, srcs, cfg)
 
     # important test!
     # based on this `rmtree` will happen below after failed clone
@@ -212,9 +212,9 @@ def _post_gitclone_processing(
 
 
 def _generate_candidate_clone_sources(
+        destds: Dataset,
         srcs: List,
-        cfg: ConfigManager or None,
-        destds: Dataset) -> List:
+        cfg: ConfigManager or None) -> List:
     """Convert "raw" clone source specs to candidate URLs
     """
     # check for configured URL mappings, either in the given config manager

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -84,7 +84,7 @@ def clone_dataset(
     # an return -- like done for checkout failure now.
     #
     candidate_sources = _generate_candidate_clone_sources(
-        srcs, cfg or destds.config)
+        srcs, cfg, destds)
 
     # important test!
     # based on this `rmtree` will happen below after failed clone
@@ -192,15 +192,22 @@ def clone_dataset(
     yield get_status_dict(status='ok', **result_props)
 
 
-def _generate_candidate_clone_sources(srcs: List, cfg) -> List:
+def _generate_candidate_clone_sources(
+        srcs: List,
+        cfg: ConfigManager or None,
+        destds: Dataset) -> List:
     """Convert "raw" clone source specs to candidate URLs
     """
     # check for configured URL mappings, either in the given config manager
     # or in the one of the destination dataset, which is typically not existent
-    # yet and the process config manager is then used effectively
-    srcs = _map_urls(cfg, srcs)
+    # yet and the process config is then used effectively
+    srcs = _map_urls(cfg or destds.config, srcs)
 
     # decode all source candidate specifications
+    # use a given config or pass None to make it use the process config
+    # manager. Theoretically, we could also do
+    # `cfg or destds.config` as done above, but some tests patch
+    # the process config manager
     candidate_sources = [decode_source_spec(s, cfg=cfg) for s in srcs]
 
     # now expand the candidate sources with additional variants of the decoded

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -146,7 +146,9 @@ def clone_dataset(
         # we are hadly able to distinguish user-error from an other errors
         yield get_status_dict(
             status='error',
-            error_message=ce.message,
+            # XXX A test in core insists on the wrong message type to be used
+            #error_message=ce.message,
+            message=ce.message,
             exception=ce,
             **result_props,
         )

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -53,7 +53,7 @@ lgr = logging.getLogger('datalad.core.distributed.clone')
 # This function is taken from datalad-core@bacdc8e8f8c942649cba98b15b426670c564ed3f
 # datalad/core/distributed/clone.py
 # Changes
-# -
+# - Refactored into smaller, more manageable units
 def clone_dataset(
         srcs,
         destds,

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -1,0 +1,330 @@
+import logging
+import re
+from os.path import expanduser
+from collections import OrderedDict
+
+from datalad.core.distributed import clone as mod_clone
+from datalad.core.distributed.clone import (
+    _get_tracking_source,
+    _map_urls,
+    decode_source_spec,
+    postclone_check_head,
+    postclone_checkout_commit,
+    postclone_preannex_cfg_ria,
+    postclonecfg_annexdataset,
+    postclonecfg_ria,
+)
+
+from datalad.interface.results import get_status_dict
+from datalad.log import log_progress
+from datalad.support.gitrepo import (
+    GitRepo,
+)
+from datalad.cmd import (
+    CommandError,
+)
+from datalad.support.exceptions import (
+    CapturedException,
+)
+from datalad.support.network import (
+    get_local_file_url,
+    is_url,
+)
+from datalad.utils import (
+    Path,
+    rmtree,
+)
+from datalad.distribution.utils import (
+    _get_flexible_source_candidates,
+)
+
+__docformat__ = 'restructuredtext'
+
+lgr = logging.getLogger('datalad.core.distributed.clone')
+
+
+# This function is taken from datalad-core@bacdc8e8f8c942649cba98b15b426670c564ed3f
+# datalad/core/distributed/clone.py
+# Changes
+# -
+def clone_dataset(
+        srcs,
+        destds,
+        reckless=None,
+        description=None,
+        result_props=None,
+        cfg=None,
+        checkout_gitsha=None,
+        clone_opts=None):
+    # docs are assigned from original version below
+
+    if not result_props:
+        # in case the caller had no specific idea on how results should look
+        # like, provide sensible defaults
+        result_props = dict(
+            action='install',
+            logger=lgr,
+            ds=destds,
+        )
+
+    if reckless is None and cfg:
+        # if reckless is not explicitly given, but we operate on a
+        # superdataset, query whether it has been instructed to operate
+        # in a reckless mode, and inherit it for the coming clone
+        reckless = cfg.get('datalad.clone.reckless', None)
+
+    dest_path = destds.pathobj
+
+    # check for configured URL mappings, either in the given config manager
+    # or in the one of the destination dataset, which is typically not existent
+    # yet and the process config manager is then used effectively
+    srcs = _map_urls(cfg or destds.config, srcs)
+
+    # decode all source candidate specifications
+    candidate_sources = [decode_source_spec(s, cfg=cfg) for s in srcs]
+
+    # now expand the candidate sources with additional variants of the decoded
+    # giturl, while duplicating the other properties in the additional records
+    # for simplicity. The hope is to overcome a few corner cases and be more
+    # robust than git clone
+    candidate_sources = [
+        dict(props, giturl=s) for props in candidate_sources
+        for s in _get_flexible_source_candidates(props['giturl'])
+    ]
+
+    # important test! based on this `rmtree` will happen below after failed clone
+    dest_path_existed = dest_path.exists()
+    if dest_path_existed and any(dest_path.iterdir()):
+        if destds.is_installed():
+            # check if dest was cloned from the given source before
+            # this is where we would have installed this from
+            # this is where it was actually installed from
+            track_name, track_url = _get_tracking_source(destds)
+            try:
+                # this will get us track_url in system native path conventions,
+                # whenever it is a path (and not a URL)
+                # this is needed to match it to any potentially incoming local
+                # source path in the 'notneeded' test below
+                track_path = str(Path(track_url))
+            except Exception as e:
+                CapturedException(e)
+                # this should never happen, because Path() will let any non-path stringification
+                # pass through unmodified, but we do not want any potential crash due to
+                # pathlib behavior changes
+                lgr.debug("Unexpected behavior of pathlib!")
+                track_path = None
+            for cand in candidate_sources:
+                src = cand['giturl']
+                if track_url == src \
+                        or (not is_url(track_url)
+                            and get_local_file_url(track_url, compatibility='git') == src) \
+                        or track_path == expanduser(src):
+                    yield get_status_dict(
+                        status='notneeded',
+                        message=("dataset %s was already cloned from '%s'",
+                                 destds,
+                                 src),
+                        **result_props)
+                    return
+        # anything else is an error
+        yield get_status_dict(
+            status='error',
+            message='target path already exists and not empty, refuse to clone into target path',
+            **result_props)
+        return
+
+    log_progress(
+        lgr.info,
+        'cloneds',
+        'Cloning dataset to %s', destds,
+        total=len(candidate_sources),
+        label='Clone attempt',
+        unit=' Candidate locations',
+    )
+    clone_opts = clone_opts or []
+    error_msgs = OrderedDict()  # accumulate all error messages formatted per each url
+    for cand in candidate_sources:
+        log_progress(
+            lgr.info,
+            'cloneds',
+            'Attempting to clone from %s to %s', cand['giturl'], dest_path,
+            update=1,
+            increment=True)
+
+        if cand.get('version', None):
+            opts = clone_opts + ["--branch=" + cand['version']]
+        else:
+            opts = clone_opts
+
+        try:
+            # TODO for now GitRepo.clone() cannot handle Path instances, and PY35
+            # doesn't make it happen seamlessly
+            GitRepo.clone(
+                path=str(dest_path),
+                url=cand['giturl'],
+                clone_options=opts,
+                create=True)
+
+        except CommandError as e:
+            ce = CapturedException(e)
+            e_stderr = e.stderr
+
+            error_msgs[cand['giturl']] = e
+            lgr.debug("Failed to clone from URL: %s (%s)",
+                      cand['giturl'], ce)
+            if dest_path.exists():
+                lgr.debug("Wiping out unsuccessful clone attempt at: %s",
+                          dest_path)
+                # We must not just rmtree since it might be curdir etc
+                # we should remove all files/directories under it
+                # TODO stringification can be removed once patlib compatible
+                # or if PY35 is no longer supported
+                rmtree(str(dest_path), children_only=dest_path_existed)
+
+            if e_stderr and 'could not create work tree' in e_stderr.lower():
+                # this cannot be fixed by trying another URL
+                re_match = re.match(r".*fatal: (.*)$", e_stderr,
+                                    flags=re.MULTILINE | re.DOTALL)
+                # cancel progress bar
+                log_progress(
+                    lgr.info,
+                    'cloneds',
+                    'Completed clone attempts for %s', destds
+                )
+                yield get_status_dict(
+                    status='error',
+                    message=re_match.group(1).strip()
+                    if re_match else "stderr: " + e_stderr,
+                    **result_props)
+                return
+            # next candidate
+            continue
+
+        result_props['source'] = cand
+        # do not bother with other sources if succeeded
+        break
+
+    log_progress(
+        lgr.info,
+        'cloneds',
+        'Completed clone attempts for %s', destds
+    )
+
+    if not destds.is_installed():
+        if len(error_msgs):
+            if all(not e.stdout and not e.stderr for e in error_msgs.values()):
+                # there is nothing we can learn from the actual exception,
+                # the exit code is uninformative, the command is predictable
+                error_msg = "Failed to clone from all attempted sources: %s"
+                error_args = list(error_msgs.keys())
+            else:
+                error_msg = "Failed to clone from any candidate source URL. " \
+                            "Encountered errors per each url were:\n- %s"
+                error_args = '\n- '.join(
+                    '{}\n  {}'.format(url, exc.to_str())
+                    for url, exc in error_msgs.items()
+                )
+        else:
+            # yoh: Not sure if we ever get here but I felt that there could
+            #      be a case when this might happen and original error would
+            #      not be sufficient to troubleshoot what is going on.
+            error_msg = "Awkward error -- we failed to clone properly. " \
+                        "Although no errors were encountered, target " \
+                        "dataset at %s seems to be not fully installed. " \
+                        "The 'succesful' source was: %s"
+            error_args = (destds.path, cand['giturl'])
+        yield get_status_dict(
+            status='error',
+            message=(error_msg, error_args),
+            **result_props)
+        return
+
+    dest_repo = destds.repo
+
+    remotes = dest_repo.get_remotes(with_urls_only=True)
+    nremotes = len(remotes)
+    if nremotes == 1:
+        remote = remotes[0]
+        lgr.debug("Determined %s to be remote of %s", remote, destds)
+    elif remotes > 1:
+        lgr.warning(
+            "Fresh clone %s unexpected has multiple remotes: %s. Using %s",
+            destds.path, remotes, remotes[0])
+        remote = remotes[0]
+    else:
+        raise RuntimeError("bug: fresh clone has zero remotes")
+
+    if not cand.get("version"):
+        postclone_check_head(destds, remote=remote)
+
+    # act on --reckless=shared-...
+    # must happen prior git-annex-init, where we can cheaply alter the repo
+    # setup through safe re-init'ing
+    if reckless and reckless.startswith('shared-'):
+        lgr.debug('Reinitializing %s to enable shared access permissions', destds)
+        destds.repo.call_git(['init', '--shared={}'.format(reckless[7:])])
+
+    # In case of RIA stores we need to prepare *before* annex is called at all
+    if result_props['source']['type'] == 'ria':
+        postclone_preannex_cfg_ria(destds, remote=remote)
+
+    yield from postclonecfg_annexdataset(
+        destds,
+        reckless,
+        description,
+        remote=remote)
+
+    if checkout_gitsha and \
+       dest_repo.get_hexsha(dest_repo.get_corresponding_branch()) != checkout_gitsha:
+        try:
+            postclone_checkout_commit(dest_repo, checkout_gitsha,
+                                      remote=remote)
+        except Exception as e:
+            ce = CapturedException(e)
+            yield get_status_dict(
+                status='error',
+                message=str(ce),
+                exception=ce,
+                **result_props,
+            )
+
+            # We were supposed to clone a particular version but failed to.
+            # This is particularly pointless in case of subdatasets and
+            # potentially fatal with current implementation of recursion.
+            # see gh-5387
+            lgr.debug("Failed to checkout %s, removing this clone attempt at %s", checkout_gitsha, dest_path)
+            # TODO stringification can be removed once pathlib compatible
+            # or if PY35 is no longer supported
+            rmtree(str(dest_path), children_only=dest_path_existed)
+            return
+
+    # perform any post-processing that needs to know details of the clone
+    # source
+    if result_props['source']['type'] == 'ria':
+        yield from postclonecfg_ria(destds, result_props['source'],
+                                    remote=remote)
+
+    if reckless:
+        # store the reckless setting in the dataset to make it
+        # known to later clones of subdatasets via get()
+        destds.config.set(
+            'datalad.clone.reckless', reckless,
+            scope='local',
+            reload=True)
+    else:
+        # We would still want to reload configuration to ensure that any of the
+        # above git invocations could have potentially changed the config
+        # TODO: might no longer be necessary if 0.14.0 adds reloading upon
+        # non-readonly commands invocation
+        destds.config.reload()
+
+    # yield successful clone of the base dataset now, as any possible
+    # subdataset clone down below will not alter the Git-state of the
+    # parent
+    yield get_status_dict(status='ok', **result_props)
+
+
+# apply patch
+lgr.debug('Apply datalad-next patch to clone.py:clone_dataset')
+clone_dataset.__doc__ = mod_clone.clone_dataset.__doc__
+mod_clone.clone_dataset = clone_dataset

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -14,17 +14,12 @@ from datalad.core.distributed.clone import (
     postclone_check_head,
     postclone_checkout_commit,
 )
-from datalad.dochelpers import single_or_plural
 from datalad.interface.results import get_status_dict
 from datalad.support.annexrepo import AnnexRepo
-from datalad.cmd import (
-    CommandError,
-)
 from datalad.support.exceptions import (
     CapturedException,
 )
 from datalad.utils import (
-    ensure_bool,
     knows_annex,
     rmtree,
 )
@@ -33,6 +28,7 @@ from datalad.distribution.dataset import (
 )
 
 from .clone_utils import (
+    _check_autoenable_special_remotes,
     _get_remote,
     _format_clone_errors,
     _try_clone,
@@ -320,83 +316,7 @@ def _post_annex_init_processing_(
     if reckless == 'auto' or (reckless and reckless.startswith('shared-')):
         repo.call_annex(['untrust', 'here'])
 
-    srs = {True: [], False: []}  # special remotes by "autoenable" key
-    remote_uuids = None  # might be necessary to discover known UUIDs
-
-    repo_config = repo.config
-    # Note: The purpose of this function is to inform the user. So if something
-    # looks misconfigured, we'll warn and move on to the next item.
-    for uuid, config in repo.get_special_remotes().items():
-        sr_name = config.get('name', None)
-        if sr_name is None:
-            lgr.warning(
-                'Ignoring special remote %s because it does not have a name. '
-                'Known information: %s',
-                uuid, config)
-            continue
-        sr_autoenable = config.get('autoenable', False)
-        try:
-            sr_autoenable = ensure_bool(sr_autoenable)
-        except ValueError as e:
-            CapturedException(e)
-            lgr.warning(
-                'Failed to process "autoenable" value %r for sibling %s in '
-                'dataset %s as bool.'
-                'You might need to enable it later manually and/or fix it up to'
-                ' avoid this message in the future.',
-                sr_autoenable, sr_name, ds.path)
-            continue
-
-        # If it looks like a type=git special remote, make sure we have up to
-        # date information. See gh-2897.
-        if sr_autoenable and repo_config.get("remote.{}.fetch".format(sr_name)):
-            try:
-                repo.fetch(remote=sr_name)
-            except CommandError as exc:
-                ce = CapturedException(exc)
-                lgr.warning("Failed to fetch type=git special remote %s: %s",
-                            sr_name, exc)
-
-        # determine whether there is a registered remote with matching UUID
-        if uuid:
-            if remote_uuids is None:
-                remote_uuids = {
-                    # Check annex-config-uuid first. For sameas annex remotes,
-                    # this will point to the UUID for the configuration (i.e.
-                    # the key returned by get_special_remotes) rather than the
-                    # shared UUID.
-                    (repo_config.get('remote.%s.annex-config-uuid' % r) or
-                     repo_config.get('remote.%s.annex-uuid' % r))
-                    for r in repo.get_remotes()
-                }
-            if uuid not in remote_uuids:
-                srs[sr_autoenable].append(sr_name)
-
-    if srs[True]:
-        lgr.debug(
-            "configuration for %s %s added because of autoenable,"
-            " but no UUIDs for them yet known for dataset %s",
-            # since we are only at debug level, we could call things their
-            # proper names
-            single_or_plural("special remote",
-                             "special remotes", len(srs[True]), True),
-            ", ".join(srs[True]),
-            ds.path
-        )
-
-    if srs[False]:
-        # if has no auto-enable special remotes
-        lgr.info(
-            'access to %s %s not auto-enabled, enable with:\n'
-            '\t\tdatalad siblings -d "%s" enable -s %s',
-            # but since humans might read it, we better confuse them with our
-            # own terms!
-            single_or_plural("dataset sibling",
-                             "dataset siblings", len(srs[False]), True),
-            ", ".join(srs[False]),
-            ds.path,
-            srs[False][0] if len(srs[False]) == 1 else "SIBLING",
-        )
+    _check_autoenable_special_remotes(repo)
 
     # we have just cloned the repo, so it has a remote `remote`, configure any
     # reachable origin of origins

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -74,6 +74,8 @@ def clone_dataset(
             logger=lgr,
             ds=destds,
         )
+    else:
+        result_props = result_props.copy()
 
     dest_path = destds.pathobj
 

--- a/datalad_next/patches/clone_ephemeral.py
+++ b/datalad_next/patches/clone_ephemeral.py
@@ -1,0 +1,130 @@
+""""""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+
+from datalad.distribution.dataset import Dataset
+from datalad.support.exceptions import CapturedException
+from datalad.support.gitrepo import GitRepo
+from datalad.support.network import RI
+from datalad.utils import (
+    Path,
+    check_symlink_capability,
+    rmtree,
+)
+
+from datalad_next.patches import clone as mod_clone
+
+lgr = logging.getLogger('datalad.core.distributed.clone')
+
+
+def _pre_annex_init_processing_(
+    *,
+    destds: Dataset,
+    reckless: None or str,
+    **kwargs
+):
+    if reckless == 'ephemeral':
+        # In ephemeral clones we set annex.private=true. This would prevent the
+        # location itself being recorded in uuid.log. With a private repo,
+        # declaring dead (see below after annex-init) seems somewhat
+        # superfluous, but on the other hand:
+        # If an older annex that doesn't support private yet touches the
+        # repo, the entire purpose of ephemeral would be sabotaged if we did
+        # not declare dead in addition. Hence, keep it regardless of annex
+        # version.
+        destds.config.set('annex.private', 'true', scope='local')
+
+    yield from orig_pre_annex_init_processing_(
+        destds=destds, reckless=reckless, **kwargs)
+
+
+def _post_annex_init_processing_(
+        *,
+        destds: Dataset,
+        remote: str,
+        reckless: None or str,
+        **kwargs
+):
+
+    if reckless == 'ephemeral':
+        _setup_ephemeral_annex(destds, remote)
+
+    yield from orig_post_annex_init_processing_(
+        destds=destds, remote=remote, reckless=reckless,
+        **kwargs)
+
+
+def _setup_ephemeral_annex(ds: Dataset, remote: str):
+    # with ephemeral we declare 'here' as 'dead' right away, whenever
+    # we symlink the remote's annex, since availability from 'here' should
+    # not be propagated for an ephemeral clone when we publish back to
+    # the remote.
+    # This will cause stuff like this for a locally present annexed file:
+    # % git annex whereis d1
+    # whereis d1 (0 copies) failed
+    # BUT this works:
+    # % git annex find . --not --in here
+    # % git annex find . --in here
+    # d1
+
+    # we don't want annex copy-to <remote>
+    ds.config.set(
+        f'remote.{remote}.annex-ignore', 'true',
+        scope='local')
+    ds.repo.set_remote_dead('here')
+
+    if check_symlink_capability(ds.repo.dot_git / 'dl_link_test',
+                                ds.repo.dot_git / 'dl_target_test'):
+        # symlink the annex to avoid needless copies in an ephemeral clone
+        annex_dir = ds.repo.dot_git / 'annex'
+        origin_annex_url = ds.config.get(f"remote.{remote}.url", None)
+        origin_git_path = None
+        if origin_annex_url:
+            try:
+                # Deal with file:// scheme URLs as well as plain paths.
+                # If origin isn't local, we have nothing to do.
+                origin_git_path = Path(RI(origin_annex_url).localpath)
+
+                # we are local; check for a bare repo first to not mess w/
+                # the path
+                if GitRepo(origin_git_path, create=False).bare:
+                    # origin is a bare repo -> use path as is
+                    pass
+                elif origin_git_path.name != '.git':
+                    origin_git_path /= '.git'
+            except ValueError as e:
+                CapturedException(e)
+                # Note, that accessing localpath on a non-local RI throws
+                # ValueError rather than resulting in an AttributeError.
+                # TODO: Warning level okay or is info level sufficient?
+                # Note, that setting annex-dead is independent of
+                # symlinking .git/annex. It might still make sense to
+                # have an ephemeral clone that doesn't propagate its avail.
+                # info. Therefore don't fail altogether.
+                lgr.warning("reckless=ephemeral mode: %s doesn't seem "
+                            "local: %s\nno symlinks being used",
+                            remote, origin_annex_url)
+        if origin_git_path:
+            # TODO make sure that we do not delete any unique data
+            rmtree(str(annex_dir)) \
+                if not annex_dir.is_symlink() else annex_dir.unlink()
+            annex_dir.symlink_to(origin_git_path / 'annex',
+                                 target_is_directory=True)
+    else:
+        # TODO: What level? + note, that annex-dead is independent
+        lgr.warning("reckless=ephemeral mode: Unable to create symlinks on "
+                    "this file system.")
+
+
+# apply patch
+lgr.debug(
+    'Apply datalad-next RIA patch to clone.py:_pre_annex_init_processing_')
+# we need to preserve the original function to be able to call it in the patch
+orig_pre_annex_init_processing_ = mod_clone._pre_annex_init_processing_
+mod_clone._pre_annex_init_processing_ = _pre_annex_init_processing_
+lgr.debug(
+    'Apply datalad-next RIA patch to clone.py:_post_annex_init_processing_')
+orig_post_annex_init_processing_ = mod_clone._post_annex_init_processing_
+mod_clone._post_annex_init_processing_ = _post_annex_init_processing_

--- a/datalad_next/patches/clone_ria.py
+++ b/datalad_next/patches/clone_ria.py
@@ -1,0 +1,61 @@
+""""""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+from typing import Dict
+
+from datalad.core.distributed.clone import (
+    postclone_preannex_cfg_ria,
+    postclonecfg_ria,
+)
+
+from datalad.distribution.dataset import Dataset
+
+from datalad_next.patches import clone as mod_clone
+
+lgr = logging.getLogger('datalad.core.distributed.clone')
+
+
+def _post_git_init_processing_(
+    *,
+    destds: Dataset,
+    gitclonerec: Dict,
+    remote: str,
+    **kwargs
+):
+    yield from orig_post_git_init_processing_(
+        destds=destds, gitclonerec=gitclonerec, remote=remote,
+        **kwargs)
+
+    # In case of RIA stores we need to prepare *before* annex is called at all
+    if gitclonerec['type'] == 'ria':
+        postclone_preannex_cfg_ria(destds, remote=remote)
+
+
+def _pre_final_processing_(
+        *,
+        destds: Dataset,
+        gitclonerec: Dict,
+        remote: str,
+        **kwargs
+):
+    if gitclonerec['type'] == 'ria':
+        yield from postclonecfg_ria(destds, gitclonerec,
+                                    remote=remote)
+
+    yield from orig_pre_final_processing_(
+        destds=destds, gitclonerec=gitclonerec, remote=remote,
+        **kwargs)
+
+
+# apply patch
+lgr.debug(
+    'Apply datalad-next RIA patch to clone.py:_post_git_init_processing_')
+# we need to preserve the original function to be able to call it in the patch
+orig_post_git_init_processing_ = mod_clone._post_git_init_processing_
+mod_clone._post_git_init_processing_ = _post_git_init_processing_
+lgr.debug(
+    'Apply datalad-next RIA patch to clone.py:_pre_final_processing_')
+orig_pre_final_processing_ = mod_clone._pre_final_processing_
+mod_clone._pre_final_processing_ = _pre_final_processing_

--- a/datalad_next/patches/clone_utils.py
+++ b/datalad_next/patches/clone_utils.py
@@ -133,6 +133,7 @@ def _test_existing_clone_target(
 
 
 def _try_clone_candidates(
+        *,
         destds: Dataset,
         candidate_sources: List,
         clone_opts: List,
@@ -177,9 +178,10 @@ def _try_clone_candidates(
             increment=True)
 
         tried_url, error, fatal = _try_clone_candidate(
-            destds,
-            cand,
-            clone_opts)
+            destds=destds,
+            cand=cand,
+            clone_opts=clone_opts,
+        )
 
         if error is not None:
             lgr.debug("Failed to clone from URL: %s (%s)",
@@ -219,6 +221,7 @@ def _try_clone_candidates(
 
 
 def _try_clone_candidate(
+        *,
         destds: Dataset,
         cand: Dict,
         clone_opts: List) -> Tuple:
@@ -243,10 +246,15 @@ def _try_clone_candidate(
       other candidates remain) will be attempted.
     """
     # right now, we only know git-clone based approaches
-    return _try_git_clone_candidate(destds, cand, clone_opts)
+    return _try_git_clone_candidate(
+        destds=destds,
+        cand=cand,
+        clone_opts=clone_opts,
+    )
 
 
 def _try_git_clone_candidate(
+        *,
         destds: Dataset,
         cand: Dict,
         clone_opts: List) -> Tuple:

--- a/datalad_next/patches/clone_utils.py
+++ b/datalad_next/patches/clone_utils.py
@@ -159,6 +159,14 @@ def _try_clone_candidates(
       and either a dict with properties of a result that should be yielded
       before an immediate return, or None, if the processing can continue
     """
+    log_progress(
+        lgr.info,
+        'cloneds',
+        'Attempting a clone into %s', destds.path,
+        unit=' candidates',
+        label='Cloning',
+        total=len(candidate_sources),
+    )
     error_msgs = dict()  # accumulate all error messages formatted per each url
     for cand in candidate_sources:
         log_progress(

--- a/datalad_next/patches/clone_utils.py
+++ b/datalad_next/patches/clone_utils.py
@@ -1,0 +1,259 @@
+"""Helpers used in the clone.py patch"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+from pathlib import Path
+import re
+from os.path import expanduser
+from typing import (
+    List,
+    Tuple,
+)
+from datalad.config import ConfigManager
+from datalad.core.distributed.clone import (
+    _get_tracking_source,
+    _map_urls,
+    decode_source_spec,
+)
+from datalad.distribution.dataset import Dataset
+from datalad.log import log_progress
+from datalad.support.exceptions import CapturedException
+from datalad.runner.exception import CommandError
+from datalad.support.gitrepo import GitRepo
+from datalad.support.network import (
+    get_local_file_url,
+    is_url,
+)
+from datalad.distribution.utils import _get_flexible_source_candidates
+from datalad.utils import rmtree
+
+__docformat__ = 'restructuredtext'
+
+lgr = logging.getLogger('datalad.core.distributed.clone')
+
+
+def _generate_candidate_clone_sources(
+        destds: Dataset,
+        srcs: List,
+        cfg: ConfigManager or None) -> List:
+    """Convert "raw" clone source specs to candidate URLs
+    """
+    # check for configured URL mappings, either in the given config manager
+    # or in the one of the destination dataset, which is typically not existent
+    # yet and the process config is then used effectively
+    srcs = _map_urls(cfg or destds.config, srcs)
+
+    # decode all source candidate specifications
+    # use a given config or pass None to make it use the process config
+    # manager. Theoretically, we could also do
+    # `cfg or destds.config` as done above, but some tests patch
+    # the process config manager
+    candidate_sources = [decode_source_spec(s, cfg=cfg) for s in srcs]
+
+    # now expand the candidate sources with additional variants of the decoded
+    # giturl, while duplicating the other properties in the additional records
+    # for simplicity. The hope is to overcome a few corner cases and be more
+    # robust than git clone
+    return [
+        dict(props, giturl=s) for props in candidate_sources
+        for s in _get_flexible_source_candidates(props['giturl'])
+    ]
+
+
+def _test_existing_clone_target(
+        destds: Dataset,
+        candidate_sources: List) -> Tuple:
+    """Check if the clone target exists, inspect it, if so
+
+    Returns
+    -------
+    (bool, dict or None)
+      A flag whether the target exists, and either a dict with properties
+      of a result that should be yielded before an immediate return, or
+      None, if the processing can continue
+    """
+    # important test! based on this `rmtree` will happen below after
+    # failed clone
+    dest_path = destds.pathobj
+    dest_path_existed = dest_path.exists()
+    if dest_path_existed and any(dest_path.iterdir()):
+        if destds.is_installed():
+            # check if dest was cloned from the given source before
+            # this is where we would have installed this from
+            # this is where it was actually installed from
+            track_name, track_url = _get_tracking_source(destds)
+            try:
+                # this will get us track_url in system native path conventions,
+                # whenever it is a path (and not a URL)
+                # this is needed to match it to any potentially incoming local
+                # source path in the 'notneeded' test below
+                track_path = str(Path(track_url))
+            except Exception as e:
+                CapturedException(e)
+                # this should never happen, because Path() will let any non-path
+                # stringification pass through unmodified, but we do not want any
+                # potential crash due to pathlib behavior changes
+                lgr.debug("Unexpected behavior of pathlib!")
+                track_path = None
+            for cand in candidate_sources:
+                src = cand['giturl']
+                if track_url == src \
+                        or (not is_url(track_url)
+                            and get_local_file_url(
+                                track_url, compatibility='git') == src) \
+                        or track_path == expanduser(src):
+                    return dest_path_existed, dict(
+                        status='notneeded',
+                        message=("dataset %s was already cloned from '%s'",
+                                 destds,
+                                 src),
+                    )
+        # anything else is an error
+        return dest_path_existed, dict(
+            status='error',
+            message='target path already exists and not empty, '
+                    'refuse to clone into target path',
+        )
+    # found no reason to stop, i.e. empty target dir
+    return dest_path_existed, None
+
+
+def _try_clone(
+        destds: Dataset,
+        candidate_sources: List,
+        clone_opts: List,
+        dest_path_existed: bool) -> Tuple:
+    """Iterate over candidate URLs and attempt a clone
+
+    Returns
+    -------
+    (dict or None, dict, dict or None)
+      The record of the last clone attempt, a mapping of candidate URLs
+      to potential error messages they yielded, and either a dict with
+      properties of a result that should be yielded before an immediate
+      return, or None, if the processing can continue
+    """
+    error_msgs = dict()  # accumulate all error messages formatted per each url
+    for cand in candidate_sources:
+        log_progress(
+            lgr.info,
+            'cloneds',
+            'Attempting to clone from %s to %s', cand['giturl'], destds.path,
+            update=1,
+            increment=True)
+
+        if cand.get('version', None):
+            opts = clone_opts + ["--branch=" + cand['version']]
+        else:
+            opts = clone_opts
+
+        try:
+            GitRepo.clone(
+                path=destds.path,
+                url=cand['giturl'],
+                clone_options=opts,
+                create=True)
+
+        except CommandError as e:
+            ce = CapturedException(e)
+            e_stderr = e.stderr
+
+            error_msgs[cand['giturl']] = e
+            lgr.debug("Failed to clone from URL: %s (%s)",
+                      cand['giturl'], ce)
+            if destds.pathobj.exists():
+                lgr.debug("Wiping out unsuccessful clone attempt at: %s",
+                          destds.path)
+                # We must not just rmtree since it might be curdir etc
+                # we should remove all files/directories under it
+                # TODO stringification can be removed once patlib compatible
+                # or if PY35 is no longer supported
+                rmtree(destds.path, children_only=dest_path_existed)
+
+            if e_stderr and 'could not create work tree' in e_stderr.lower():
+                # this cannot be fixed by trying another URL
+                re_match = re.match(r".*fatal: (.*)$", e_stderr,
+                                    flags=re.MULTILINE | re.DOTALL)
+                # cancel progress bar
+                log_progress(
+                    lgr.info,
+                    'cloneds',
+                    'Completed clone attempts for %s', destds
+                )
+                return cand, error_msgs, dict(
+                    status='error',
+                    message=re_match.group(1).strip()
+                    if re_match else "stderr: " + e_stderr,
+                )
+            # next candidate
+            continue
+
+        # do not bother with other sources if succeeded
+        break
+
+    log_progress(
+        lgr.info,
+        'cloneds',
+        'Completed clone attempts for %s', destds
+    )
+    return cand, error_msgs, None
+
+
+def _format_clone_errors(
+        destds: Dataset,
+        error_msgs: List,
+        last_clone_url: str) -> Tuple:
+    """Format all accumulated clone errors across candidates into one message
+
+    Returns
+    -------
+    (str, list)
+      Message body and string formating arguments for it.
+    """
+    if len(error_msgs):
+        if all(not e.stdout and not e.stderr for e in error_msgs.values()):
+            # there is nothing we can learn from the actual exception,
+            # the exit code is uninformative, the command is predictable
+            error_msg = "Failed to clone from all attempted sources: %s"
+            error_args = list(error_msgs.keys())
+        else:
+            error_msg = "Failed to clone from any candidate source URL. " \
+                        "Encountered errors per each url were:\n- %s"
+            error_args = '\n- '.join(
+                '{}\n  {}'.format(url, exc.to_str())
+                for url, exc in error_msgs.items()
+            )
+    else:
+        # yoh: Not sure if we ever get here but I felt that there could
+        #      be a case when this might happen and original error would
+        #      not be sufficient to troubleshoot what is going on.
+        error_msg = "Awkward error -- we failed to clone properly. " \
+                    "Although no errors were encountered, target " \
+                    "dataset at %s seems to be not fully installed. " \
+                    "The 'succesful' source was: %s"
+        error_args = (destds.path, last_clone_url)
+    return error_msg, error_args
+
+
+def _get_remote(repo: GitRepo) -> str:
+    """Return the name of the remote of a freshly clones repo
+
+    Raises
+    ------
+    RuntimeError
+      In case there is no remote, which should never happen.
+    """
+    remotes = repo.get_remotes(with_urls_only=True)
+    nremotes = len(remotes)
+    if nremotes == 1:
+        remote = remotes[0]
+        lgr.debug("Determined %s to be remote of %s", remote, repo)
+    elif remotes > 1:
+        lgr.warning(
+            "Fresh clone %s unexpected has multiple remotes: %s. Using %s",
+            repo.path, remotes, remotes[0])
+        remote = remotes[0]
+    else:
+        raise RuntimeError("bug: fresh clone has zero remotes")
+    return remote


### PR DESCRIPTION
The series provides a patch to replace `clone_dataset()` the key workhorse of datalad-core's `clone` command. The patch causes no change to any functionality, but refactors the code from large monolithic functions into significantly smaller, more comprehensible units. Emphasis is made on separating function that control the flow of processing (`patches/clone.py`) from utilities that perform focused tasks (`patches/clone_utils.py`).

Key feature of the refactoring is the provisioning of a set of dedicated function that implement particular stages of the clone and post-clone setup processing:

- `_try_clone_candidates()` (the main clone attempt loop)
- `_try_clone_candidate()` (handle a single clone attempt)
- `_try_git_clone_candidate()` (only workhorse ATM with all git-clone specifics)
- `_post_gitclone_processing_()` (implements the logic to call all others)
- `_post_git_init_processing_()`
- `_pre_annex_init_processing_()`
- `_annex_init()`
- `_post_annex_init_processing_()`
- `_pre_final_processing_()`

All functions implement a keyword-argument-only API. All functions ending with the name `processing_` are implemented as generators that yield standard DataLad result records.

Any of these functions can be "patched" following the pattern used in `datalad-next` for any kind of modifications of datalad-core. This capability is demonstrated by pulling out two optional features, originally intermingled with essential code:

- `patches/clone_ria.py`
- `patches/clone_ephemeral.py` (related: https://github.com/datalad/datalad/issues/6961)

(Note that for both patches, the documentation is not patched right now, because it is unclear whether the approach find acceptance by the project at all. However documentation patches are done elsewhere too, and could be done here).

These document how it is possible, with this new implementation, to provide such add-on features externally, without having to introduce them in datalad-core directly. They also show, how the patches can benefit from the keyword-argument-only API. They should continue to work as designed, as long as the particular keyword-arguments the require continue to be provided with the same semantics.

Taken together, this series provides a solution to a number of issues that are linked below with a brief comment:

- https://github.com/datalad/datalad/issues/4903 -- more-or-less arbitrary modifications can be implemented following `git-clone`. The latter is itself encapsulated in the `_try_clone()` utility, so it would even be possible to patch-in means to establish repository clones that do not involve calling `git-clone`
- This is related to https://github.com/datalad/datalad-registry/issues/7 -- while we already have flexibility to add handling of new URL-types (e.g., URL mapping, subdataset candidate URL configurations), now, either `_try_clone()` or another utility (`_generate_candidate_clone_sources()`) can be patched to query an external resolver of some kind, including a DataLad registry
- https://github.com/datalad/datalad/issues/5289 -- the datalad-next style patching has proven to be somewhat reliable, and continue to grow in usage. This series modifies datalad-core to enable more surgical patching for add-on functionality. Continuing this for other parts of the code base would lessen the need for (possibly expensive) hooks that may require additional setup and maintenance.

The patch-in-a-clone-feature approach should be applicable to the growling list of open issues asking for additional (special interest) capabilities. Examples:

- https://github.com/datalad/datalad/issues/6408
- https://github.com/datalad/datalad/issues/5094
- https://github.com/datalad/datalad/issues/4142

Lastly, this approach can help to expedite work on rejuvenating datalad components that struggle to keep up within the corset of datalad-core, with its ambition to remain as stable as possible. One example is the RIA functionality that alone is associated with 7% of the open issues, and would benefit from a few faster, less constrained development cycles. The previous impossibility of `clone` to be customized externally (like done here), was one of the main reasons for having to introduce RIA in datalad-core directly, rather than having it prove itself in a dedicated extension.