### PR TITLE
Remove `require_dataset()` usage from codebase

### DIFF
--- a/datalad_next/create_sibling_webdav.py
+++ b/datalad_next/create_sibling_webdav.py
@@ -25,8 +25,10 @@ from datalad_next.dataset import (
     datasetmethod,
 )
 from datalad.distribution.dataset import (
-    EnsureDataset,
-    require_dataset,
+    # this does nothing but provide documentation
+    # only kept here until this command is converted to
+    # pre-call parameter validation
+    EnsureDataset as NoOpEnsureDataset,
 )
 from datalad_next.interface import (
     Interface,
@@ -47,6 +49,7 @@ from datalad_next.constraints import (
     EnsureNone,
     EnsureStr,
 )
+from datalad_next.constraints.dataset import EnsureDataset
 from datalad_next.exceptions import CapturedException
 from datalad_next.credman import CredentialManager
 from datalad_next.utils import (
@@ -156,7 +159,7 @@ class CreateSiblingWebDAV(Interface):
             doc="""specify the dataset to process.  If
             no dataset is given, an attempt is made to identify the dataset
             based on the current working directory""",
-            constraints=EnsureDataset() | EnsureNone()),
+            constraints=NoOpEnsureDataset() | EnsureNone()),
         name=Parameter(
             args=('-s', '--name',),
             metavar='NAME',
@@ -299,10 +302,8 @@ class CreateSiblingWebDAV(Interface):
             # leads to unresolvable, circular dependency with publish-depends
             raise ValueError("sibling names must not be equal")
 
-        ds = require_dataset(
-            dataset,
-            check_installed=True,
-            purpose='create WebDAV sibling(s)')
+        ds = EnsureDataset(
+            installed=True, purpose='create WebDAV sibling(s)')(dataset).ds
 
         res_kwargs = dict(
             action='create_sibling_webdav',

--- a/datalad_next/credentials.py
+++ b/datalad_next/credentials.py
@@ -30,8 +30,10 @@ from datalad_next.interface import (
 from datalad_next.exceptions import CapturedException
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import (
-    EnsureDataset,
-    require_dataset,
+    # this does nothing but provide documentation
+    # only kept here until this command is converted to
+    # pre-call parameter validation
+    EnsureDataset as NoOpEnsureDataset,
 )
 from datalad_next.dataset import datasetmethod
 from datalad_next.constraints import (
@@ -39,6 +41,7 @@ from datalad_next.constraints import (
     EnsureNone,
     EnsureStr,
 )
+from datalad_next.constraints.dataset import EnsureDataset
 
 lgr = logging.getLogger('datalad.local.credentials')
 
@@ -160,7 +163,7 @@ class Credentials(Interface):
             args=("-d", "--dataset"),
             doc="""specify a dataset whose configuration to inspect
             rather than the global (user) settings""",
-            constraints=EnsureDataset() | EnsureNone()),
+            constraints=NoOpEnsureDataset() | EnsureNone()),
         action=Parameter(
             args=("action",),
             nargs='?',
@@ -257,11 +260,11 @@ class Credentials(Interface):
                 "property specification is provided")
 
         # which config manager to use: global or from dataset
-        cfg = require_dataset(
-            dataset,
+        cfg = EnsureDataset(
             # we do not actually need it
-            check_installed=False,
-            purpose='manage credentials').config if dataset else dlcfg
+            installed=None,
+            purpose='manage credentials',
+        )(dataset).ds.config if dataset else dlcfg
 
         credman = CredentialManager(cfg)
 

--- a/datalad_next/tree.py
+++ b/datalad_next/tree.py
@@ -29,7 +29,6 @@ from datalad_next.exceptions import (
     NoDatasetFound
 )
 from datalad.support.param import Parameter
-from datalad.distribution.dataset import require_dataset
 
 from datalad.local.subdatasets import Subdatasets
 from datalad_next.constraints import (
@@ -38,6 +37,7 @@ from datalad_next.constraints import (
     EnsureInt,
     EnsureRange,
 )
+from datalad_next.constraints.dataset import EnsureDataset
 from datalad_next.utils import get_dataset_root
 from datalad.ui import ui
 from datalad_next.dataset import (
@@ -1217,7 +1217,7 @@ class DatasetNode(_TreeNode):
         super().__init__(*args, **kwargs)
 
         try:
-            self.ds = require_dataset(self.path, check_installed=False)
+            self.ds = EnsureDataset(installed=None)(self.path).ds
             self.is_installed = self.ds.is_installed()
             self.ds_depth, self.ds_absolute_depth = self.calculate_dataset_depth()
         except Exception as ex:


### PR DESCRIPTION
as long as `require_dataset()` is still provided upstream), and in `datalad_next.patches` (for compatibility).

It shall never be introduced in other places again. `datalad_next.constraints.dataset.EnsureDataset` can and must be used now.

Closes #139