### PR TITLE
Do credential type detection for reporting

### DIFF
--- a/datalad_next/credman/manager.py
+++ b/datalad_next/credman/manager.py
@@ -201,8 +201,9 @@ class CredentialManager(object):
             # no secret, no credential
             if any(not p.startswith('_') for p in cred):
                 lgr.debug(
-                    'Not reporting on credential fragment with no secret: %r',
-                    cred,
+                    'Not reporting on credential fragment '
+                    '(name=%r) with no secret: %r',
+                    name, cred,
                 )
             return
 
@@ -727,6 +728,17 @@ class CredentialManager(object):
         _type_hint = cred.get('type', _type_hint)
         if _type_hint:
             cred['type'] = _type_hint
+            return
+
+        # if we get here, we don't know what type this is
+        # let's derive one for a few clear-cut cases where we can be
+        # reasonable sure what type a credential is
+        if set(cred) == set(('token',)):
+            # all we have is a token property -- very likely a token-type
+            # credential. Move the token to the secret property and
+            # assign the type
+            cred['type'] = 'token'
+            cred['secret'] = cred.pop('token')
 
     def _complete_credential_props(
             self, name: str,

--- a/datalad_next/credman/tests/test_credman.py
+++ b/datalad_next/credman/tests/test_credman.py
@@ -215,6 +215,21 @@ def test_credman_get():
     assert 'mysecret' == res['secret']
 
 
+def test_credman_get_guess_type():
+    # define token-only-no-type credential in config override
+    credman = CredentialManager(
+        ConfigManager(overrides={
+            'datalad.credential.mike.token': 'some',
+        })
+    )
+    # we get it reported fine, token property converted to the
+    # 'secret' and a proper 'type' assigned
+    assert credman.get('mike') == {
+        'secret': 'some',
+        'type': 'token',
+    }
+
+
 def test_credman_obtain(memory_keyring):
     credman = CredentialManager(ConfigManager())
     # senseless, but valid call


### PR DESCRIPTION
For now the only scenario is a credential specification that comprises a token-property only.

However, with the recent RF there is now a dedicated piece of code that could be extended arbitrarily to support additional scenarios.

```
❯ DATALAD_CREDENTIAL_MIKE_TOKEN=some dl -f json_pp credentials get mike
{
  "action": "credentials",
  "cred_secret": "some",
  "cred_type": "token",
  "name": "mike",
  "status": "ok"
}

```
Closes #251