### PR TITLE
fix a bug where ssh subprocesses steal stdin

### DIFF
--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import subprocess
 import sys
 from itertools import chain
 from pathlib import (
@@ -368,7 +369,7 @@ class _SshCat:
         return ThreadedRunner(
             cmd=cmd,
             protocol_class=protocol,
-            stdin=stdin,
+            stdin=subprocess.DEVNULL if stdin is None else stdin,
             timeout=timeout,
         ).run()
 


### PR DESCRIPTION
This PR fixes a bug that was triggered when an annexremote process uses ssh to communicate with a remote.

The issue was the the annexremote process would not receive all data that was sent over stdin. The reason for that was that the ssh-subprocesses inherit stdin from the parant process, i.e. from annexremote, and suck in data before the annexremote can read it. This is due to a `None`-argument in the subprocess.Popen stdin keyword argument. That leads to the subprocess inheriting stdin from the parent process. Instead `subprocess.DEVNULL`, would be a proper argument.

This should fix the error discussed in PR #159 and also appears in PR #164
