### PR TITLE
Joint validation of a full command parameterization 

### DIFF
--- a/datalad_next/commands/__init__.py
+++ b/datalad_next/commands/__init__.py
@@ -12,6 +12,8 @@ from datalad.interface.utils import (
 )
 from datalad.support.param import Parameter
 
+from datalad_next.constraints.parameter import EnsureCommandParameterization
+
 
 class ValidatedInterface(Interface):
     """Alternative base class for commands with uniform parameter validation
@@ -31,63 +33,38 @@ class ValidatedInterface(Interface):
     a command's ``__call__`` method can focus on the core purpose of the
     command, while validation and error handling can be delegated elsewhere.
 
-    Validators for individual parameters are declared in a ``_validators_``
-    class member. This is a dict mapping from parameter name to a
-    ``Constraint`` instance. The latter can be the same as those used for the
-    ``Parameter`` specifications.  ``ValidatedInterface.validate_args()`` will
-    inspect this dict for the presence of a validator for particular
-    parameters, and run them. The output of the respective validator will be
-    collected and passed to the underlying command's ``__call__`` method.
-    Consequently, a command only needs to support the output values of the
-    validators declared by itself.
+    A validator for all individual parameters and the joint-set of all
+    parameters is declared in a ``_validator_`` class member.
+    This should be an instance of ``EnsureCommandParameterization``. This
+    default implementation can be subclassed if validation of inter-parameter
+    depenencies is desired (implement
+    ``EnsureCommandParameterization.joint_validation()`` with the necessary
+    checks.
+    Only the output of this validator (`Constraint` implementation) will be
+    passed to the underlying command's ``__call__`` method. Consequently,
+    a command only needs to support the output values of the validators
+    declared by itself.
 
-    In two cases no validation is performed: 1) when no validator for a
-    particular parameter is declared, any input value is passed on as-is.
-    2) when a parameter value is identical to its default value, the default
-    is passed as-is.
+    When ``EnsureCommandParameterization`` or a subclass is used for
+    validation, there are two cases for which no (full) validation is
+    performed: 1) when no validator for a particular parameter is declared,
+    any input value is passed on as-is. 2) When a parameter value is identical
+    to its default value, the default is passed as-is.
 
     An important consequence of the second condition is that validators need
     not cover a default value. For example, a parameter ``path=None``, where
     ``None`` is a special value used to indiciate an optional and unset value,
     but actually only paths are acceptable input values, can be described as::
 
-        _validators_ = {'path': EnsurePath()}
+        _validator_ = EnsureCommandParameterization({'path': EnsurePath()})
 
     and it is not necessary to do something like
     ``EnsurePath() | EnsureNone()``.
 
     To transition a command from ``Interface`` to ``ValidatedInterface``,
-    replace the base class declaration and declare a ``_validators_`` class
+    replace the base class declaration and declare a ``_validator_`` class
     member. Any ``constraints=`` declaration for ``Parameter`` instances
     should either be removed, or moved to the corresponding entry in
-    ``_validators_``.
+    ``_validator_``.
     """
-    @classmethod
-    def validate_args(cls: Interface, kwargs: Dict, at_default: set) -> Dict:
-        validated = {}
-        for argname, arg in kwargs.items():
-            if argname in at_default:
-                # do not validate any parameter where the value matches the
-                # default declared in the signature. Often these are just
-                # 'do-nothing' settings or have special meaning that need
-                # not be communicated to a user. Not validating them has
-                # two consequences:
-                # - the condition can simply be referred to as "default
-                #   behavior" regardless of complexity
-                # - a command implementation must always be able to handle
-                #   its own defaults directly, and cannot delegate a
-                #   default value handling to a constraint
-                #
-                # we must nevertheless pass any such default value through
-                # to make/keep them accessible to the general result handling
-                # code
-                validated[argname] = arg
-                continue
-            validator = cls._validators_.get(argname, lambda x: x)
-            # TODO option to validate all args despite failure
-            try:
-                validated[argname] = validator(arg)
-            except Exception as e:
-                raise ValueError(
-                    f'Validation of parameter {argname!r} failed') from e
-        return validated
+    _validator_ = None

--- a/datalad_next/commands/download.py
+++ b/datalad_next/commands/download.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 
 import datalad
 from datalad_next.commands import (
+    EnsureCommandParameterization,
     ValidatedInterface,
     Parameter,
     build_doc,
@@ -121,7 +122,7 @@ class Download(ValidatedInterface):
 
     # Interface.validate_args() will inspect this dict for the presence of a
     # validator for particular parameters
-    _validators_ = dict(
+    _validator_ = EnsureCommandParameterization(dict(
         spec=spec_constraint,
         # if given, it must also exist as a source for configuration items
         # and/or credentials
@@ -131,7 +132,7 @@ class Download(ValidatedInterface):
         #credential=
         # TODO EnsureHashAlgorithm
         #hash=EnsureHashAlgorithm | EnsureIterableOf(EnsureHashAlgorithm)
-    )
+    ))
 
     # this is largely here for documentation and CLI parser building
     _params_ = dict(

--- a/datalad_next/commands/tests/test_create_sibling_webdav.py
+++ b/datalad_next/commands/tests/test_create_sibling_webdav.py
@@ -212,7 +212,7 @@ def test_constraints_checking(path=None):
     ds = Dataset(path).create()
     url = "http://localhost:22334/abc"
     for key in ("existing", "mode"):
-        with pytest.raises(ValueError, match="value is not one of"):
+        with pytest.raises(ValueError, match="is not one of"):
             create_sibling_webdav(
                 dataset=ds, url=url, **{key: "illegal-value"})
 

--- a/datalad_next/commands/tests/test_credentials.py
+++ b/datalad_next/commands/tests/test_credentials.py
@@ -17,6 +17,7 @@ from ..credentials import (
     normalize_specs,
 )
 from datalad_next.exceptions import IncompleteResultsError
+from datalad_next.utils import external_versions
 from datalad_next.tests.utils import (
     MemoryKeyring,
     assert_in,
@@ -105,7 +106,10 @@ def check_credentials_cli():
         # it is a shame that the error is not coming out on
         # stderr
         run_main(['credentials', 'remove'], exit_code=1)
-        cml.assert_logged('.*name must be provided')
+        if external_versions['datalad'] > '0.17.9':
+            # depends on (yet unreleased)
+            # https://github.com/datalad/datalad/pull/7210
+            cml.assert_logged('.*name must be provided')
     # catch missing `name` via Python call too
     assert_raises(IncompleteResultsError, cred, 'set', spec=[':mike'])
     # no name and no property

--- a/datalad_next/constraints/basic.py
+++ b/datalad_next/constraints/basic.py
@@ -230,7 +230,7 @@ class EnsureChoice(Constraint):
 
     def __call__(self, value):
         if value not in self._allowed:
-            raise ValueError(f"value {value} is not one of {self._allowed}")
+            raise ValueError(f"value {value!r} is not one of {self._allowed}")
         return value
 
     def long_description(self):

--- a/datalad_next/constraints/compound.py
+++ b/datalad_next/constraints/compound.py
@@ -158,7 +158,7 @@ class EnsureMapping(Constraint):
             self._value_constraint.short_description(),
         )
 
-    def __call__(self, value) -> Dict:
+    def _get_key_value(self, value) -> tuple:
         # determine key and value from various kinds of input
         if isinstance(value, str):
             # will raise if it cannot split into two
@@ -176,6 +176,10 @@ class EnsureMapping(Constraint):
         else:
             raise ValueError(f'Unsupported data type for mapping: {value!r}')
 
+        return key, val
+
+    def __call__(self, value) -> Dict:
+        key, val = self._get_key_value(value)
         key = self._key_constraint(key)
         val = self._value_constraint(val)
         return {key: val}

--- a/datalad_next/constraints/parameter.py
+++ b/datalad_next/constraints/parameter.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 from typing import (
     Any,

--- a/datalad_next/constraints/parameter.py
+++ b/datalad_next/constraints/parameter.py
@@ -114,10 +114,8 @@ class EnsureParameterConstraint(EnsureMapping):
           constraint that handles all aspects of the specification in a
           homogenous fashion via the Constraint interface.
         default: Any
-          A parameter's default value. Any (intermediate) constraint is tested
-          whether it considers the default to be a valid value. If not,
-          the constraint is automatically expanded to also cover this
-          particular value.
+          A parameter's default value. It is configured as a "pass-through"
+          value that will not be subjected to validation.
         item_constraint:
           If given, it override any constraint declared in the Parameter
           instance given to `spec`
@@ -127,11 +125,10 @@ class EnsureParameterConstraint(EnsureMapping):
         """
         value_constraint = _get_comprehensive_constraint(
             spec,
-            default,
             item_constraint,
             nargs,
         )
-        return cls(value_constraint)
+        return cls(value_constraint, passthrough=default)
 
 
 # that mapping is NOT to be expanded!
@@ -146,7 +143,6 @@ _constraint_spec_map = {
 
 def _get_comprehensive_constraint(
         param_spec: aParameter,
-        default: Any,
         item_constraint_override: ConstraintDerived = None,
         nargs_override: str or int = None):
     action = param_spec.cmd_kwargs.get('action')
@@ -216,12 +212,5 @@ def _get_comprehensive_constraint(
         # wrap into a(nother) sequence
         # (think: list of 2-tuples, etc.
         constraint = EnsureIterableOf(list, constraint)
-
-    # lastly try to validate the default, if that fails
-    # wrap into alternative
-    try:
-        constraint(default)
-    except Exception:
-        constraint = constraint | EnsureValue(default)
 
     return constraint

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -115,9 +115,9 @@ def test_EnsureParameterConstraint():
     with pytest.raises(ValueError):
         c({'some': [[3, 2], [1]]})
     # no iterable
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         c({'some': [3, [1, 2]]})
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         c({'some': 3})
     # overwrite an item constraint and nargs
     c = EnsureParameterConstraint.from_parameter(
@@ -152,6 +152,13 @@ def test_EnsureParameterConstraint_passthrough():
         c.parameter_constraint(None)
     # setting is retrievable
     assert c.passthrough_value is None
+
+    # now the "same" via from_parameter()
+    c = EnsureParameterConstraint.from_parameter(
+        Parameter(constraints=EnsureInt()),
+        default=None)
+    assert c(dict(p=None)) == {'p': None}
+    assert c('p=5') == {'p': 5}
 
 
 nested_json = """\

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -54,7 +54,7 @@ def test_EnsureParameterConstraint():
     # invalid name
     with pytest.raises(ValueError):
         c({'4way': 123})
-    assert c('some=value') == dict(some='value')
+    assert c('so1230_s82me=value') == dict(so1230_s82me='value')
     # now some from a standard Parameter declaration
     c = EnsureParameterConstraint.from_parameter(
         Parameter(), 'whateverdefault')
@@ -136,6 +136,22 @@ def test_EnsureParameterConstraint():
             pytest.deprecated_call():
         EnsureParameterConstraint.from_parameter(
             Parameter(), 2, item_constraint='unknown')
+
+
+def test_EnsureParameterConstraint_passthrough():
+    c = EnsureParameterConstraint(EnsureInt(), passthrough=None)
+    # rejects wrong ones
+    with pytest.raises(ValueError):
+        c('p=mike')
+    # accepts correct ones
+    assert c('p=5') == {'p': 5}
+    # and passes through
+    assert c(dict(p=None)) == {'p': None}
+    # even when the actual value constraint would not
+    with pytest.raises(TypeError):
+        c.parameter_constraint(None)
+    # setting is retrievable
+    assert c.passthrough_value is None
 
 
 nested_json = """\

--- a/datalad_next/patches/interface_utils.py
+++ b/datalad_next/patches/interface_utils.py
@@ -112,9 +112,9 @@ def _execute_command_(
     )
 
     # validate the complete parameterization
-    if hasattr(interface, 'validate_args'):
-        allkwargs = interface.validate_args(
-            kwargs=allkwargs,
+    if hasattr(interface, '_validator_') and interface._validator_ is not None:
+        allkwargs = interface._validator_(
+            allkwargs,
             at_default=at_default,
         )
 


### PR DESCRIPTION
This provides a solution to the `EnsureMappings` proposal from datalad/datalad-gooey#311, albeit in a command-specific fashion.

This now establishes an interface to perform additional validation steps (uniformly across all APIs) after per-parameter validation was completed successfully.

The underlying validator class could also be a source for documentation to be exposed to users via the help-generation tooling, but this is not done here, because they largely sit in datalad-core.

The utility of this approach is demo'ed on the `credentials` command, which moves information from one parameter to another, depending on the origin API. This is fully captured, and no validation or type conversiion code remains in the actual command implementation (`__call__`).

The impact on implementation complexity for commands that do not require validation of inter-parameter dependencies is demo'ed for the `download` command.

Ping #115