### PR TITLE
Account for internal eval_results method move in next's imports

### DIFF
--- a/datalad_next/commands/__init__.py
+++ b/datalad_next/commands/__init__.py
@@ -6,10 +6,13 @@ from datalad.interface.base import (
     build_doc,
 )
 from datalad.interface.results import get_status_dict
-from datalad.interface.utils import (
-    eval_results,
-    generic_result_renderer,
-)
+from datalad.interface.utils import generic_result_renderer
+try:
+    # datalad 0.17.10+
+    from datalad.interface.base import eval_results
+except ImportError:
+    # older datalad
+    from datalad.interface.utils import eval_results
 from datalad.support.param import Parameter
 
 from datalad_next.constraints.parameter import EnsureCommandParameterization

--- a/datalad_next/patches/interface_utils.py
+++ b/datalad_next/patches/interface_utils.py
@@ -11,7 +11,6 @@ from datalad.core.local.resulthooks import (
     match_jsonhook2result,
     run_jsonhook,
 )
-from datalad.interface import utils as mod_interface_utils
 from datalad.interface.results import known_result_xfms
 from datalad.interface.utils import (
     anInterface,
@@ -249,5 +248,14 @@ def _execute_command_(
 
 
 # apply patch
-lgr.debug('Apply datalad-next patch to interface.utils.py:_execute_command_')
-mod_interface_utils._execute_command_ = _execute_command_
+from datalad.interface import utils as mod_interface_utils
+if hasattr(mod_interface_utils, '_execute_command_'):
+    lgr.debug(
+        'Apply datalad-next patch to interface.utils.py:_execute_command_')
+    mod_interface_utils._execute_command_ = _execute_command_
+else:
+    # we have datalad 0.17.10+ and the target has moved
+    from datalad.interface import base as mod_interface_base
+    lgr.debug(
+        'Apply datalad-next patch to interface.base.py:_execute_command_')
+    mod_interface_base._execute_command_ = _execute_command_


### PR DESCRIPTION
This is a companion PR to https://github.com/datalad/datalad/pull/7170 to be merged upon a new DataLad release, when tests will start raising deprecation warnigns. If you'd like a changelog entry, please let me know.

- Closes #182