### PR TITLE
Only work for complete credentials in `DataladAuth`

### DIFF
--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -122,11 +122,17 @@ class DataladAuth(requests.auth.AuthBase):
             # get a realm ID for this authentication scheme
             realm = get_auth_realm(url, auth_schemes, scheme=ascheme)
             # ask for matching credentials
-            creds = self._credman.query(
-                _sortby='last-used',
-                type=ctype,
-                realm=realm,
-            )
+            creds = [
+                (name, cred) for name, cred in self._credman.query(
+                    _sortby='last-used',
+                    type=ctype,
+                    realm=realm,
+                )
+                # we can only work with complete credentials, although
+                # query() might return others. We exclude them here
+                # to be able to fall back on manual entry further down
+                if cred.get('secret')
+            ]
             if creds:
                 # we have matches, go with the last used one
                 name, cred = creds[0]


### PR DESCRIPTION
Previously, the last used credential matching a `realm` was used unconditionally. With this change all matching credentials are filtered to exclude any credentials without a secret set.

A secret might not be present for any reason (removed by an external process, or never set to begin with). Regardless of the cause for such an anomaly, such a credential can never work for authentication. Therefore, we exclude them immediately. Should no other credential matching a realm provide a secret, prompting for credential entry is attempted.

Closes #245