### PR TITLE
Add a warning on old git-annex versions to datalad-annex::

### DIFF
--- a/datalad_next/gitremote/datalad_annex.py
+++ b/datalad_next/gitremote/datalad_annex.py
@@ -205,6 +205,7 @@ from datalad.runner import (
 )
 from datalad.support.annexrepo import AnnexRepo
 from datalad.support.exceptions import CapturedException
+from datalad.support.external_versions import external_versions
 from datalad.support.gitrepo import GitRepo
 from datalad.support.constraints import EnsureInt
 from datalad.ui import ui
@@ -316,6 +317,14 @@ class RepoAnnexGitRemote(object):
         self.pending_credential = None
         # must come after the two above!
         self.credential_env = self._get_credential_env()
+
+        annex_version = external_versions['cmd:annex']
+        if annex_version < '8.20211123':
+            self.log(
+                f'git-annex version {annex_version} is unsupported, '
+                'please upgrade',
+                level=1
+            )
 
     def _get_credential_env(self):
         """


### PR DESCRIPTION
It turns the documentation note into a piece of code that
would reveal an issue in debug mode (at least).

Ping datalad/datalad-next#104