### PR TITLE
Generalize URL handler matching for AnyUrlOperations

### DIFF
--- a/datalad_next/url_operations/tests/test_any.py
+++ b/datalad_next/url_operations/tests/test_any.py
@@ -2,7 +2,24 @@ import pytest
 from .. import (
     UrlOperationsResourceUnknown,
 )
-from ..any import AnyUrlOperations
+from ..any import (
+    _url_handlers,
+    AnyUrlOperations,
+    HttpUrlOperations,
+    FileUrlOperations,
+)
+
+
+def test_get_best_url_handler(monkeypatch):
+    ops = AnyUrlOperations()
+    assert type(ops._get_handler('https://example.com')) == HttpUrlOperations
+    # it will report the "longest-matching" Handler
+    # we create a non-sensicle FileUrlOperations record to test that
+    with monkeypatch.context() as m:
+        m.setitem(_url_handlers, 'https://ex.*\.co', FileUrlOperations)
+        # the handlers are sucked into the class, so we need a new instance
+        ops = AnyUrlOperations()
+        assert type(ops._get_handler('https://example.com')) == FileUrlOperations
 
 
 def test_any_url_operations(tmp_path):


### PR DESCRIPTION
It no longer looks at the URL scheme, match perform regex matching.

It avoids having to invent artificial URL schemes like azure://, and instead be able to say http[s].://[^/]+\.blob\.core\.windows\.net.... (or something like that) to be able to provision arbitrarily customized handlers for arbitrarily tiny target audiences, with reduced chances for conflicts across extensions feeding into the switch board

Closes #172

### PR checklist

- [ ] If this PR is not complete, select "Create Draft Pull Request" in the pull request button's menu.
  Consider using a task list (e.g., `- [ ] add tests ...`) to indicate remaining to-do items.
- [ ] Provide an overview of the changes you're making and explain why you're proposing them. Ideally, include them as a new file in `changelog.d/`
- [ ] Include `Fixes #NNN` somewhere in the description if this PR addresses an existing issue.
- [ ] If you would like to list yourself as a DataLad contributor and your name is not mentioned please modify .zenodo.json file.
- [ ] **Delete these instructions**. :-)

Thanks for contributing!
