### PR TITLE
Introduce `apply_patch()` helper

### DIFF
--- a/datalad_next/patches/annexrepo.py
+++ b/datalad_next/patches/annexrepo.py
@@ -3,7 +3,6 @@ import os
 import re
 from unittest.mock import patch
 
-from datalad_next.datasets import LegacyAnnexRepo as AnnexRepo
 from datalad_next.exceptions import (
     CommandError,
 )
@@ -15,6 +14,7 @@ from datalad_next.utils import (
     get_specialremote_credential_properties,
     needs_specialremote_credential_envpatch,
 )
+from datalad_next.utils.patch import apply_patch
 
 
 # reuse logger from -core, despite the unconventional name
@@ -96,5 +96,7 @@ def annexRepo__enable_remote(self, name, options=None, env=None):
     # implement store-after-success here
 
 
-lgr.debug('Apply datalad-next patch to annexrepo.py:AnnexRepo.enable_remote')
-AnnexRepo.enable_remote = annexRepo__enable_remote
+apply_patch(
+    'datalad.support.annexrepo', 'AnnexRepo', 'enable_remote',
+    annexRepo__enable_remote,
+    msg='Apply datalad-next patch to annexrepo.py:AnnexRepo.enable_remote')

--- a/datalad_next/patches/clone.py
+++ b/datalad_next/patches/clone.py
@@ -8,7 +8,6 @@ from typing import (
 )
 
 from datalad.config import ConfigManager
-from datalad.core.distributed import clone as mod_clone
 from datalad.core.distributed.clone import (
     configure_origins,
     postclone_check_head,
@@ -20,6 +19,7 @@ from datalad_next.utils import (
     knows_annex,
     rmtree,
 )
+from datalad_next.utils.patch import apply_patch
 from datalad_next.datasets import (
     LegacyAnnexRepo as AnnexRepo,
     Dataset,
@@ -352,6 +352,10 @@ def _pre_final_processing_(
 
 
 # apply patch
-lgr.debug('Apply datalad-next patch to clone.py:clone_dataset')
-clone_dataset.__doc__ = mod_clone.clone_dataset.__doc__
-mod_clone.clone_dataset = clone_dataset
+orig_clone_dataset = apply_patch(
+    'datalad.core.distributed.clone', None, 'clone_dataset', clone_dataset,
+    msg='Apply datalad-next patch to clone.py:clone_dataset')
+apply_patch(
+    'datalad.core.distributed.clone', 'clone_dataset', '__doc__',
+    orig_clone_dataset.__doc__,
+    msg='Reuse docstring of original clone_dataset()')

--- a/datalad_next/patches/clone_ephemeral.py
+++ b/datalad_next/patches/clone_ephemeral.py
@@ -11,12 +11,12 @@ from datalad_next.utils import (
     check_symlink_capability,
     rmtree,
 )
+from datalad_next.utils.patch import apply_patch
 
 from datalad_next.datasets import (
     Dataset,
     LegacyGitRepo as GitRepo,
 )
-from datalad_next.patches import clone as mod_clone
 
 lgr = logging.getLogger('datalad.core.distributed.clone')
 
@@ -121,12 +121,11 @@ def _setup_ephemeral_annex(ds: Dataset, remote: str):
 
 
 # apply patch
-lgr.debug(
-    'Apply datalad-next RIA patch to clone.py:_pre_annex_init_processing_')
-# we need to preserve the original function to be able to call it in the patch
-orig_pre_annex_init_processing_ = mod_clone._pre_annex_init_processing_
-mod_clone._pre_annex_init_processing_ = _pre_annex_init_processing_
-lgr.debug(
-    'Apply datalad-next RIA patch to clone.py:_post_annex_init_processing_')
-orig_post_annex_init_processing_ = mod_clone._post_annex_init_processing_
-mod_clone._post_annex_init_processing_ = _post_annex_init_processing_
+orig_pre_annex_init_processing_ = apply_patch(
+    'datalad_next.patches.clone', None, '_pre_annex_init_processing_',
+    _pre_annex_init_processing_,
+    msg='Apply datalad-next RIA patch to clone.py:_pre_annex_init_processing_')
+orig_post_annex_init_processing_ = apply_patch(
+    'datalad_next.patches.clone', None, '_post_annex_init_processing_',
+    _post_annex_init_processing_,
+    msg='Apply datalad-next RIA patch to clone.py:_post_annex_init_processing_')

--- a/datalad_next/patches/clone_ria.py
+++ b/datalad_next/patches/clone_ria.py
@@ -11,8 +11,7 @@ from datalad.core.distributed.clone import (
 )
 
 from datalad_next.datasets import Dataset
-
-from datalad_next.patches import clone as mod_clone
+from datalad_next.utils.patch import apply_patch
 
 lgr = logging.getLogger('datalad.core.distributed.clone')
 
@@ -50,12 +49,11 @@ def _pre_final_processing_(
 
 
 # apply patch
-lgr.debug(
-    'Apply datalad-next RIA patch to clone.py:_post_git_init_processing_')
-# we need to preserve the original function to be able to call it in the patch
-orig_post_git_init_processing_ = mod_clone._post_git_init_processing_
-mod_clone._post_git_init_processing_ = _post_git_init_processing_
-lgr.debug(
-    'Apply datalad-next RIA patch to clone.py:_pre_final_processing_')
-orig_pre_final_processing_ = mod_clone._pre_final_processing_
-mod_clone._pre_final_processing_ = _pre_final_processing_
+orig_post_git_init_processing_ = apply_patch(
+    'datalad_next.patches.clone', None, '_post_git_init_processing_',
+    _post_git_init_processing_,
+    msg='Apply datalad-next RIA patch to clone.py:_post_git_init_processing_')
+orig_pre_final_processing_ = apply_patch(
+    'datalad_next.patches.clone', None, '_pre_final_processing_',
+    _pre_final_processing_,
+    msg='Apply datalad-next RIA patch to clone.py:_pre_final_processing_')

--- a/datalad_next/patches/distribution_dataset.py
+++ b/datalad_next/patches/distribution_dataset.py
@@ -1,11 +1,9 @@
 import logging
-from datalad.distribution import dataset as mod_distribution_dataset
+
+from datalad_next.utils.patch import apply_patch
 
 # use same logger as -core, looks weird but is correct
 lgr = logging.getLogger('datalad.dataset')
-
-# we need to preserve it as the workhorse, this patch only wraps around it
-orig_resolve_path = mod_distribution_dataset.resolve_path
 
 
 def resolve_path(path, ds=None, ds_resolved=None):
@@ -20,10 +18,12 @@ def resolve_path(path, ds=None, ds_resolved=None):
         return orig_resolve_path(ds=ds, ds_resolved=ds_resolved)
 
 
+# we need to preserve it as the workhorse, this patch only wraps around it
+orig_resolve_path = apply_patch(
+    'datalad.distribution.dataset', None, 'resolve_path',
+    resolve_path,
+    msg='Apply datalad-next patch to distribution.dataset:resolve_path')
+
 # re-use docs
 resolve_path.__doc__ = orig_resolve_path.__doc__
 
-
-# apply patch
-lgr.debug('Apply datalad-next patch to distribution.dataset:resolve_path')
-mod_distribution_dataset.resolve_path = resolve_path

--- a/datalad_next/patches/interface_utils.py
+++ b/datalad_next/patches/interface_utils.py
@@ -21,6 +21,7 @@ from datalad.interface.utils import (
     _process_results,
 )
 from datalad_next.exceptions import IncompleteResultsError
+from datalad_next.utils.patch import apply_patch
 
 
 # use same logger as -core
@@ -248,14 +249,12 @@ def _execute_command_(
 
 
 # apply patch
-from datalad.interface import utils as mod_interface_utils
-if hasattr(mod_interface_utils, '_execute_command_'):
-    lgr.debug(
-        'Apply datalad-next patch to interface.utils.py:_execute_command_')
-    mod_interface_utils._execute_command_ = _execute_command_
-else:
+patch_msg = \
+    'Apply datalad-next patch to interface.(utils|base).py:_execute_command_'
+try:
+    apply_patch('datalad.interface.utils', None, '_execute_command_',
+                _execute_command_, msg=patch_msg)
+except AttributeError:
     # we have datalad 0.17.10+ and the target has moved
-    from datalad.interface import base as mod_interface_base
-    lgr.debug(
-        'Apply datalad-next patch to interface.base.py:_execute_command_')
-    mod_interface_base._execute_command_ = _execute_command_
+    apply_patch('datalad.interface.base', None, '_execute_command_',
+                _execute_command_, msg=patch_msg)

--- a/datalad_next/patches/push_optimize.py
+++ b/datalad_next/patches/push_optimize.py
@@ -12,6 +12,7 @@ from datalad_next.datasets import (
     LegacyAnnexRepo as AnnexRepo,
     Dataset,
 )
+from datalad_next.utils.patch import apply_patch
 
 
 lgr = logging.getLogger('datalad.core.distributed.push')
@@ -409,5 +410,4 @@ def _sync_remote_annex_branch(repo, target, is_annex_repo):
         lgr.debug('Remote does not have a git-annex branch: %s', e)
 
 
-lgr.debug("Patching datalad.core.distributed.push._push")
-mod_push._push = _push
+apply_patch('datalad.core.distributed.push', None, '_push', _push)

--- a/datalad_next/patches/runnerthreads.py
+++ b/datalad_next/patches/runnerthreads.py
@@ -5,12 +5,11 @@ import logging
 from datalad.runner import runnerthreads as mod_runnerthreads
 
 from datalad_next.utils.consts import COPY_BUFSIZE
+from datalad_next.utils.patch import apply_patch
+
 
 # use same logger as -core, looks weird but is correct
 lgr = logging.getLogger('datalad.runner.runnerthreads')
-
-# we need to preserve it as the workhorse, this patch only wraps around it
-orig_ReadThread__init__ = mod_runnerthreads.ReadThread.__init__
 
 
 def ReadThread__init__(
@@ -35,7 +34,7 @@ def ReadThread__init__(
     )
 
 
-# apply patch
-lgr.debug(
-    'Apply datalad-next patch to runner.runnerthreads.ReadThread.__init__')
-mod_runnerthreads.ReadThread.__init__ = ReadThread__init__
+# we need to preserve it as the workhorse, this patch only wraps around it
+orig_ReadThread__init__ = apply_patch(
+    'datalad.runner.runnerthreads', 'ReadThread', '__init__',
+    ReadThread__init__)

--- a/datalad_next/patches/siblings.py
+++ b/datalad_next/patches/siblings.py
@@ -1,15 +1,17 @@
 import logging
 
-from datalad.distribution import siblings as mod_siblings
 from datalad_next.datasets import LegacyAnnexRepo as AnnexRepo
 from datalad.support.exceptions import (
     AccessDeniedError,
     AccessFailedError,
     CapturedException,
 )
+from datalad_next.utils.patch import apply_patch
+
 
 # use same logger as -core
 lgr = logging.getLogger('datalad.distribution.siblings')
+
 
 # This function is taken from datalad-core@2ed709613ecde8218a215dcb7d74b4a352825685
 # datalad/distribution/siblings.py
@@ -39,7 +41,10 @@ def _enable_remote(ds, repo, name, res_kwargs, **unused_kwargs):
         return
 
     # get info on special remote
-    sp_remotes = {v['name']: dict(v, uuid=k) for k, v in repo.get_special_remotes().items()}
+    sp_remotes = {
+        v['name']: dict(v, uuid=k)
+        for k, v in repo.get_special_remotes().items()
+    }
     remote_info = sp_remotes.get(name, None)
 
     if remote_info is None:
@@ -61,6 +66,5 @@ def _enable_remote(ds, repo, name, res_kwargs, **unused_kwargs):
     yield result_props
 
 
-# apply patch
-lgr.debug('Apply datalad-next patch to siblings.py:_enable_remote')
-mod_siblings._enable_remote = _enable_remote
+apply_patch(
+    'datalad.distribution.siblings', None, '_enable_remote', _enable_remote)

--- a/datalad_next/patches/tests/test_push_to_export_remote.py
+++ b/datalad_next/patches/tests/test_push_to_export_remote.py
@@ -104,7 +104,7 @@ def test_is_export_remote():
 def test_patch_pass_through():
     # Ensure that the original _transfer_data is called if the target remote
     # has exporttree # not set to "yes"
-    with patch("datalad_next.patches.push_to_export_remote.push._push_data") as pd_mock:
+    with patch("datalad_next.patches.push_to_export_remote.mod_push._push_data") as pd_mock:
         tuple(_call_transfer("no-target", False))
         eq_(pd_mock.call_count, 1)
 
@@ -112,7 +112,7 @@ def test_patch_pass_through():
 def test_patch_execute_export():
     # Ensure that export is called if the target remote has exporttree set to
     # "yes"
-    with patch(f"{module_name}.push._push_data") as pd_mock, \
+    with patch(f"{module_name}.mod_push._push_data") as pd_mock, \
          patch(f"{module_name}._get_export_log_entry") as gele_mock:
         gele_mock.return_value = None
         results = tuple(_call_transfer("yes-target", False))
@@ -144,7 +144,7 @@ def test_patch_skip_ignore_targets_export():
 def test_patch_check_envpatch():
     # Ensure that export is called if the target remote has exporttree not set
     # to "yes"
-    with patch(f"{module_name}.push._push_data") as pd_mock, \
+    with patch(f"{module_name}.mod_push._push_data") as pd_mock, \
          patch(f"{module_name}.needs_specialremote_credential_envpatch") as nsce_mock, \
          patch(f"{module_name}.get_specialremote_credential_envpatch") as gsce_mock, \
          patch(f"{module_name}._get_export_log_entry") as gele_mock, \
@@ -170,7 +170,7 @@ def test_patch_check_envpatch():
 
 def test_no_special_remotes():
     # Ensure that the code works if no special remotes exist
-    with patch(f"{module_name}.push._push_data") as pd_mock:
+    with patch(f"{module_name}.mod_push._push_data") as pd_mock:
         tuple(_call_transfer("no-target", False, False))
         eq_(pd_mock.call_count, 1)
 

--- a/datalad_next/utils/patch.py
+++ b/datalad_next/utils/patch.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from importlib import import_module
+import logging
+from typing import Any
+
+lgr = logging.getLogger('datalad.ext.next.utils.patch')
+
+
+def apply_patch(
+        modname: str,
+        objname: str | None,
+        attrname: str,
+        patch: Any,
+        msg: str | None = None,
+        expect_attr_present=True,
+):
+    """
+    Monkey patch helper
+
+    Parameters
+    ----------
+    modname: str
+      Importable name of the module with the patch target.
+    objname: str or None
+      If `None`, patch will target an attribute of the module,
+      otherwise an object name within the module can be specified.
+    attrname: str
+      Name of the attribute to replace with the patch, either
+      in the module or the given object (see ``objname``)
+    patch:
+      The identified attribute will be replaced with this object.
+    msg: str or None
+      If given, a debug-level log message with this text will be
+      emitted, otherwise a default message is generated.
+    expect_attr_present: bool
+      If True (default) an exception is raised when the target
+      attribute is not found.
+
+    Returns
+    -------
+    object
+      The original, unpatched attribute -- if ``expect_attr_present``
+      is enabled, or ``None`` otherwise.
+
+    Raises
+    ------
+    ImportError
+      When the target module cannot be imported
+    AttributedError
+      When the target object is not found, or the target attribute is
+      not found.
+    """
+    orig_attr = None
+
+    msg = msg or f'Apply patch to {modname}.{attrname}'
+    lgr.debug(msg)
+
+    # we want to fail on ImportError
+    mod = import_module(modname, package='datalad')
+    if objname:
+        # we want to fail on a missing object
+        obj = getattr(mod, objname)
+    else:
+        # the target is the module itself
+        obj = mod
+
+    if expect_attr_present:
+        # we want to fail on a missing attribute/object
+        orig_attr = getattr(obj, attrname)
+
+    setattr(obj, attrname, patch)
+
+    return orig_attr


### PR DESCRIPTION
Among other things is defaults to raising an exception when a patch target is not found. This should better prevent invalid patching attempts due to unexpected changes in the patch target.
