### PR TITLE
Add command error and timeout handling to ssh upload 

### DIFF
--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -45,7 +45,11 @@ class UrlOperations:
             self._cfg = datalad.cfg
         return self._cfg
 
-    def sniff(self, url: str, *, credential: str = None) -> Dict:
+    def sniff(self,
+              url: str,
+              *,
+              credential: str | None = None,
+              timeout: float | None = None) -> Dict:
         """Gather information on a URL target, without downloading it
 
         Returns
@@ -68,7 +72,10 @@ class UrlOperations:
           Implementations that can distinguish a general "connection error"
           from an absent download target raise `AccessFailedError` for
           connection errors, and `UrlTargetNotFound` for download targets
-          found absent after a conenction was established successfully.
+          found absent after a connection was established successfully.
+        TimeoutError
+          If `timeout` is given and the operation does not complete within the
+          number of seconds that a specified by `timeout`.
         """
         raise NotImplementedError
 
@@ -76,8 +83,9 @@ class UrlOperations:
                  from_url: str,
                  to_path: Path | None,
                  *,
-                 credential: str = None,
-                 hash: list[str] = None) -> Dict:
+                 credential: str | None = None,
+                 hash: list[str] | None = None,
+                 timeout: float | None = None) -> Dict:
         """Download from a URL to a local file or stream to stdout
 
         Parameters
@@ -99,6 +107,10 @@ class UrlOperations:
           `hashlib` module. A corresponding hash will be computed simultaenous
           to the download (without reading the data twice), and included
           in the return value.
+        timeout: float, optional
+          If given, specifies a timeout in seconds. If the operation is not
+          completed within this time, it will raise a `TimeoutError`-exception.
+          If timeout is None, the operation will never timeout.
 
         Returns
         -------
@@ -122,6 +134,9 @@ class UrlOperations:
           from an absent download target raise `AccessFailedError` for
           connection errors, and `UrlTargetNotFound` for download targets
           found absent after a conenction was established successfully.
+        TimeoutError
+          If `timeout` is given and the operation does not complete within the
+          number of seconds that a specified by `timeout`.
         """
         raise NotImplementedError
 
@@ -129,8 +144,9 @@ class UrlOperations:
                from_path: Path | None,
                to_url: str,
                *,
-               credential: str = None,
-               hash: list[str] = None) -> Dict:
+               credential: str | None = None,
+               hash: list[str] | None = None,
+               timeout: float | None = None) -> Dict:
         """Upload from a local file or stream to a URL
 
         Parameters
@@ -153,6 +169,10 @@ class UrlOperations:
           `hashlib` module. A corresponding hash will be computed simultaenous
           to the upload (without reading the data twice), and included
           in the return value.
+        timeout: float, optional
+          If given, specifies a timeout in seconds. If the operation is not
+          completed within this time, it will raise a `TimeoutError`-exception.
+          If timeout is None, the operation will never timeout.
 
         Returns
         -------
@@ -166,6 +186,9 @@ class UrlOperations:
         ------
         FileNotFoundError
           If the source file cannot be found.
+        TimeoutError
+          If `timeout` is given and the operation does not complete within the
+          number of seconds that a specified by `timeout`.
         """
         raise NotImplementedError
 
@@ -201,7 +224,7 @@ class UrlOperations:
             noninteractive_level=logging.DEBUG,
         )
 
-    def _get_hasher(self, hash: list[str]) -> list:
+    def _get_hasher(self, hash: list[str] | None) -> list:
         if not hash:
             return []
 
@@ -216,7 +239,9 @@ class UrlOperations:
             _hasher.append(hr())
         return _hasher
 
-    def _get_hash_report(self, hash_names: list[str], hashers: list) -> Dict:
+    def _get_hash_report(self,
+                         hash_names: list[str] | None,
+                         hashers: list) -> Dict:
         if not hash_names:
             return {}
         else:

--- a/datalad_next/url_operations/any.py
+++ b/datalad_next/url_operations/any.py
@@ -75,7 +75,11 @@ class AnyUrlOperations(UrlOperations):
         scheme = self._get_url_scheme(url)
         return scheme in _urlscheme_handlers.keys()
 
-    def sniff(self, url: str, *, credential: str = None) -> Dict:
+    def sniff(self,
+              url: str,
+              *,
+              credential: str | None = None,
+              timeout: float | None = None) -> Dict:
         """Call `*UrlOperations.sniff()` for the respective URL scheme"""
         return self._get_handler(url).sniff(url, credential=credential)
 
@@ -83,8 +87,9 @@ class AnyUrlOperations(UrlOperations):
                  from_url: str,
                  to_path: Path | None,
                  *,
-                 credential: str = None,
-                 hash: str = None) -> Dict:
+                 credential: str | None = None,
+                 hash: list[str] | None = None,
+                 timeout: float | None = None) -> Dict:
         """Call `*UrlOperations.download()` for the respective URL scheme"""
         return self._get_handler(from_url).download(
             from_url, to_path, credential=credential, hash=hash)

--- a/datalad_next/url_operations/file.py
+++ b/datalad_next/url_operations/file.py
@@ -36,7 +36,11 @@ class FileUrlOperations(UrlOperations):
         path = request.url2pathname(parsed.path)
         return Path(path)
 
-    def sniff(self, url: str, *, credential: str = None) -> Dict:
+    def sniff(self,
+              url: str,
+              *,
+              credential: str | None = None,
+              timeout: float | None = None) -> Dict:
         """Gather information on a URL target, without downloading it
 
         See :meth:`datalad_next.url_operations.UrlOperations.sniff`
@@ -53,7 +57,7 @@ class FileUrlOperations(UrlOperations):
             if not k.startswith('_')
         }
 
-    def _sniff(self, url: str, credential: str = None) -> Dict:
+    def _sniff(self, url: str, credential: str | None = None) -> Dict:
         # turn url into a native path
         from_path = self._file_url_to_path(url)
         # if anything went wrong with the conversion, or we lack
@@ -74,8 +78,9 @@ class FileUrlOperations(UrlOperations):
                  # unused, but theoretically could be used to
                  # obtain escalated/different privileges on a system
                  # to gain file access
-                 credential: str = None,
-                 hash: str = None) -> Dict:
+                 credential: str | None = None,
+                 hash: list[str] | None = None,
+                 timeout: float | None = None) -> Dict:
         """Copy a file:// URL target to a local path
 
         See :meth:`datalad_next.url_operations.UrlOperations.download`
@@ -118,8 +123,9 @@ class FileUrlOperations(UrlOperations):
                from_path: Path | None,
                to_url: str,
                *,
-               credential: str = None,
-               hash: list[str] = None) -> Dict:
+               credential: str | None = None,
+               hash: list[str] | None = None,
+               timeout: float | None = None) -> Dict:
         """Copy a local file to a file:// URL target
 
         Any missing parent directories of the URL target are created as

--- a/datalad_next/url_operations/http.py
+++ b/datalad_next/url_operations/http.py
@@ -41,14 +41,18 @@ class HttpUrlOperations(UrlOperations):
         'user-agent': user_agent('datalad', datalad.__version__),
     }
 
-    def get_headers(self, headers: Dict = None) -> Dict:
+    def get_headers(self, headers: Dict | None = None) -> Dict:
         # start with the default
         hdrs = dict(HttpUrlOperations._headers)
         if headers is not None:
             hdrs.update(headers)
         return hdrs
 
-    def sniff(self, url: str, *, credential: str = None) -> Dict:
+    def sniff(self,
+              url: str,
+              *,
+              credential: str | None = None,
+              timeout: float | None = None) -> Dict:
         """Gather information on a URL target, without downloading it
 
         See :meth:`datalad_next.url_operations.UrlOperations.sniff`
@@ -110,8 +114,9 @@ class HttpUrlOperations(UrlOperations):
                  from_url: str,
                  to_path: Path | None,
                  *,
-                 credential: str = None,
-                 hash: str = None) -> Dict:
+                 credential: str | None = None,
+                 hash: list[str] | None = None,
+                 timeout: float | None = None) -> Dict:
         """Download via HTTP GET request
 
         See :meth:`datalad_next.url_operations.UrlOperations.download`
@@ -226,7 +231,7 @@ class HttpUrlOperations(UrlOperations):
         return req.url, props
 
     def _stream_download_from_request(
-            self, r, to_path, hash: list[str] = None) -> Dict:
+            self, r, to_path, hash: list[str] | None = None) -> Dict:
         from_url = r.url
         hasher = self._get_hasher(hash)
         progress_id = self._get_progress_id(from_url, to_path)

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -62,7 +62,11 @@ class SshUrlOperations(UrlOperations):
                 "|| exit 244"
     _cat_cmd = "cat '{fpath}'"
 
-    def sniff(self, url: str, *, credential: str = None) -> Dict:
+    def sniff(self,
+              url: str,
+              *,
+              credential: str | None = None,
+              timeout: float | None = None) -> Dict:
         """Gather information on a URL target, without downloading it
 
         See :meth:`datalad_next.url_operations.UrlOperations.sniff`
@@ -141,8 +145,9 @@ class SshUrlOperations(UrlOperations):
                  # unused, but theoretically could be used to
                  # obtain escalated/different privileges on a system
                  # to gain file access
-                 credential: str = None,
-                 hash: str = None) -> Dict:
+                 credential: str | None = None,
+                 hash: str | None = None,
+                 timeout: float | None = None) -> Dict:
         """Download a file by streaming it through an SSH connection.
 
         On the server-side, the file size is determined and sent. Afterwards
@@ -211,8 +216,9 @@ class SshUrlOperations(UrlOperations):
                from_path: Path | None,
                to_url: str,
                *,
-               credential: str = None,
-               hash: list[str] = None) -> Dict:
+               credential: str | None = None,
+               hash: list[str] | None = None,
+               timeout: float | None = None) -> Dict:
         """Upload a file by streaming it through an SSH connection.
 
         It, more or less, runs `ssh <host> 'cat > <path>'.
@@ -313,8 +319,7 @@ class _SshCat:
             payload_cmd: str,
             protocol: type[WitlessProtocol],
             stdin: Queue | None = None,
-            timeout: float | None = None,
-            ) -> Any | Generator:
+            timeout: float | None = None) -> Any | Generator:
         fpath = self._parsed.path
         cmd = ['ssh']
         cmd.extend(self.ssh_args)

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -325,10 +325,6 @@ class _NoCaptureGeneratorProtocol(NoCapture, GeneratorMixIn):
         NoCapture.__init__(self, done_future, encoding)
         GeneratorMixIn.__init__(self, )
 
-    def pipe_data_received(self, fd: int, data: bytes):
-        assert fd == 1
-        self.send_result(data)
-
 
 class _StdOutCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
     def __init__(self, done_future=None, encoding=None):

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -230,6 +230,13 @@ class SshUrlOperations(UrlOperations):
         ------
         ...
         """
+
+        if from_path is None:
+            raise ValueError(
+                "SshUrlOperations.upload() does not yet support "
+                "uploading from stdin"
+            )
+
         # die right away, if we lack read permissions or there is no file
         expected_size = from_path.stat().st_size
 

--- a/datalad_next/url_operations/tests/test_ssh.py
+++ b/datalad_next/url_operations/tests/test_ssh.py
@@ -1,4 +1,5 @@
 import pytest
+
 from datalad_next.exceptions import (
     AccessFailedError,
     UrlTargetNotFound,
@@ -73,7 +74,9 @@ def test_ssh_url_upload(tmp_path, monkeypatch):
 
     payload_path.write_text(payload)
     # TODO this should fail (parent dir for the upload missing)
-    ops.upload(payload_path, upload_url)
+    with pytest.raises(UrlTargetNotFound):
+        ops.upload(payload_path, upload_url)
     # TODO this just verifies that the above call should have failed
     # because it did
-    assert upload_path.read_text() == payload
+    with pytest.raises(FileNotFoundError):
+        assert upload_path.read_text() == payload


### PR DESCRIPTION
This PR adds triggering and handling of CommandError, and timeout handling to `SshUrlOperations.upload()`.

A `timeout`-keyword argument is added to the `UrlOperations`-interface.

In addition, there are some type-definition fixes, as well as:
-  raise an exception if `from_path` in `SshUrlOperations.upload()` is `None`, because the method does not properly support uploading from stdin.

