### PR TITLE
Loading URL handlers from configuration 

### DIFF
--- a/datalad_next/url_operations/tests/test_any.py
+++ b/datalad_next/url_operations/tests/test_any.py
@@ -5,9 +5,9 @@ from .. import (
 from ..any import (
     _url_handlers,
     AnyUrlOperations,
-    HttpUrlOperations,
-    FileUrlOperations,
 )
+from ..http import HttpUrlOperations
+from ..file import FileUrlOperations
 
 
 def test_get_best_url_handler(monkeypatch):
@@ -19,7 +19,7 @@ def test_get_best_url_handler(monkeypatch):
         m.setitem(
             _url_handlers,
             'https://ex.*\.co',
-            ('datalad_next.url_operations.file', 'FileUrlOperations'),
+            ('datalad_next.url_operations.file.FileUrlOperations',),
         )
         # the handlers are sucked into the class, so we need a new instance
         ops = AnyUrlOperations()


### PR DESCRIPTION
Here is an example:

```cfg
[datalad "url-handler.(^|.*::)s3://mybucket/"]
    class = datalad_next.url_operations.fsspec.FsspecUrlOperations
    kwargs = {\"fs_kwargs\": {\"s3\": {\"anon\": false}}}
```

This defines a dedicated handler for accessing the AWS S3 bucket
'mybucket', and turns off anonymous access for this bucket specifically.

A regex-match expression is directly included in the config subsection
name (following the pattern of the standard Git `url.<base>.insteadOf`
configuration pattern).

The only mandatory configuration property is `class`. It points to an
importable class implementing the `UrlOperations` API.

If necessary, arbitrary keyword-arguments for the class constructur
can be specified, JSON-encoded, in a `kwargs` configuration item.

On instantiating the `AnyUrlOperations` handler, the configuration is
parse using the `ConfigManager` given to the handler, and configuration
based handler specifications overwrite and extend any handlers declare
in the built-in handler registry.

All active handlers are logged at level 8. Invalid handler
configuration is ignore and reported at 'debug' log level.

Closes #217

Note that above example does not actually work in the context of this branch, because FSSPEC support currently is a development draft https://github.com/datalad/datalad-next/pull/215
However, the changes in this PR are also part of that PR to verify that they work in the way presented here. I have factored them out into a separate PR, because it is unknown when #215 would be merged.