### PR TITLE
Add support for ssh upload from stdin

### DIFF
--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -224,7 +224,7 @@ class UrlOperations:
             noninteractive_level=logging.DEBUG,
         )
 
-    def _get_hasher(self, hash: list[str] | None) -> list:
+    def _get_hasher(self, hash: list[str] | None) -> list[callable]:
         if not hash:
             return []
 


### PR DESCRIPTION
This PR enables `SshUrlOperations.upload()` to use stdin as upload source, as documented in the `UrlOperations.upload()` interface description. A test is provided.

The code assumes that `datalad_next.url_operations._progress_report_start` is capable of handling an `expected_size` of `None`, and that this triggers a report for an upload of unknown size.
