### PR TITLE
'uncurl' special remote 

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -13,10 +13,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/datalad_next/annexremote/__init__.py
+++ b/datalad_next/annexremote/__init__.py
@@ -1,0 +1,14 @@
+# import all the pieces one would need for an implementation
+# in a single place
+from annexremote import UnsupportedRequest
+
+from datalad.customremotes import (
+    # this is an enhanced RemoteError that self-documents its cause
+    RemoteError,
+    SpecialRemote as _SpecialRemote,
+)
+from datalad.customremotes.main import main as super_main
+
+
+class SpecialRemote(_SpecialRemote):
+    pass

--- a/datalad_next/annexremote/tests/test_uncurl.py
+++ b/datalad_next/annexremote/tests/test_uncurl.py
@@ -1,0 +1,269 @@
+from pathlib import Path
+import pytest
+import re
+
+from datalad_next.tests.utils import (
+    with_tempfile,
+    with_tree,
+)
+from datalad_next.constraints.dataset import EnsureDataset
+from datalad_next.exceptions import IncompleteResultsError
+from datalad_next.url_operations.any import AnyUrlOperations
+
+from ..uncurl import (
+    UncurlRemote,
+    UnsupportedRequest,
+)
+
+
+# for some tests below it is important that this base config contains no
+# url= or match= declaration (or any other tailoring to a specific use case)
+std_initargs = [
+    'type=external',
+    'externaltype=uncurl',
+    'encryption=none',
+]
+
+res_kwargs = dict(
+    result_renderer='disabled',
+)
+
+class NoOpAnnex:
+    def error(*args, **kwargs):
+        pass
+
+    def info(*args, **kwargs):
+        pass
+
+    def debug(*args, **kwargs):
+        pass
+
+
+def test_uncurl_store(tmp_path):
+    # not yet
+    r = UncurlRemote(NoOpAnnex())
+    with pytest.raises(UnsupportedRequest):
+        r.transfer_store(None, None)
+
+
+def test_uncurl_remove(tmp_path):
+    # not yet
+    r = UncurlRemote(NoOpAnnex())
+    with pytest.raises(UnsupportedRequest):
+        r.remove(None)
+
+
+def test_uncurl_claimurl(tmp_path):
+    r = UncurlRemote(NoOpAnnex())
+    # if we have a match expression defined, this determines claim or noclaim
+    r.match = [re.compile('bongo.*')]
+    assert r.claimurl('bongo://joe')
+    assert not r.claimurl('http://example.com')
+    r.match = None
+    # without a match expression, the url handler decides
+    r.url_handler = AnyUrlOperations()
+    for url in ('http://example.com',
+                'https://example.com',
+                'ssh://example.com',
+                'file:///home/me'):
+        assert r.claimurl(url)
+    assert not r.claimurl('bongo://joe')
+
+
+def test_uncurl_checkurl(tmp_path):
+    exists_path = tmp_path / 'testfile'
+    exists_path.write_text('123')
+    exists_url = exists_path.as_uri()
+    no_exists_url = (tmp_path / 'notestfile').as_uri()
+    # checkurl is basically an 'exists?' test against a URL.
+    # the catch is that this test is not performed against the
+    # incoming URL, but against the mangled URL that is the result
+    # of instantiating the URL template based on all properties
+    # extractable from the URL alone (via any configured match
+    # expressions)
+    r = UncurlRemote(NoOpAnnex())
+    r.url_handler = AnyUrlOperations()
+    # no match and no template defined
+    assert not r.checkurl(no_exists_url)
+    assert r.checkurl(exists_url)
+    #
+    # now with rewriting
+    #
+    # MIH cannot think of a usecase where declaring a URL template
+    # would serve any purpose without also declaring a match expression
+    # here.
+    # outside the context of checkurl() this is different: It would
+    # make sense to declare a template that only uses standard key properties
+    # in order to define/declare upload targets for existing keys.
+    # consequently, checkurl() is ignoring a template-based rewriting
+    # when no match is defined, or when the matchers cannot extract all
+    # necessary identifiers from the incoming (single) URL in order to
+    # instantiate the URL template. In such cases, the original URL is
+    # used for checking
+    r.url_tmpl = '{absurd}'
+    assert not r.checkurl(no_exists_url)
+    assert r.checkurl(exists_url)
+
+    # now add a matcher to make use of URL rewriting even for 'addurl'-type
+    # use case, such as: we want to pass a "fixed" URL verbatim to some kind
+    # of external redirector service
+    r.url_tmpl = 'http://httpbin.org/redirect-to?url={origurl}'
+    r.match = [
+        re.compile('.*(?P<origurl>http://.*)$'),
+    ]
+    assert not r.checkurl('garbledhttp://httpbin.org/status/404')
+    assert r.checkurl('garbledhttp://httpbin.org/bytes/24')
+
+
+# sibling of `test_uncurl_checkurl()`, but more high-level
+def test_uncurl_addurl_unredirected(tmp_path):
+    ds = EnsureDataset()(tmp_path / 'ds').ds.create(**res_kwargs)
+    dsca = ds.repo.call_annex
+    # same set as in `test_uncurl_checkurl()`
+    dsca(['initremote', 'myuncurl'] + std_initargs + [
+        'match=.*(?P<origurl>http://.*)$',
+        'url=http://httpbin.org/redirect-to?url={origurl}',
+    ])
+    # feed it a broken URL, which must be getting fixed by the rewritting
+    # (pulls 24 bytes)
+    testurl = 'garbledhttp://httpbin.org/bytes/24'
+    dsca(['addurl', '--file=dummy', testurl])
+    # we got what we expected
+    assert ds.status(
+        'dummy', annex='basic', return_type='item-or-list', **res_kwargs
+        )['bytesize'] == 24
+    # make sure git-annex recorded an unmodified URL
+    assert any(testurl in r.get('urls', [])
+               for r in ds.repo.whereis('dummy', output='full').values())
+
+
+@with_tempfile
+@with_tree(tree={
+    'lvlA1': {'lvlB2_flavor1.tar': 'data_A1B2F1'},
+})
+def test_uncurl(wdir=None, archive_path=None):
+    archive_path = Path(archive_path)
+    ds = EnsureDataset()(wdir).ds.create(**res_kwargs)
+    dsca = ds.repo.call_annex
+    dsca(['initremote', 'myuncurl'] + std_initargs + [
+        'match=bingofile://(?P<basepath>.*)/(?P<lvlA>[^/]+)/(?P<lvlB>[^/]+)_(?P<flavor>.*)$ someothermatch',
+        'url=file://{basepath}/{lvlA}/{lvlB}_{flavor}',
+    ])
+    data_url = (archive_path / 'lvlA1' / 'lvlB2_flavor1.tar').as_uri()
+    # prefix the URL so git-annex has no idea how to handle it
+    # (same as migrating from an obsolete system with no support anymore)
+    data_url = f'bingo{data_url}'
+    dsca(['addurl', '--file', 'data_A1B2F1.dat', data_url])
+    assert (ds.pathobj / 'data_A1B2F1.dat').read_text() == 'data_A1B2F1'
+    # file is known to be here and a (uncurl) remote
+    assert len(ds.repo.whereis('data_A1B2F1.dat')) == 2
+    # must survive an fsck (CHECKPRESENT)
+    dsca(['fsck', '-q', '-f', 'myuncurl'])
+
+
+def test_uncurl_ria_access(tmp_path):
+    """
+    - create dataset with test file and push into RIA store
+    - create INDEPENDENT dataset and 'addurl' test file directly from RIA
+    - test that addurls work without any config, just initremote with no
+      custom settings
+    - now move RIA and hence break URL
+    - fix1: only using a URL template, point to dataset dir in RIA store
+      plus some always available key-properties
+    - alternative fix2: simpler template, plus match expression to
+      "understand" some structural aspects of RIA and reuse them
+    """
+    # we create a dataset to bootstrap the test setup, with on file
+    # of known content
+    srcds = EnsureDataset()(tmp_path / 'srcds').ds.create(**res_kwargs)
+    testfile_content = 'mikewashere!'
+    (srcds.pathobj / 'testfile.txt').write_text(testfile_content)
+    srcds.save(**res_kwargs)
+    # pull out some essential properties for the underlying key for later
+    # use in this test
+    testkey_props = srcds.status(
+        'testfile.txt', annex='basic', return_type='item-or-list', **res_kwargs)
+    testkey_props = {
+        k: v for k, v in testkey_props.items()
+        if k in ('key', 'hashdirmixed', 'hashdirlower')
+    }
+
+    # establish a RIA sibling and push
+    baseurl = (tmp_path / "ria").as_uri()
+    srcds.create_sibling_ria(
+        # use a ria+file:// URL for simplicity
+        f'ria+{baseurl}',
+        name='ria',
+        new_store_ok=True,
+        **res_kwargs
+    )
+    srcds.push(to='ria', **res_kwargs)
+    # setup is done
+
+    # start of the actual test
+    # create a fresh dataset
+    ds = EnsureDataset()(tmp_path / 'testds').ds.create(**res_kwargs)
+    dsca = ds.repo.call_annex
+    # we add uncurl WITH NO config whatsoever.
+    # this must be enough to be able to use the built-in downloaders
+    target_fname = 'mydownload.txt'
+    dsca(['initremote', 'myuncurl'] + std_initargs)
+    dsca(['addurl', '--file', target_fname,
+          # we download from the verbatim, hand-crafted URL
+          f'{baseurl}/{srcds.id[:3]}/{srcds.id[3:]}/annex/objects/'
+          f'{testkey_props["hashdirmixed"]}'
+          f'{testkey_props["key"]}/{testkey_props["key"]}'
+    ])
+    assert (ds.pathobj / target_fname).read_text() == testfile_content
+    # make sure the re-downloaded key ends up having the same keyname in
+    # the new dataset
+    assert ds.status(
+        target_fname, annex='basic', return_type='item-or-list',
+        **res_kwargs)['key'] == testkey_props['key']
+
+    # now we drop the key...
+    ds.drop(target_fname, **res_kwargs)
+    assert not (ds.pathobj / target_fname).exists()
+    # ...and we move the RIA store to break the recorded
+    # URL (simulating an infrastructure change)
+    (tmp_path / 'ria').rename(tmp_path / 'ria_moved')
+
+    # verify that no residual magic makes data access possible
+    with pytest.raises(IncompleteResultsError):
+        ds.get(target_fname, **res_kwargs)
+
+    # fix it via an access URL config,
+    # point directly via a hard-coded dataset ID
+    # NOTE: last line is no f-string!
+    url_tmpl = f'{(tmp_path / "ria_moved").as_uri()}/{srcds.id[:3]}/{srcds.id[3:]}' \
+        + '/annex/objects/{annex_dirhash}/{annex_key}/{annex_key}'
+    ds.configuration(
+        'set', f'remote.myuncurl.uncurl-url={url_tmpl}', **res_kwargs)
+    # confirm checkpresent acknowledges this
+    dsca(['fsck', '-q', '-f', 'myuncurl'])
+    # confirm transfer_retrieve acknowledges this
+    ds.get(target_fname, **res_kwargs)
+
+    # but we can also do without hard-coding anything, so let's drop again
+    ds.drop(target_fname, **res_kwargs)
+    assert not (ds.pathobj / target_fname).exists()
+
+    # for that we need to add a match expression that can "understand"
+    # the original URL. All we need is to distinguish the old base path
+    # from the structured components in the RIA store (for the
+    # latter we can simple account for 4 levels of sudirs
+    ds.configuration(
+        'set',
+        'remote.myuncurl.uncurl-match='
+        'file://(?P<basepath>.*)/(?P<dsdir>[^/]+/[^/]+)/annex/objects/.*$',
+        **res_kwargs)
+    # NOTE: last line is no f-string!
+    url_tmpl = f'{(tmp_path / "ria_moved").as_uri()}' \
+        + '/{dsdir}/annex/objects/{annex_dirhash}/{annex_key}/{annex_key}'
+    ds.configuration(
+        'set', f'remote.myuncurl.uncurl-url={url_tmpl}', **res_kwargs)
+    # confirm checkpresent acknowledges this
+    dsca(['fsck', '-q', '-f', 'myuncurl'])
+    # confirm transfer_retrieve acknowledges this
+    ds.get(target_fname, **res_kwargs)
+    assert (ds.pathobj / target_fname).read_text() == testfile_content

--- a/datalad_next/annexremote/tests/test_uncurl.py
+++ b/datalad_next/annexremote/tests/test_uncurl.py
@@ -241,8 +241,9 @@ def test_uncurl_ria_access(tmp_path):
     # fix it via an access URL config,
     # point directly via a hard-coded dataset ID
     # NOTE: last line is no f-string!
-    url_tmpl = f'{(tmp_path / "ria_moved").as_uri()}/{srcds.id[:3]}/{srcds.id[3:]}' \
-        + '/annex/objects/{annex_dirhash}/{annex_key}/{annex_key}'
+    url_tmpl = (
+        tmp_path / "ria_moved" / srcds.id[:3] / srcds.id[3:]
+        ).as_uri() + '/annex/objects/{annex_dirhash}/{annex_key}/{annex_key}'
     ds.configuration(
         'set', f'remote.myuncurl.uncurl-url={url_tmpl}', **res_kwargs)
     # confirm checkpresent acknowledges this
@@ -266,7 +267,7 @@ def test_uncurl_ria_access(tmp_path):
         'file://(?P<basepath>.*)/(?P<dsdir>[^/]+/[^/]+)/annex/objects/.*$',
         **res_kwargs)
     # NOTE: last line is no f-string!
-    url_tmpl = f'{(tmp_path / "ria_moved").as_uri()}' \
+    url_tmpl = (tmp_path / "ria_moved").as_uri() \
         + '/{dsdir}/annex/objects/{annex_dirhash}/{annex_key}/{annex_key}'
     ds.configuration(
         'set', f'remote.myuncurl.uncurl-url={url_tmpl}', **res_kwargs)

--- a/datalad_next/annexremote/tests/test_uncurl.py
+++ b/datalad_next/annexremote/tests/test_uncurl.py
@@ -3,6 +3,7 @@ import pytest
 import re
 
 from datalad_next.tests.utils import (
+    skip_if_on_windows,
     with_tempfile,
     with_tree,
 )
@@ -161,6 +162,9 @@ def test_uncurl(wdir=None, archive_path=None):
     dsca(['fsck', '-q', '-f', 'myuncurl'])
 
 
+# RIA tooling is not working for this test on windows
+# https://github.com/datalad/datalad/issues/7212
+@skip_if_on_windows
 def test_uncurl_ria_access(tmp_path):
     """
     - create dataset with test file and push into RIA store
@@ -223,7 +227,9 @@ def test_uncurl_ria_access(tmp_path):
 
     # now we drop the key...
     ds.drop(target_fname, **res_kwargs)
-    assert not (ds.pathobj / target_fname).exists()
+    assert not ds.status(
+        target_fname, annex='availability', return_type='item-or-list',
+        **res_kwargs)['has_content']
     # ...and we move the RIA store to break the recorded
     # URL (simulating an infrastructure change)
     (tmp_path / 'ria').rename(tmp_path / 'ria_moved')
@@ -246,7 +252,9 @@ def test_uncurl_ria_access(tmp_path):
 
     # but we can also do without hard-coding anything, so let's drop again
     ds.drop(target_fname, **res_kwargs)
-    assert not (ds.pathobj / target_fname).exists()
+    assert not ds.status(
+        target_fname, annex='availability', return_type='item-or-list',
+        **res_kwargs)['has_content']
 
     # for that we need to add a match expression that can "understand"
     # the original URL. All we need is to distinguish the old base path

--- a/datalad_next/annexremote/uncurl.py
+++ b/datalad_next/annexremote/uncurl.py
@@ -15,6 +15,11 @@ operations framework. It serves two main purposes:
    (e.g. moving to a different technical system or a different data
    organization on a storage system).
 
+Requirements
+------------
+
+This special remote implementation requires git-annex version 8.20210127 (or
+later) to be available.
 
 Download helper with credential management support
 --------------------------------------------------
@@ -56,6 +61,13 @@ use after having used them successfully::
 By adding files via downloads from URLs in this fashion, datasets can be built
 that track information across a range of locations/services, using a possibly
 heterogeneous set of access methods.
+
+This feature is very similar to the ``datalad`` special remote implementation
+included in the core DataLad package. The difference here is that alternative
+implementations of downloaders are employed and the ``datalad-next`` credential
+system is used instead of the "providers" mechanism from DataLad's core
+package.
+
 
 Transforming recorded URLs
 --------------------------

--- a/datalad_next/annexremote/uncurl.py
+++ b/datalad_next/annexremote/uncurl.py
@@ -1,0 +1,349 @@
+"""
+Goals
+
+- Keep deposited data accessible without having to update (also deposited)
+  datalad datasets
+
+Identifiers can only come from URLs.
+
+Q: are the standard identifiers (dsid, annex uuid) any good? They would never work
+in a template with checkurl(). But they would work, when uploading existing keys.
+
+Setup
+
+It is enough to simply enable the remote in a dataset. But this is a special case
+similar to what the `datalad` special remote is doing. It can be used to
+employ this special remote as a download helper with datalad protocol and
+credential support.
+
+However, typically one would want to define a `match` expression to limit the
+handling of URL to a particular host, or data structures on one or more hosts.
+
+When different access methods are required to read from vs write to the same
+location, as second uncurl remote with sameas= must be configured.
+
+Configuration
+
+- `remote.<remotename>.uncurl-url`
+- `remote.<remotename>.uncurl-match`
+
+Built-in URL components
+
+- `datalad_dsid` - the DataLad dataset ID (UUID)
+- `annex_dirhash` - "mixed" variant of the two level hash for a particular key
+  (uses POSIX directory separators, and included a trailing separator)
+- `annex_dirhash_lower` - "lower case" variant of the two level hash for a
+  particular key (uses POSIX directory separators, and included a trailing
+  separator)
+- `annex_key` - git-annex key name for a request
+- `annex_remoteuuid` - UUID of the special remote (location) used by git-annex
+- `git_remotename` - Name of the Git remote for the uncurl special remote
+
+Additional components can be defined by configuring `match` expression
+configurations that are evaluated on each recorded URL for any given git-annex
+key. It is recommended that each `match` expression uses unique match group
+identifiers to avoid value conflicts.
+
+https://docs.python.org/3/library/string.html#format-string-syntax
+"""
+
+from functools import partial
+import json
+from pathlib import Path
+import re
+from urllib.parse import urlparse
+
+# we intentionally limit ourselves to the most basic interface
+# and even that we only need to get a `ConfigManager` instance.
+# If that class would support a plain path argument, we could
+# avoid it entirely
+from datalad.dataset.gitrepo import GitRepo
+
+from datalad_next.exceptions import (
+    CapturedException,
+    DownloadError,
+)
+from datalad_next.url_operations.any import AnyUrlOperations
+from datalad_next.utils import ensure_list
+
+from . import (
+    RemoteError,
+    SpecialRemote,
+    UnsupportedRequest,
+    super_main
+)
+
+
+
+class UncurlRemote(SpecialRemote):
+    """ """
+    def __init__(self, annex):
+        super().__init__(annex)
+        self.configs.update(
+            url='Python format language template composing an access URL',
+            match='(whitespace-separated list of) regular expression(s) to match particular components in supported URL via named groups',
+        )
+        self.repo = None
+        self.url_tmpl = None
+        self.match = None
+        self.url_handler = None
+        # cache of properties that do not vary within a session
+        # or across annex keys
+        self.persistent_tmpl_props = {}
+
+    def initremote(self):
+        # at present there is nothing that needs to be done on init/enable.
+        # the remote is designed to work without any specific setup too
+        pass
+
+    def prepare(self):
+        # we need the git remote name to be able to look up config about
+        # that remote
+        remotename = self.annex.getgitremotename()
+        # get the repo to gain access to its config
+        self.repo = GitRepo(self.annex.getgitdir())
+        # check the config for a URL template setting
+        self.url_tmpl = self.repo.cfg.get(
+            f'remote.{remotename}.uncurl-url', '')
+        # only if we have no local, overriding, configuration ask git-annex
+        # for the committed special remote config on the URL template
+        if not self.url_tmpl:
+            # ask for the commit config, could still be empty
+            self.url_tmpl = self.annex.getconfig('url')
+            # TODO test the case of a fully absent URL template
+            # that would be fine and only verbatim recorded URLs could
+            # be sent to a downloader
+
+        # unconditionally ask git-annex for a match-url setting, any local
+        # config ammends, and does not override
+        self.match = self.annex.getconfig('match')
+        if self.match:
+            self.match = self.match.split()
+            # TODO implement sanity checks, but running it through re.compile()
+            # might just be enough
+            self.match = [re.compile(m) for m in self.match]
+        # extend with additonal matchers from local config
+        self.match = (self.match or []) + [
+            re.compile(m)
+            for m in ensure_list(self.repo.cfg.get(
+                f'remote.{remotename}.uncurl-match', [], get_all=True))
+        ]
+
+        self.message(
+            f'URL rewriting template: {self.url_tmpl!r}', type='debug')
+        self.message(
+            f'Active URL match expressions: {[e.pattern for e in self.match]!r}',
+            type='debug')
+
+        # let the URL hander use the repo's config
+        self.url_handler = AnyUrlOperations(cfg=self.repo.cfg)
+
+        # cache template properties
+        # using function arg name syntax, we need the identifiers to be valid
+        # Python symbols to work in `format()`
+        self.persistent_tmpl_props.update(
+            datalad_dsid=self.repo.cfg.get('datalad.dataset.id', ''),
+            git_remotename=remotename,
+            annex_remoteuuid=self.annex.getuuid(),
+        )
+
+
+    def claimurl(self, url):
+        """Needs to check if want to handle a given URL
+
+        If match expressions are configured, matches the URL against all known
+        URL expressions, and returns `True` if there is any match, or
+        `False` otherwise.
+
+        If no match expressions are configured, return `True` of the URL
+        scheme is supported, or `False` otherwise.
+        """
+        if self.match:
+            return self.is_recognized_url(url)
+        else:
+            return self.url_handler.is_supported_url(url)
+
+    def checkurl(self, url):
+        """
+        When running `git-annex addurl`, this is called after CLAIMURL
+        indicated that we could handle a URL. It can return information
+        on the URL target (e.g., size of the download, a target filename,
+        or a sequence thereof with additional URLs pointing to individual
+        components that would jointly make up the full download from the
+        given URL. However, all of that is optional, and a simple `True`
+        returned is sufficient to make git-annex call `TRANSFER RETRIEVE`.
+        """
+        # try-except, because a URL template might need something
+        # that cannot be extracted from this very URL.
+        # we cannot consult a key that may already point to the same
+        # content as the URL, and may have other information --
+        # we simply dont have it at this point
+        try:
+            url = self.get_mangled_url(
+                url,
+                self.url_tmpl,
+                self.extract_tmpl_props(
+                    tmpl=self.url_tmpl,
+                    urls=[url],
+                ),
+            )
+        except KeyError as e:
+            self.message(
+                'URL rewriting template requires unavailable component '
+                f'{e}, continuing with original URL',
+                type='debug',
+            )
+            # otherwise go ahead with the orginal URL. the template might
+            # just be here to aid structured uploads
+        try:
+            urlprops = self.url_handler.sniff(url)
+            return True
+        except DownloadError as e:
+            # TODO untested and subject to change due to
+            # https://github.com/datalad/datalad-next/issues/154
+            # leave a trace in the logs
+            CapturedException(e)
+            return False
+        # we could return a URL/size/filename triple instead of a bool.
+        # this would make git annex download from a URL different from the input,
+        # and to the given filename.
+        # it could be nice to report the (mangled) url, even if the handler reports
+        # a potentially deviating URL (redirects, etc.). Keeping external
+        # resolvers in the loop can be intentional, and users could provide
+        # resolved URL if they consider that desirable.
+        # however, going with the original URL kinda does that already, rewriting
+        # is happening anyways. And not reporting triplets avoids the issue
+        # of git-annex insisting to write into a dedicated directory for this
+        # download.
+
+    def transfer_retrieve(self, key, filename):
+        self._check_retrieve(
+            key,
+            partial(self.url_handler.download, to_path=Path(filename)),
+            ('download', 'from'),
+        )
+
+    def checkpresent(self, key):
+        return self._check_retrieve(
+            key,
+            self.url_handler.sniff,
+            ('find', 'at'),
+        )
+
+    #
+    # unsupported (yet)
+    #
+    def transfer_store(self, key, filename):
+        raise UnsupportedRequest('"uncurl" remote cannot store content')
+
+    def remove(self, key):
+        raise UnsupportedRequest('"uncurl" remote cannot remove content')
+
+    #
+    # helpers
+    #
+    def is_recognized_url(self, url):
+        return any(m.match(url) for m in self.match or [])
+
+    def get_key_urls(self, key) -> list[str]:
+        # ask git-annex for the URLs it has on record for the key.
+        # this will also work within checkurl() for a temporary key
+        # generated by git-annex after claimurl()
+        urls = self.annex.geturls(key, prefix='')
+        self.message(f"Known urls for {key!r}: {urls}", type='debug')
+        if self.url_tmpl:
+            # we have a rewriting template. extract all properties
+            # from all known URLs and instantiate the template
+            # to get the ONE desired URL
+            props = self.extract_tmpl_props(
+                tmpl=self.url_tmpl,
+                urls=urls,
+                key=key,
+            )
+            url = self.get_mangled_url(
+                fallback_url=None,
+                tmpl=self.url_tmpl,
+                tmpl_props=props,
+            )
+            return [url]
+        # we have no rewriting template, and must return all URLs we know
+        # to let the caller sort it out
+        return urls
+
+    def get_mangled_url(self, fallback_url, tmpl, tmpl_props):
+        if not tmpl:
+            # the best thing we can do without a URL template is to
+            # return the URL itself
+            return fallback_url
+        url = tmpl.format(**tmpl_props)
+        return url
+
+    def extract_tmpl_props(self, tmpl, *, urls=None, key=None):
+        # look up all the standard
+        allprops = dict(self.persistent_tmpl_props)
+        if key:
+            allprops['annex_key'] = key
+            # if we are working on a specific key, check the template if it
+            # needs more key-specific properties. The conditionals below
+            # are intentionally unprecise to avoid false-negatives given the
+            # flexibility of the format-string-syntax
+            if 'annex_dirhash' in tmpl:
+                allprops['annex_dirhash'] = self.annex.dirhash(key)
+            if 'annex_dirhash_lower' in tmpl:
+                allprops['annex_dirhash_lower'] = self.annex.dirhash_lower(key)
+        # try all URLs against all matchers
+        for url in ensure_list(urls):
+            for matcher in (self.match or []):
+                match = matcher.match(url)
+                if not match:
+                    # ignore any non-match
+                    continue
+                # we only support named groups in expressions so this is sufficient
+                props = match.groupdict()
+                if any(p in allprops and allprops[p] != props[p] for p in props):
+                    self.message(
+                        'Partial URL property shadowing detected. '
+                        'Avoid by using unique expression match group names.',
+                        type='debug'
+                    )
+                allprops.update(props)
+        return allprops
+
+    def _check_retrieve(self, key, handler, action: tuple):
+        urls = self.get_key_urls(key)
+        # depending on the configuration (rewriting template or not)
+        # we could have one or more URLs to try
+        for url in urls:
+            try:
+                handler(url)
+                # we succeeded, no need to try again
+                return True
+            except DownloadError as e:
+                # TODO subject to change due to
+                # https://github.com/datalad/datalad-next/issues/154
+                # TODO return False if we can be sure that the remote
+                # system works properly and just the key is not around
+                ce = CapturedException(e)
+                self.message(
+                    f'Failed to {action[0]} key {key!r} {action[1]} {url!r}',
+                    type='debug')
+        raise RemoteError(
+            f'Failed to {action[0]} {key!r} {action[1]} any of {urls!r}')
+
+
+_sniff2checkurl_map = {
+    'content-length': 'size',
+}
+"""Translate property names returned by AnyUrlOperations.sniff()
+to those expected from checkurl()"""
+
+
+def main():
+    """cmdline entry point"""
+    super_main(
+        cls=UncurlRemote,
+        remote_name='uncurl',
+        description=\
+        "flexible access data (in archive systems) "
+        "via a variety of identification schemes",
+    )

--- a/datalad_next/annexremote/uncurl.py
+++ b/datalad_next/annexremote/uncurl.py
@@ -166,6 +166,7 @@ Tips
 When multiple match expressions are defined, it is recommended to use unique
 names for each match-group to avoid collisions.
 """
+from __future__ import annotations
 
 from functools import partial
 import json

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,6 +79,16 @@ Git-annex backends
    xdlra
 
 
+Git-annex special remotes
+-------------------------
+
+.. currentmodule:: datalad_next.annexremote
+.. autosummary::
+   :toctree: generated
+
+   uncurl
+
+
 Indices and tables
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ datalad.extensions =
 console_scripts =
     git-annex-backend-XDLRA = datalad_next.backend.xdlra:main
     git-remote-datalad-annex = datalad_next.gitremote.datalad_annex:main
+    git-annex-remote-uncurl = datalad_next.annexremote.uncurl:main
 
 [versioneer]
 # See the docstring in versioneer.py for instructions. Note that you must


### PR DESCRIPTION
TODO

- [x] complete documentation
- [ ] allow additional identifiers to come from configuration. Recorded in https://github.com/datalad/datalad-next/issues/157 (not to be aimed for here)