### PR TITLE
Don't split prompt and question in CredentialManager

### DIFF
--- a/datalad_next/credman.py
+++ b/datalad_next/credman.py
@@ -510,17 +510,17 @@ class CredentialManager(object):
         if not ui.is_interactive:
             lgr.debug('Cannot ask for credential property %r in non-interactive session', name)
             return
-        self._prompt(prompt)
-        return ui.question(name, title=None)
+
+        return ui.question(name, title=prompt)
 
     def _ask_secret(self, type_hint=None, prompt=None):
         if not ui.is_interactive:
             lgr.debug('Cannot ask for credential secret in non-interactive session')
             return
-        self._prompt(prompt)
+
         return ui.question(
             type_hint or 'secret',
-            title=None,
+            title=prompt,
             repeat=self._cfg.obtain(
                 'datalad.credentials.repeat-secret-entry'),
             hidden=self._cfg.obtain(


### PR DESCRIPTION
The `title` parameter of `ui.question` is intended for the prompting text, which is somewhat misleading by name.

In opposition to the `Credential`'s in datalad core, the CredentialManager splits the prompting text and the input retrieval when asking for a property or secret by calling `ui.message` and then `ui.question`. While this is kinda fine with CLI, other `ui` backends like gooey can't handle this properly. In combination with patching `create-sibling-ghlike` this led to https://github.com/datalad/datalad-gooey/issues/340.


