### PR TITLE
Importless declaration of URL handler

### DIFF
--- a/datalad_next/url_operations/tests/test_any.py
+++ b/datalad_next/url_operations/tests/test_any.py
@@ -16,7 +16,11 @@ def test_get_best_url_handler(monkeypatch):
     # it will report the "longest-matching" Handler
     # we create a non-sensicle FileUrlOperations record to test that
     with monkeypatch.context() as m:
-        m.setitem(_url_handlers, 'https://ex.*\.co', FileUrlOperations)
+        m.setitem(
+            _url_handlers,
+            'https://ex.*\.co',
+            ('datalad_next.url_operations.file', 'FileUrlOperations'),
+        )
         # the handlers are sucked into the class, so we need a new instance
         ops = AnyUrlOperations()
         assert type(ops._get_handler('https://example.com')) == FileUrlOperations


### PR DESCRIPTION
Previously, the dict based on which `AnyUrlOperations` selects a handler must contain a handler class as values. This made it necessary to import everything first, and thereby creates an avoidable startup cost.

Now one declares a tuple with a module name and a class name to import on demand as values.

This avoids unconditional dependencies on special interest packages.

Closes datalad/datalad-next#175
