### PR TITLE
Consolidate `Dataset` import on `datalad_next.dataset`

### DIFF
--- a/datalad_next/constraints/base.py
+++ b/datalad_next/constraints/base.py
@@ -7,7 +7,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from datalad.distribution.dataset import Dataset
+    from datalad_next.dataset import Dataset
 
 ConstraintDerived = TypeVar('ConstraintDerived', bound='Constraint')
 DatasetDerived = TypeVar('DatasetDerived', bound='Dataset')

--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -20,10 +20,12 @@ from urllib.parse import (
     urlunparse,
 )
 
-from datalad.distribution.dataset import (
+from datalad_next.dataset import (
     Dataset,
-    EnsureDataset,
     datasetmethod,
+)
+from datalad.distribution.dataset import (
+    EnsureDataset,
     require_dataset,
 )
 from datalad.distribution.utils import _yield_ds_w_matching_siblings

--- a/datalad_next/credentials.py
+++ b/datalad_next/credentials.py
@@ -27,7 +27,6 @@ from datalad.interface.base import (
 from datalad.support.exceptions import CapturedException
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import (
-    datasetmethod,
     EnsureDataset,
     require_dataset,
 )
@@ -38,6 +37,7 @@ from datalad.interface.utils import (
     eval_results,
     generic_result_renderer,
 )
+from datalad_next.dataset import datasetmethod
 from datalad_next.constraints import (
     EnsureChoice,
     EnsureNone,

--- a/datalad_next/dataset.py
+++ b/datalad_next/dataset.py
@@ -1,0 +1,4 @@
+from datalad.distribution.dataset import (
+    Dataset,
+    datasetmethod,
+)

--- a/datalad_next/download.py
+++ b/datalad_next/download.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse
 
 import datalad
 from datalad.distribution.dataset import (
-    datasetmethod,
     resolve_path,
 )
 from datalad.interface.base import (
@@ -41,6 +40,7 @@ from datalad_next.constraints import (
 )
 from datalad_next.constraints.base import AltConstraints
 from datalad_next.constraints.dataset import EnsureDataset
+from datalad_next.dataset import datasetmethod
 from datalad_next.http_url_operations import HttpUrlOperations
 from datalad_next.file_url_operations import FileUrlOperations
 from datalad_next.ssh_url_operations import SshUrlOperations

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -23,9 +23,7 @@ from datalad.utils import (
     knows_annex,
     rmtree,
 )
-from datalad.distribution.dataset import (
-    Dataset,
-)
+from datalad_next.dataset import Dataset
 
 from .clone_utils import (
     _check_autoenable_special_remotes,

--- a/datalad_next/patches/clone_ephemeral.py
+++ b/datalad_next/patches/clone_ephemeral.py
@@ -4,7 +4,6 @@ __docformat__ = 'restructuredtext'
 
 import logging
 
-from datalad.distribution.dataset import Dataset
 from datalad.support.exceptions import CapturedException
 from datalad.support.gitrepo import GitRepo
 from datalad.support.network import RI
@@ -14,6 +13,7 @@ from datalad.utils import (
     rmtree,
 )
 
+from datalad_next.dataset import Dataset
 from datalad_next.patches import clone as mod_clone
 
 lgr = logging.getLogger('datalad.core.distributed.clone')

--- a/datalad_next/patches/clone_ria.py
+++ b/datalad_next/patches/clone_ria.py
@@ -10,7 +10,7 @@ from datalad.core.distributed.clone import (
     postclonecfg_ria,
 )
 
-from datalad.distribution.dataset import Dataset
+from datalad_next.dataset import Dataset
 
 from datalad_next.patches import clone as mod_clone
 

--- a/datalad_next/patches/clone_utils.py
+++ b/datalad_next/patches/clone_utils.py
@@ -17,7 +17,6 @@ from datalad.core.distributed.clone import (
     _map_urls,
     decode_source_spec,
 )
-from datalad.distribution.dataset import Dataset
 from datalad.dochelpers import single_or_plural
 from datalad.log import log_progress
 from datalad.support.annexrepo import AnnexRepo
@@ -33,6 +32,7 @@ from datalad.utils import (
     ensure_bool,
     rmtree,
 )
+from datalad_next.dataset import Dataset
 
 __docformat__ = 'restructuredtext'
 

--- a/datalad_next/patches/configuration.py
+++ b/datalad_next/patches/configuration.py
@@ -14,11 +14,7 @@ __docformat__ = 'restructuredtext'
 import logging
 
 from datalad import cfg as dlcfg
-from datalad.distribution.dataset import (
-    Dataset,
-    datasetmethod,
-    require_dataset,
-)
+from datalad.distribution.dataset import require_dataset
 from datalad.interface.base import (
     build_doc,
 )
@@ -40,6 +36,10 @@ from datalad.support.exceptions import (
 )
 from datalad.utils import (
     ensure_list,
+)
+from datalad_next.dataset import (
+    Dataset,
+    datasetmethod,
 )
 
 lgr = logging.getLogger('datalad.local.configuration')

--- a/datalad_next/patches/interface_utils.py
+++ b/datalad_next/patches/interface_utils.py
@@ -144,7 +144,7 @@ def _execute_command_(
     dataset_arg = allkwargs.get('dataset', None)
     ds = None
     if dataset_arg is not None:
-        from datalad.distribution.dataset import Dataset
+        from datalad_next.dataset import Dataset
         if isinstance(dataset_arg, Dataset):
             ds = dataset_arg
         else:

--- a/datalad_next/patches/push_optimize.py
+++ b/datalad_next/patches/push_optimize.py
@@ -3,13 +3,13 @@ import logging
 import re
 
 import datalad.core.distributed.push as mod_push
-from datalad.distribution.dataset import Dataset
 from datalad.log import log_progress
 from datalad.runner.exception import CommandError
 from datalad.support.annexrepo import AnnexRepo
 from datalad.utils import (
     ensure_list,
 )
+from datalad_next.dataset import Dataset
 
 
 lgr = logging.getLogger('datalad.core.distributed.push')

--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -10,13 +10,13 @@ from typing import (
 from unittest.mock import patch
 
 import datalad.core.distributed.push as push
-from datalad.distribution.dataset import Dataset
 from datalad.runner.exception import CommandError
 from datalad.support.annexrepo import AnnexRepo
 from datalad_next.constraints import EnsureChoice
 from datalad.support.exceptions import CapturedException
 from datalad.support.param import Parameter
 from datalad_next.credman import CredentialManager
+from datalad_next.dataset import Dataset
 from datalad_next.utils import (
     get_specialremote_credential_envpatch,
     get_specialremote_credential_properties,

--- a/datalad_next/patches/tests/test_push.py
+++ b/datalad_next/patches/tests/test_push.py
@@ -3,11 +3,12 @@ from datalad.tests.utils_pytest import (
     assert_result_count,
     with_tempfile,
 )
-from datalad.distribution.dataset import Dataset
 from datalad.core.distributed.clone import Clone
 
 # run all -core tests, because with _push() we patched a central piece
 from datalad.core.distributed.tests.test_push import *
+
+from datalad_next.dataset import Dataset
 
 
 # we override this specific test, because the original behavior is no longer

--- a/datalad_next/tests/test_create_sibling_webdav.py
+++ b/datalad_next/tests/test_create_sibling_webdav.py
@@ -22,9 +22,6 @@ from datalad.api import (
     clone,
     create_sibling_webdav,
 )
-from datalad.distribution.dataset import (
-    Dataset,
-)
 from datalad.tests.utils_pytest import (
     with_tempfile,
     with_tree
@@ -33,6 +30,7 @@ from datalad_next.tests.utils import (
     serve_path_via_webdav,
     with_credential,
 )
+from datalad_next.dataset import Dataset
 
 from ..create_sibling_webdav import _get_url_credential
 

--- a/datalad_next/tests/test_credman.py
+++ b/datalad_next/tests/test_credman.py
@@ -13,7 +13,6 @@ import pytest
 from unittest.mock import patch
 
 from datalad.config import ConfigManager
-from datalad.distribution.dataset import Dataset
 from ..credman import (
     CredentialManager,
     _get_cred_cfg_var,
@@ -28,6 +27,7 @@ from datalad.tests.utils_pytest import (
     with_tempfile,
     with_testsui,
 )
+from datalad_next.dataset import Dataset
 
 
 def test_credmanager():

--- a/datalad_next/tests/test_tree.py
+++ b/datalad_next/tests/test_tree.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from os import sep
 
 import pytest
-from datalad.distribution.dataset import Dataset
 from datalad.cli.tests.test_main import run_main
 from datalad.tests.test_utils_testrepos import BasicGitTestRepo
 from datalad.tests.utils_pytest import (
@@ -23,6 +22,8 @@ from datalad.utils import (
     chpwd
 )
 from datalad.ui import ui
+
+from datalad_next.dataset import Dataset
 
 from ..tree import (
     Tree,

--- a/datalad_next/tree.py
+++ b/datalad_next/tree.py
@@ -27,11 +27,7 @@ from datalad.support.exceptions import (
     NoDatasetFound
 )
 from datalad.support.param import Parameter
-from datalad.distribution.dataset import (
-    datasetmethod,
-    require_dataset,
-    Dataset,
-)
+from datalad.distribution.dataset import require_dataset
 from datalad.interface.results import (
     get_status_dict,
 )
@@ -46,6 +42,10 @@ from datalad_next.constraints import (
 )
 from datalad.utils import get_dataset_root
 from datalad.ui import ui
+from datalad_next.dataset import (
+    Dataset,
+    datasetmethod,
+)
 
 lgr = logging.getLogger('datalad.local.tree')
 


### PR DESCRIPTION
This is the start of migrating away from historical pieces in `datalad.distribution.dataset`, eventually making the entire module obsolete.

Ping https://github.com/datalad/datalad-next/issues/139