### PR TITLE
Patch datalad.runner.runnerthreads.ReadThread to use shutil buffer size default

### DIFF
--- a/changelog.d/20221118_111838_michael.hanke_runnerbuf.md
+++ b/changelog.d/20221118_111838_michael.hanke_runnerbuf.md
@@ -1,0 +1,5 @@
+### 💫 Enhancements and new features
+
+- Add patch to `ThreadedRunner` to use a more optimal buffer size for its
+  read thread. This was previously fixed to 1024 bytes, and now uses the
+  value of `shutil.COPY_BUFSIZE` as a platform-tailored default.

--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -9,5 +9,6 @@ from . import (
     interface_utils,
     push_to_export_remote,
     push_optimize,
+    runnerthreads,
     siblings,
 )

--- a/datalad_next/patches/runnerthreads.py
+++ b/datalad_next/patches/runnerthreads.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+try:
+    from shutil import COPY_BUFSIZE
+except ImportError:
+    # too old
+    from datalad.utils import on_windows
+    # from PY3.10
+    COPY_BUFSIZE = 1024 * 1024 if on_windows else 64 * 1024
+from datalad.runner import runnerthreads as mod_runnerthreads
+
+# use same logger as -core, looks weird but is correct
+lgr = logging.getLogger('datalad.runner.runnerthreads')
+
+# we need to preserve it as the workhorse, this patch only wraps around it
+orig_ReadThread__init__ = mod_runnerthreads.ReadThread.__init__
+
+
+def ReadThread__init__(
+    self,
+    identifier: str,
+    signal_queues: list[mod_runnerthreads.Queue],
+    user_info: mod_runnerthreads.Any,
+    source: mod_runnerthreads.IO,
+    destination_queue: mod_runnerthreads.Queue,
+    # This is the key aspect of the patch, use a platform-tailored
+    # default, not the small-ish 1024 bytes
+    length: int = COPY_BUFSIZE,
+):
+    orig_ReadThread__init__(
+        self,
+        identifier=identifier,
+        signal_queues=signal_queues,
+        user_info=user_info,
+        source=source,
+        destination_queue=destination_queue,
+        length=length,
+    )
+
+
+# apply patch
+lgr.debug(
+    'Apply datalad-next patch to runner.runnerthreads.ReadThread.__init__')
+mod_runnerthreads.ReadThread.__init__ = ReadThread__init__


### PR DESCRIPTION
This has a dramatic effect on the throughput, i.e. when using `ThreadedRunner()` for SSH-based downloads.