### PR TITLE
Allow for opt-in parameter default validation

### DIFF
--- a/datalad_next/commands/create_sibling_webdav.py
+++ b/datalad_next/commands/create_sibling_webdav.py
@@ -251,7 +251,7 @@ class CreateSiblingWebDAV(ValidatedInterface):
             """),
     )
 
-    _validator_ = CreateSiblingWebDAVParamValidator(dict(
+    _validators = dict(
         url=EnsureParsedURL(
             required=['scheme', 'netloc'],
             forbidden=['query', 'fragment'],
@@ -269,7 +269,11 @@ class CreateSiblingWebDAV(ValidatedInterface):
         existing=EnsureChoice('skip', 'error', 'reconfigure'),
         recursive=EnsureBool(),
         recursion_limit=EnsureInt() & EnsureRange(min=0),
-    ))
+    )
+    _validator_ = CreateSiblingWebDAVParamValidator(
+        _validators,
+        validate_defaults=('dataset',),
+    )
 
     @staticmethod
     @datasetmethod(name='create_sibling_webdav')

--- a/datalad_next/commands/tests/test_create_sibling_webdav.py
+++ b/datalad_next/commands/tests/test_create_sibling_webdav.py
@@ -27,6 +27,7 @@ from datalad.api import (
     create_sibling_webdav,
 )
 from datalad_next.datasets import Dataset
+from datalad_next.utils import chpwd
 
 
 webdav_cred = ('dltest-my&=webdav', 'datalad', 'secure')
@@ -70,11 +71,12 @@ def check_common_workflow(
     targetdir = Path(remotepath) / targetdir_name
     url = f'{url}/{targetdir_name}'
 
-    res = ds.create_sibling_webdav(
-        url,
-        credential=webdav_cred[0] if declare_credential else None,
-        mode=mode,
-        **ca)
+    with chpwd(ds.path):
+        res = create_sibling_webdav(
+            url,
+            credential=webdav_cred[0] if declare_credential else None,
+            mode=mode,
+            **ca)
     assert_in_results(
         res,
         action='create_sibling_webdav.storage',

--- a/datalad_next/constraints/dataset.py
+++ b/datalad_next/constraints/dataset.py
@@ -61,7 +61,9 @@ class EnsureDataset(Constraint):
                 elif not self._installed and is_installed:
                     raise ValueError(f'{value} already exists locally')
             return DatasetParameter(value, value)
-        elif not isinstance(value, (str, PurePath)):
+        # anticipate what require_dataset() could handle and fail if we got
+        # something else
+        elif not isinstance(value, (str, PurePath, type(None))):
             raise TypeError(f"Cannot create Dataset from {type(value)}")
 
         from datalad.distribution.dataset import require_dataset


### PR DESCRIPTION
This change addresses a key shortcoming of the new command parameter
validation approach. Previously, it did not process a parameter's
default value (at all), and required each command implementation to
handle a default value directly.

This caused an inconvenience for the ubiquitous `dataset` parameter,
which often defaults to `None` to indicate "will discover in CWD".
However, given that `None` is the default, this discovery would need
to be implemented in each command, rather than using the standard
`EnsureDataset`.

With this change, `EnsureCommandParameterization` can be
parameterized with a new `validate_defaults` argument to cause
processing of an individual parameter's default.

Here, this is implemented for the `create_sibling_webdav()` command
as a demonstration. Likely other commands need a similar change.

Closes #225