### PR TITLE
Make dataset-lookup behavior of `credentials` identical to `download` 

### DIFF
--- a/datalad_next/commands/credentials.py
+++ b/datalad_next/commands/credentials.py
@@ -53,14 +53,14 @@ class CredentialsParamValidator(EnsureCommandParameterization):
             param_constraints=dict(
                 action=EnsureChoice(*credential_actions),
                 dataset=EnsureDataset(
-                    # we do not actually require it
-                    installed=None,
+                    # if given, it must also exist as a source for
+                    # configuration items and/or credentials
+                    installed=True,
                     purpose='manage credentials',
                 ),
                 name=EnsureStr(),
                 prompt=EnsureStr(),
             ),
-            validate_defaults=('dataset',),
             # order in joint_constraints is relevant!
             joint_constraints={
                 ParameterConstraintContext(('action', 'name', 'spec'),
@@ -296,6 +296,10 @@ class Credentials(ValidatedInterface):
     def __call__(action='query', spec=None, *, name=None, prompt=None,
                  dataset=None):
         # which config manager to use: global or from dataset
+        # It makes no sense to work with a non-existing dataset's config,
+        # due to https://github.com/datalad/datalad/issues/7299
+        # so the `dataset` validator must not run for the default value
+        # ``None``
         cfg = dataset.ds.config if dataset else dlcfg
 
         credman = CredentialManager(cfg)

--- a/datalad_next/commands/tests/test_download.py
+++ b/datalad_next/commands/tests/test_download.py
@@ -207,7 +207,7 @@ def test_download_no_credential_leak_to_http(capsys):
     # after download, it asks for a name
     'dataladtest_test_download_new_bearer_token',
 ])
-def test_download_new_bearer_token(capsys):
+def test_download_new_bearer_token(memory_keyring, capsys):
     try:
         download({f'{hbsurl}/bearer': '-'})
         # and it was saved under this name


### PR DESCRIPTION
When called with `dataset=None`, `credentials()` would auto-locate
a dataset containing CWD (and use its configuration), whereas
`download()` would use the global configuration in this case.

This change makes the behavior uniform and chooses what `download()`
did as the model behavior.

This uniformatization is meaningful on its own.

However, due to datalad/datalad#7299 it is
also a necessity, because otherwise credentials deposited by
`download()` remain invisible to `credentials()` -- which is the
superficial trigger for datalad#249

Closes datalad#249