### PR TITLE
DOC: Add an example of adding a user_password credential

### DIFF
--- a/changelog.d/20220824_140528_m.szczepanik_credentials_example.md
+++ b/changelog.d/20220824_140528_m.szczepanik_credentials_example.md
@@ -1,0 +1,5 @@
+### 📝 Documentation
+
+- Add an example of adding a `user_password`-type credentials, with a
+  given `user` property, to the examples in the `credentials`
+  command. https://github.com/datalad/datalad-next/pull/103 (by @mslw)

--- a/datalad_next/credentials.py
+++ b/datalad_next/credentials.py
@@ -220,6 +220,10 @@ class Credentials(Interface):
         dict(text="Upgrade a legacy credential by annotating it with a 'type' property",
              code_py="credentials('set', name='legacycred', spec={'type': 'user_password')",
              code_cmd="datalad credentials set legacycred type=user_password"),
+        dict(text="Set a new credential of type user_password, with a given user property, "
+                  "and input its secret interactively",
+             code_py="credentials('set', name='mycred', spec={'type': 'user_password', 'user': '<username>'})",
+             code_cmd="datalad credentials set mycred type=user_password user=<username>"),
         dict(text="Obtain a (possibly yet undefined) credential with a minimum set of "
                   "properties. All missing properties and secret will be "
                   "prompted for, no information will be stored! "


### PR DESCRIPTION
This adds an example of how to set a new credential of type user_password, with a given user property, to the examples in the
credentials command. For some reason, I always had to think twice before adding a new user_password credentials based on the existing docs (maybe it's just me). I thought this usage could have an explicit example.

The added example shows that type and user need to be defined as properties, and entry of the secret is interactive. While it was probably clear from the other examples and command description, now it's explicit. Also, it is the first example where more than one property is being given.