### PR TITLE
CredentialManager.obtain() helper for a standard credential workflow

### DIFF
--- a/datalad_next/utils/credman.py
+++ b/datalad_next/utils/credman.py
@@ -435,10 +435,6 @@ class CredentialManager(object):
         # prefix for all config variables of this credential
         prefix = _get_cred_cfg_var(name, '')
 
-        def _get_props():
-            return (k[len(prefix):] for k in self._cfg.keys()
-                    if k.startswith(prefix))
-
         to_remove = [
             k[len(prefix):] for k in self._cfg.keys()
             if k.startswith(prefix)
@@ -460,7 +456,7 @@ class CredentialManager(object):
                     CapturedException(e)
                 else:
                     # we could not delete the field
-                    raise
+                    raise  # pragma: nocover
 
         del_field(name, 'secret')
         if type_hint:
@@ -676,11 +672,6 @@ class CredentialManager(object):
         )
         return known_credentials
 
-    def _prompt(self, prompt):
-        if not prompt:
-            return
-        ui.message(prompt)
-
     def _ask_property(self, name, prompt=None):
         if not ui.is_interactive:
             lgr.debug('Cannot ask for credential property %r in non-interactive session', name)
@@ -701,12 +692,6 @@ class CredentialManager(object):
             hidden=self._cfg.obtain(
                 'datalad.credentials.hidden-secret-entry'),
         )
-
-    def _props_defined_in_cfg(self, name, keys):
-        return [
-            k for k in keys
-            if _get_cred_cfg_var(name, k) in self._cfg
-        ]
 
     def _unset_credprops_anyscope(self, name, keys):
         """Reloads the config after unsetting all relevant variables

--- a/datalad_next/utils/credman.py
+++ b/datalad_next/utils/credman.py
@@ -639,16 +639,16 @@ class CredentialManager(object):
                 _prompt=prompt,
                 _type_hint=type_hint,
             )
-            # check if we know the realm, if so include in the credential,
-            # if not avoid asking for it interactively
-            # (it is a server-specified property users would generally not
-            # know, if they do, they can use the `credentials` command
-            # upfront).
-            realm = query_props.get('realm')
-            if realm:
-                kwargs['realm'] = realm
             try:
                 cred = self.get(**kwargs)
+                # check if we know the realm, if so include in the credential,
+                realm = (query_props or {}).get('realm')
+                if realm:
+                    cred['realm'] = realm
+                if name is None and type_hint:
+                    # we are not expecting to retrieve a particular credential.
+                    # make the type hint the actual type of the credential
+                    cred['type'] = type_hint
             except Exception as e:
                 lgr.debug('Obtaining credential failed: %s', e)
 

--- a/datalad_next/utils/credman.py
+++ b/datalad_next/utils/credman.py
@@ -574,6 +574,11 @@ class CredentialManager(object):
         known, a user is prompted to enter one interactively (if possible
         in the current session).
 
+        If a credential was entered manually, any given ``type_hint`` will
+        be included as a ``type`` property of the returned credential.
+        Likewise, any ``realm`` property included in the ``query_props``
+        is included in the returned credential in this case.
+
         If desired, a credential workflow can be completed, after a credential
         was found to be valid/working, by storing or updating it in the
         credential store::

--- a/datalad_next/utils/tests/test_credman.py
+++ b/datalad_next/utils/tests/test_credman.py
@@ -56,6 +56,13 @@ def check_credmanager():
     eq_(credman.get('dummy', secret='mike', _type_hint='token'),
         dict(type='token', secret='mike'))
 
+    # remove a secret that has not yet been set
+    eq_(credman.remove('elusive', type_hint='user_password'), False)
+
+    # but the secret was written to the keystore
+    with pytest.raises(ValueError):
+        credman.set('mycred', forbidden_propname='some')
+
     # no instructions what to do, no legacy entry, nothing was changed
     # but the secret was written to the keystore
     eq_(credman.set('mycred', secret='some'), dict(secret='some'))
@@ -92,6 +99,8 @@ def check_credmanager():
     eq_(credman.get('mycred'), dict(dummy='good', this='that', secret='some'))
     # remove individual property
     eq_(credman.set('mycred', dummy=None), dict(dummy=None))
+    # remove individual property that is not actually present
+    eq_(credman.set('mycred', imaginary=None), dict(imaginary=None))
     # ensure removal
     eq_(credman.get('mycred'), dict(this='that', secret='some'))
 
@@ -111,6 +120,11 @@ def check_credmanager():
     # remove complete credential
     credman.remove('mycred')
     eq_(credman.get('mycred'), None)
+
+    # test prompting for a secret when none is given
+    res = with_testsui(responses=['mysecret'])(credman.set)(
+        'mycred', other='prop')
+    assert res == {'other': 'prop', 'secret': 'mysecret'}
 
     # test prompting for a name when None is given
     res = with_testsui(responses=['mycustomname'])(credman.set)(
@@ -188,6 +202,8 @@ def check_query():
     # and the most recent one (with timestamp) is an unrelated one
     credman.set('unrelated', _lastused=True, secret='unrelated')
 
+    # smoke test for an unsorted report
+    assert len(credman.query()) > 1
     # now we want all credentials that match the realm, sorted by
     # last-used timestamp -- most recent first
     slist = credman.query(realm='http://ex.com/login', _sortby='last-used')
@@ -198,3 +214,18 @@ def check_query():
                           _reverse=False)
     eq_(['cred.0', 'cred.1', 'cred.2', 'cred.no.time'],
         [i[0] for i in slist])
+
+
+def test_credman_get():
+    # we are not making any writes, any config must work
+    credman = CredentialManager(ConfigManager())
+    # must be prompting for missing properties
+    res = with_testsui(responses=['myuser'])(credman.get)(
+        None, _type_hint='user_password', _prompt='myprompt',
+        secret='dummy')
+    assert 'myuser' == res['user']
+    # same for the secret
+    res = with_testsui(responses=['mysecret'])(credman.get)(
+        None, _type_hint='user_password', _prompt='myprompt',
+        user='dummy')
+    assert 'mysecret' == res['secret']


### PR DESCRIPTION
See docstring for details.

This replaces a more specific implementation in the context of `create_sibling_webdav()`, and is now available as a more generic helper for use in other scenarios too.