### PR TITLE
Let `credentials()` and `CredentialManager.set()` prompt for name

### DIFF
--- a/datalad_next/credentials.py
+++ b/datalad_next/credentials.py
@@ -252,7 +252,7 @@ class Credentials(Interface):
         # `spec` could be many things, make uniform dict
         specs = normalize_specs(spec)
 
-        if action in ('set', 'remove') and not name:
+        if action == 'remove' and not name:
             raise ValueError(
                 f"Credential name must be provided for action {action!r}")
         if action == 'get' and not name and not spec:
@@ -281,11 +281,14 @@ class Credentials(Interface):
                     exception=CapturedException(e),
                 )
                 return
+            # pull name out of report, if entered manually
+            if not name and updated is not None:
+                name = updated.pop('name', None)
             yield get_status_dict(
                 action='credentials',
-                status='ok',
+                status='notneeded' if updated is None else 'ok',
                 name=name,
-                **_prefix_result_keys(updated),
+                **_prefix_result_keys(updated if updated else specs),
             )
         elif action == 'get':
             cred = credman.get(name=name, _prompt=prompt, **specs)

--- a/datalad_next/tests/test_credentials.py
+++ b/datalad_next/tests/test_credentials.py
@@ -17,6 +17,7 @@ from ..credentials import (
     Credentials,
     normalize_specs,
 )
+from datalad.support.exceptions import IncompleteResultsError
 from datalad.support.keyring_ import MemoryKeyring
 from datalad.tests.utils_pytest import (
     assert_in,
@@ -102,10 +103,10 @@ def check_credentials_cli():
     with swallow_logs(new_level=logging.ERROR) as cml:
         # it is a shame that the error is not coming out on
         # stderr
-        run_main(['credentials', 'set'], exit_code=1)
+        run_main(['credentials', 'remove'], exit_code=1)
         cml.assert_logged('.*name must be provided')
     # catch missing `name` via Python call too
-    assert_raises(ValueError, cred, 'set', spec=[':mike'])
+    assert_raises(IncompleteResultsError, cred, 'set', spec=[':mike'])
     # no name and no property
     assert_raises(ValueError, cred, 'get')
 


### PR DESCRIPTION
This change enables users and commands to leave a credential name unspecified. If possible (interactive session), a user will be prompted for a name (until a unique name was entered), or "skip" was indicated.

If entering a credential name is not possible, a `ValueError` is raised.

`CredentialManager.set()` is enhanced with an additional `_context` argument that is included in a name prompt to provide context to a user what kind of credential is being saved. Calling commands typically have a better idea on that vs barfing a potentially complex credential with all properties in the terminal.

A new `_suggested_name` argument for `CredentialManager.set()` can be used by callers to suggest a default name. If the suggestion conflicts with an existing credential it is ignored.

Closes datalad/datalad-next#130