### PR TITLE
`UrlOperations` distinguish between connection-error and not-found

### DIFF
--- a/datalad_next/exceptions.py
+++ b/datalad_next/exceptions.py
@@ -4,8 +4,17 @@ from datalad.runner import CommandError
 from datalad.support.exceptions import (
     AccessDeniedError,
     AccessFailedError,
-    NoDatasetFound,
     CapturedException,
-    IncompleteResultsError,
     DownloadError,
+    IncompleteResultsError,
+    NoDatasetFound,
+    TargetFileAbsent,
 )
+
+# derive from TargetFileAbsent as the closest equivalent in datalad-core
+class UrlTargetNotFound(TargetFileAbsent):
+    """A connection request succeeded in principle, but target was not found
+
+    Equivalent of an HTTP404 response.
+    """
+    pass

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -29,6 +29,7 @@ from datalad.tests.utils_pytest import (
     rmtree,
     serve_path_via_http,
     skip_if_on_windows,
+    skip_ssh,
     skip_wo_symlink_capability,
     swallow_logs,
     with_tempfile,

--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -64,6 +64,11 @@ class UrlOperations:
           status code) as its `status` property.  Any underlying exception must
           be linked via the `__cause__` property (e.g. `raise
           AccessFailedError(...) from ...`).
+        UrlTargetNotFound
+          Implementations that can distinguish a general "connection error"
+          from an absent download target raise `AccessFailedError` for
+          connection errors, and `UrlTargetNotFound` for download targets
+          found absent after a conenction was established successfully.
         """
         raise NotImplementedError
 
@@ -111,6 +116,12 @@ class UrlOperations:
           a status code (e.g. HTTP status code) as its `status` property.
           Any underlying exception must be linked via the `__cause__`
           property (e.g. `raise DownloadError(...) from ...`).
+        AccessFailedError
+        UrlTargetNotFound
+          Implementations that can distinguish a general "connection error"
+          from an absent download target raise `AccessFailedError` for
+          connection errors, and `UrlTargetNotFound` for download targets
+          found absent after a conenction was established successfully.
         """
         raise NotImplementedError
 

--- a/datalad_next/url_operations/http.py
+++ b/datalad_next/url_operations/http.py
@@ -81,7 +81,7 @@ class HttpUrlOperations(UrlOperations):
                 if e.response.status_code == 404:
                     # special case reporting for a 404
                     raise UrlTargetNotFound(
-                        from_url, status=e.response.status_code) from e
+                        url, status=e.response.status_code) from e
                 else:
                     raise AccessFailedError(
                         msg=str(e), status=e.response.status_code) from e

--- a/datalad_next/url_operations/tests/test_any.py
+++ b/datalad_next/url_operations/tests/test_any.py
@@ -1,0 +1,39 @@
+import pytest
+from datalad_next.exceptions import (
+    AccessFailedError,
+    UrlTargetNotFound,
+)
+from ..any import AnyUrlOperations
+
+
+def test_any_url_operations(tmp_path):
+    test_path = tmp_path / 'myfile'
+    test_url = test_path.as_uri()
+    ops = AnyUrlOperations()
+    # no target file (yet), precise exception
+    with pytest.raises(UrlTargetNotFound):
+        ops.sniff(test_url)
+    # now put something at the target location
+    test_path.write_text('surprise!')
+    # and now it works
+    props = ops.sniff(test_url)
+    # we get the correct file size reported
+    assert props['content-length'] == test_path.stat().st_size
+
+    # and download
+    download_path = tmp_path / 'download'
+    props = ops.download(test_url, download_path, hash=['sha256'])
+    assert props['sha256'] == '71de4622cf536ed4aa9b65fc3701f4fc5a198ace2fa0bda234fd71924267f696'
+    assert props['content-length'] == 9 == test_path.stat().st_size
+
+    # remove source and try again
+    test_path.unlink()
+    with pytest.raises(UrlTargetNotFound):
+        ops.download(test_url, download_path)
+
+    # try some obscure URL scheme
+    with pytest.raises(ValueError):
+        ops.sniff('weird://stuff')
+
+    # and it could have been figured out before
+    assert ops.is_supported_url('weird://stuff') == False

--- a/datalad_next/url_operations/tests/test_file.py
+++ b/datalad_next/url_operations/tests/test_file.py
@@ -1,0 +1,32 @@
+import pytest
+from datalad_next.exceptions import (
+    AccessFailedError,
+    UrlTargetNotFound,
+)
+from ..file import FileUrlOperations
+
+
+def test_file_url_operations(tmp_path):
+    test_path = tmp_path / 'myfile'
+    test_url = test_path.as_uri()
+    ops = FileUrlOperations()
+    # no target file (yet), precise exception
+    with pytest.raises(UrlTargetNotFound):
+        ops.sniff(test_url)
+    # now put something at the target location
+    test_path.write_text('surprise!')
+    # and now it works
+    props = ops.sniff(test_url)
+    # we get the correct file size reported
+    assert props['content-length'] == test_path.stat().st_size
+
+    # and download
+    download_path = tmp_path / 'download'
+    props = ops.download(test_url, download_path, hash=['sha256'])
+    assert props['sha256'] == '71de4622cf536ed4aa9b65fc3701f4fc5a198ace2fa0bda234fd71924267f696'
+    assert props['content-length'] == 9 == test_path.stat().st_size
+
+    # remove source and try again
+    test_path.unlink()
+    with pytest.raises(UrlTargetNotFound):
+        ops.download(test_url, download_path)

--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import pytest
+from datalad_next.exceptions import (
+    AccessFailedError,
+    UrlTargetNotFound,
+)
+from datalad_next.tests.utils import with_credential
+from ..http import HttpUrlOperations
+
+
+hbsurl = 'https://httpbin.org'
+hbscred = (
+    'hbscred',
+    dict(user='mike', secret='dummy', type='user_password',
+         realm=f'{hbsurl}/Fake Realm'),
+)
+
+@with_credential(hbscred[0], **hbscred[1])
+def test_http_url_operations(tmp_path):
+    ops = HttpUrlOperations()
+    # authentication after redirect
+    target_url = f'{hbsurl}/basic-auth/mike/dummy'
+    props = ops.sniff(f'{hbsurl}/redirect-to?url={target_url}')
+    # we get the resolved URL after redirect back
+    assert props['url'] == target_url
+    # same again, but credentials are wrong
+    target_url = f'{hbsurl}/basic-auth/mike/WRONG'
+    with pytest.raises(AccessFailedError):
+        ops.sniff(f'{hbsurl}/redirect-to?url={target_url}')
+    # make sure we get the size info
+    assert ops.sniff(f'{hbsurl}/bytes/63')['content-length'] == 63
+
+    # download
+    # SFRUUEJJTiBpcyBhd2Vzb21l == 'HTTPBIN is awesome'
+    props = ops.download(f'{hbsurl}/base64/SFRUUEJJTiBpcyBhd2Vzb21l',
+                         tmp_path / 'mydownload',
+                         hash=['md5'])
+    assert (tmp_path / 'mydownload').read_text() == 'HTTPBIN is awesome'
+
+    # 404s
+    with pytest.raises(UrlTargetNotFound):
+        ops.sniff(f'{hbsurl}/status/404')
+    with pytest.raises(UrlTargetNotFound):
+        ops.download(f'{hbsurl}/status/404', tmp_path / 'dontmatter')

--- a/datalad_next/url_operations/tests/test_ssh.py
+++ b/datalad_next/url_operations/tests/test_ssh.py
@@ -1,0 +1,55 @@
+import pytest
+from datalad_next.exceptions import (
+    AccessFailedError,
+    UrlTargetNotFound,
+)
+from datalad_next.tests.utils import (
+    skip_ssh,
+    skip_if_on_windows,
+)
+from ..ssh import SshUrlOperations
+
+
+# path magic inside the test is posix only
+@skip_if_on_windows
+# SshUrlOperations does not work against a windows server
+# and the test uses 'localhost' as target
+@skip_ssh
+def test_ssh_url_operations(tmp_path, monkeypatch):
+    test_path = tmp_path / 'myfile'
+    test_url = f'ssh://localhost{test_path}'
+    ops = SshUrlOperations()
+    # no target file (yet), precise exception
+    with pytest.raises(UrlTargetNotFound):
+        ops.sniff(test_url)
+    # this is different for a general connection error
+    with pytest.raises(AccessFailedError):
+        ops.sniff(f'ssh://localhostnotaround{test_path}')
+    # now put something at the target location
+    test_path.write_text('surprise!')
+    # and now it works
+    props = ops.sniff(test_url)
+    # we get the correct file size reported
+    assert props['content-length'] == test_path.stat().st_size
+
+    # simulate a "protocol error" where the server-side command
+    # is not reporting the magic header
+    with monkeypatch.context() as m:
+        m.setattr(SshUrlOperations, '_stat_cmd', 'echo nothing')
+        # we get a distinct exception
+        with pytest.raises(RuntimeError):
+            ops.sniff(test_url)
+
+    # and download
+    download_path = tmp_path / 'download'
+    props = ops.download(test_url, download_path, hash=['sha256'])
+    assert props['sha256'] == '71de4622cf536ed4aa9b65fc3701f4fc5a198ace2fa0bda234fd71924267f696'
+    assert props['content-length'] == 9 == test_path.stat().st_size
+
+    # remove source and try again
+    test_path.unlink()
+    with pytest.raises(UrlTargetNotFound):
+        ops.download(test_url, download_path)
+    # this is different for a general connection error
+    with pytest.raises(AccessFailedError):
+        ops.download(f'ssh://localhostnotaround{test_path}', download_path)


### PR DESCRIPTION
When a URL works in principle, but points to something that is just not there (e.g. HTTP404) vs we cannot tell right now (HTTP5xx, or network down). This now raises `AccessFailedError` for a general error and `UrlTargetNotFound` for a 404-like error.

This is needed for a reliable operation of CHECKPRESENT in git-annex special remotes, and for meaningful error reporting in general.

This changeset also include dedicated unit tests for `UrlOperations`.

Closes #148
