### PR TITLE
Deploy dedicated HTTPBIN instance

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,6 +69,7 @@ environment:
       # datalad-annex git remote needs something after git-annex_8.20211x
       INSTALL_GITANNEX: git-annex -m snapshot
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+      DEPLOY_HTTPBIN: yes
     # Windows core tests
     - ID: WinP39core
       # ~35 min
@@ -152,7 +153,6 @@ matrix:
   allow_failures:
     - KNOWN2FAIL: 1
 
-
 # do not run the CI if only documentation changes were made
 # documentation builds are tested elsewhere and cheaper
 skip_commits:
@@ -179,6 +179,12 @@ cache:
   # TODO: Can we cache `brew`?
   #- /usr/local/Cellar
   #- /usr/local/bin
+  # cache the docker image for httpbin. in 2023 it has not changed in
+  # 4 years, not worth pulling each time
+  # given the low change frequency we also do not invalidate the cache
+  # but would do manually, if needed
+  - /home/appveyor/cache/httpbin.dockerimg
+  - C:\Users\appveyor\httpbin.dockerimg
 
 
 # turn of support for MS project build support (not needed)
@@ -212,7 +218,6 @@ init:
   - cmd: "set TEMP=C:\\DLTMP"
   - sh: export TMPDIR=~/DLTMP
 
-
 install:
   # enable external SSH access to CI worker on all other systems
   # needs APPVEYOR_SSH_KEY defined in project settings (or environment)
@@ -242,6 +247,8 @@ install:
   - sh: tools/appveyor/install-git-annex ${INSTALL_GITANNEX}
   # enable the git-annex provisioned by the installer
   - "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
+  # HTTPBIN
+  - sh: "[ -n \"$DEPLOY_HTTPBIN\" ] && tools/appveyor/docker-load-httpbin && docker run -p 8765:80 kennethreitz/httpbin &"
 
 
 #before_build:

--- a/datalad_next/annexremotes/tests/test_uncurl.py
+++ b/datalad_next/annexremotes/tests/test_uncurl.py
@@ -4,6 +4,7 @@ import re
 
 from datalad_next.utils import on_windows
 from datalad_next.tests.utils import (
+    get_httpbin_urls,
     skip_ssh,
     skip_if_on_windows,
     with_tempfile,
@@ -22,6 +23,7 @@ from ..uncurl import (
     UncurlRemote,
 )
 
+hbsurl = get_httpbin_urls()['standard']
 
 # for some tests below it is important that this base config contains no
 # url= or match= declaration (or any other tailoring to a specific use case)
@@ -34,6 +36,7 @@ std_initargs = [
 res_kwargs = dict(
     result_renderer='disabled',
 )
+
 
 class NoOpAnnex:
     def error(*args, **kwargs):
@@ -140,7 +143,7 @@ def test_uncurl_checkurl(tmp_path):
     # now add a matcher to make use of URL rewriting even for 'addurl'-type
     # use case, such as: we want to pass a "fixed" URL verbatim to some kind
     # of external redirector service
-    r.url_tmpl = 'http://httpbin.org/redirect-to?url={origurl}'
+    r.url_tmpl = f'{hbsurl}/redirect-to?url={{origurl}}'
     r.match = [
         re.compile('.*(?P<origurl>http://.*)$'),
     ]
@@ -155,7 +158,7 @@ def test_uncurl_addurl_unredirected(tmp_path):
     # same set as in `test_uncurl_checkurl()`
     dsca(['initremote', 'myuncurl'] + std_initargs + [
         'match=.*(?P<origurl>http://.*)$',
-        'url=http://httpbin.org/redirect-to?url={origurl}',
+        f'url={hbsurl}/redirect-to?url={{origurl}}',
     ])
     # feed it a broken URL, which must be getting fixed by the rewritting
     # (pulls 24 bytes)

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -2,6 +2,8 @@ import logging
 from functools import wraps
 from pathlib import Path
 
+import urllib
+
 # all datalad-core test utils needed for datalad-next
 from datalad.tests.utils_pytest import (
     DEFAULT_BRANCH,
@@ -167,3 +169,36 @@ def with_credential(name, **kwargs):
 
         return _with_credential
     return with_credential_decorator
+
+
+def get_httpbin_urls():
+    """Return cannonical access URLs for the HTTPBIN service
+
+    This function checks whether a service is deployed at
+    localhost:8765 and if so, it return this URL as the 'standard' URL.
+    If not, a URL pointing to the cannonical instance is returned.
+
+    For tests that need to have the service served via a specific
+    protocol (https vs http), the corresponding URLs are returned
+    too. They always point to the cannonical deployment, as some
+    tests require both protocols simultaneously and a local deployment
+    generally won't have https.
+    """
+    hburl = 'http://httpbin.org'
+    hbsurl = 'https://httpbin.org'
+    ciurl = 'http://localhost:8765'
+
+    ci_httpbin = False
+    try:
+        # if we have a CI deployment of a dedicated HTTPBIN
+        # it would be here
+        urllib.request.urlopen(ciurl)
+        ci_httpbin = True
+    except urllib.error.URLError:
+        pass
+
+    return dict(
+        standard=ciurl if ci_httpbin else hbsurl,
+        http=hburl,
+        https=hbsurl,
+    )

--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 import pytest
 
-from datalad_next.tests.utils import with_credential
+from datalad_next.tests.utils import (
+    get_httpbin_urls,
+    with_credential,
+)
 from ..http import (
     HttpUrlOperations,
     UrlOperationsRemoteError,
@@ -9,12 +12,13 @@ from ..http import (
 )
 
 
-hbsurl = 'https://httpbin.org'
+hbsurl = get_httpbin_urls()['standard']
 hbscred = (
     'hbscred',
     dict(user='mike', secret='dummy', type='user_password',
          realm=f'{hbsurl}/Fake Realm'),
 )
+
 
 @with_credential(hbscred[0], **hbscred[1])
 def test_http_url_operations(tmp_path):

--- a/tools/appveyor/docker-load-httpbin
+++ b/tools/appveyor/docker-load-httpbin
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e -u
+
+imgfile=~/cache/httpbin.dockerimg
+
+if [ -f "$imgfile" ]; then
+  # we have the image cached
+  docker load < $imgfile
+else
+  # pull from dockerhub
+  docker pull kennethreitz/httpbin
+  # and export for caching
+  mkdir -p $(dirname $imgfile)
+  docker save kennethreitz/httpbin > "$imgfile"
+fi


### PR DESCRIPTION
Improve the test reliability by making it less dependent on the public
instance.

This change enables this for the standard Ubuntu CI run on appveyor. Others could follow, but for now it is most important to have a single run be unaffected to be able to tell false positives.

Closes #236
