### PR TITLE
New `memory_keyring` fixture

### DIFF
--- a/datalad_next/commands/tests/test_credentials.py
+++ b/datalad_next/commands/tests/test_credentials.py
@@ -19,7 +19,6 @@ from ..credentials import (
 from datalad_next.exceptions import IncompleteResultsError
 from datalad_next.utils import external_versions
 from datalad_next.tests.utils import (
-    MemoryKeyring,
     assert_in,
     assert_in_results,
     assert_raises,
@@ -74,12 +73,11 @@ def test_normalize_specs():
         assert_raises(ValueError, normalize_specs, error)
 
 
-def test_credentials():
+def test_credentials(memory_keyring):
     # we want all tests to bypass the actual system keyring
-    with patch('datalad.support.keyring_.keyring', MemoryKeyring()):
-        check_credentials_cli()
-        check_interactive_entry_set()
-        check_interactive_entry_get()
+    check_credentials_cli()
+    check_interactive_entry_set()
+    check_interactive_entry_get()
 
 
 def test_errorhandling_smoketest():
@@ -185,16 +183,16 @@ def test_result_renderer():
     ))
 
 
-def test_extreme_credential_name():
+def test_extreme_credential_name(memory_keyring):
     cred = Credentials()
     extreme = 'ΔЙקم๗あ |/;&%b5{}"'
-    with patch('datalad.support.keyring_.keyring', MemoryKeyring()):
-        assert_in_results(
-            cred('set',
-                 name=extreme,
-                 # use CLI style spec to exercise more code
-                 spec=[f'someprop={extreme}', f'secret={extreme}'],
-            ),
-            cred_someprop=extreme,
-            cred_secret=extreme,
-        )
+    assert_in_results(
+        cred(
+            'set',
+            name=extreme,
+            # use CLI style spec to exercise more code
+            spec=[f'someprop={extreme}', f'secret={extreme}'],
+        ),
+        cred_someprop=extreme,
+        cred_secret=extreme,
+    )

--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -1,1 +1,48 @@
+import pytest
+
 from datalad.conftest import setup_package
+
+
+@pytest.fixture(autouse=False, scope="function")
+def memory_keyring():
+    """Patch keyring to temporarily use a backend that only stores in memory
+
+    No credential read or write actions will impact any existing credential
+    store of any configured backend.
+
+    The patched-in backend is yielded by the fixture. It offers a ``store``
+    attribute, which is a ``dict`` that uses keys of the pattern::
+
+        (datalad-<credential name>, <field name>)
+
+    and the associated secrets as values. For non-legacy credentials the
+    ``<field name>`` is uniformly ``'secret'``. For legacy credentials
+    other values are also used, including fields that are not actually
+    secrets.
+    """
+    import keyring
+    import keyring.backend
+
+    class MemoryKeyring(keyring.backend.KeyringBackend):
+        # high priority
+        priority = 1000
+
+        def __init__(self):
+            self.store = {}
+
+        def set_password(self, servicename, username, password):
+            self.store[(servicename, username)] = password
+
+        def get_password(self, servicename, username):
+            return self.store.get((servicename, username))
+
+        def delete_password(self, servicename, username):
+            del self.store[(servicename, username)]
+
+    old_backend = keyring.get_keyring()
+    new_backend = MemoryKeyring()
+    keyring.set_keyring(new_backend)
+
+    yield new_backend
+
+    keyring.set_keyring(old_backend)

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -40,7 +40,6 @@ from datalad.tests.utils_pytest import (
 )
 from datalad.tests.test_utils_testrepos import BasicGitTestRepo
 from datalad.cli.tests.test_main import run_main
-from datalad.support.keyring_ import MemoryKeyring
 from datalad_next.utils import (
     CredentialManager,
     optional_args,


### PR DESCRIPTION
This fixture provides an isolated keyring in-memory-only backend for tests that needs to store/retrieve credentials.

The fixture is function-scope, hence the backend is destroyed at the end of each test.

Closes https://github.com/datalad/datalad/issues/7295