### PR TITLE
STORE/upload support for uncurl

### DIFF
--- a/datalad_next/annexremote/uncurl.py
+++ b/datalad_next/annexremote/uncurl.py
@@ -195,6 +195,7 @@ from datalad.dataset.gitrepo import GitRepo
 from datalad_next.exceptions import (
     CapturedException,
     DownloadError,
+    UrlTargetNotFound,
 )
 from datalad_next.url_operations.any import AnyUrlOperations
 from datalad_next.utils import ensure_list
@@ -451,6 +452,10 @@ class UncurlRemote(SpecialRemote):
                 handler(url)
                 # we succeeded, no need to try again
                 return True
+            except UrlTargetNotFound:
+                # general system access worked, but at the key location is nothing
+                # to be found
+                return False
             except DownloadError as e:
                 # TODO subject to change due to
                 # https://github.com/datalad/datalad-next/issues/154

--- a/datalad_next/url_operations/any.py
+++ b/datalad_next/url_operations/any.py
@@ -81,7 +81,8 @@ class AnyUrlOperations(UrlOperations):
               credential: str | None = None,
               timeout: float | None = None) -> Dict:
         """Call `*UrlOperations.sniff()` for the respective URL scheme"""
-        return self._get_handler(url).sniff(url, credential=credential)
+        return self._get_handler(url).sniff(
+            url, credential=credential, timeout=timeout)
 
     def download(self,
                  from_url: str,
@@ -92,4 +93,5 @@ class AnyUrlOperations(UrlOperations):
                  timeout: float | None = None) -> Dict:
         """Call `*UrlOperations.download()` for the respective URL scheme"""
         return self._get_handler(from_url).download(
-            from_url, to_path, credential=credential, hash=hash)
+            from_url, to_path, credential=credential, hash=hash,
+            timeout=timeout)

--- a/datalad_next/url_operations/any.py
+++ b/datalad_next/url_operations/any.py
@@ -95,3 +95,15 @@ class AnyUrlOperations(UrlOperations):
         return self._get_handler(from_url).download(
             from_url, to_path, credential=credential, hash=hash,
             timeout=timeout)
+
+    def upload(self,
+               from_path: Path | None,
+               to_url: str,
+               *,
+               credential: str | None = None,
+               hash: list[str] | None = None,
+               timeout: float | None = None) -> Dict:
+        """Call `*UrlOperations.upload()` for the respective URL scheme"""
+        return self._get_handler(to_url).upload(
+            from_path, to_url, credential=credential, hash=hash,
+            timeout=timeout)

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 import logging
 import sys
 from itertools import chain
-from pathlib import Path
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
 from queue import (
     Full,
     Queue,
@@ -278,7 +281,7 @@ class SshUrlOperations(UrlOperations):
         ssh_runner_generator = ssh_cat.run(
             # leave special exit code when writing fails, but not the
             # general SSH access
-            'cat > {fpath} || exit 244',
+            "( mkdir -p '{fdir}' && cat > '{fpath}' ) || exit 244",
             protocol=_NoCaptureGeneratorProtocol,
             stdin=upload_queue,
             timeout=timeout,
@@ -357,7 +360,10 @@ class _SshCat:
         cmd.extend([
             '-e', 'none',
             self._parsed.hostname,
-            payload_cmd.format(fpath=fpath),
+            payload_cmd.format(
+                fdir=str(PurePosixPath(fpath).parent),
+                fpath=fpath,
+            ),
         ])
         return ThreadedRunner(
             cmd=cmd,

--- a/datalad_next/url_operations/tests/test_ssh.py
+++ b/datalad_next/url_operations/tests/test_ssh.py
@@ -75,13 +75,14 @@ def test_ssh_url_upload(tmp_path, monkeypatch):
         ops.upload(payload_path, upload_url)
 
     payload_path.write_text(payload)
-    # TODO this should fail (parent dir for the upload missing)
-    with pytest.raises(UrlTargetNotFound):
-        ops.upload(payload_path, upload_url)
-    # TODO this just verifies that the above call should have failed
-    # because it did
-    with pytest.raises(FileNotFoundError):
-        assert upload_path.read_text() == payload
+    # upload creates parent dirs, so the next just works.
+    # this may seem strange for SSH, but FILE does it too.
+    # likewise an HTTP upload is also not required to establish
+    # server-side preconditions first.
+    # this functionality is not about about exposing a full
+    # remote FS abstraction -- just upload
+    ops.upload(payload_path, upload_url)
+    assert upload_path.read_text() == payload
 
 
 # SshUrlOperations does not work against a windows server


### PR DESCRIPTION
This works in general, but `test_uncurl_store_via_ssh` shows a strange breakage pattern for my locally. Upload works, download works, CHECKPRESENT works, but `fsck` (which is CHECKPRESENT, plus download) does *not* work, and is only broken for SSH-only.

Git annex chatter for this looks like this:

```
...
[2022-12-02 06:01:03.35514891] (Annex.ExternalAddonProcess) /home/mih/env/datalad-dev/bin/git-annex-remote-uncurl[1] --> CHECKPRESENT-SUCCESS MD5E-s9--7291db66cf824b80413cfd5b76928997.txt

[2022-12-02 06:01:03.355586187] (Annex.ExternalAddonProcess) /home/mih/env/datalad-dev/bin/git-annex-remote-uncurl[1] <-- TRANSFER RETRIEVE MD5E-s9--7291db66cf824b80413cfd5b76928997.txt .git/annex/tmp/MD5E-s9--7291db66cf824b80413cfd5b76928997.txt

  external special remote protocol error, unexpectedly received "<EOF>" (unable to parse command)
```

So it succeed "sniffing" the key location via SSH, but then the special remote process closes its stdout(?), or maybe dies entirely?

When I switch the test `test_uncurl_store_via_ssh` from a `ssh://` to a `file://` target URL, everything works.

@christian-monch can you have a look at that please?