### PR TITLE
On-demand constraint-tailoring to dataset arguments

### DIFF
--- a/datalad_next/constraints/tests/test_exceptions.py
+++ b/datalad_next/constraints/tests/test_exceptions.py
@@ -1,0 +1,67 @@
+from types import MappingProxyType
+
+from ..basic import EnsureInt
+from ..exceptions import (
+    CommandParametrizationError,
+    ConstraintError,
+    ConstraintErrors,
+    ParameterConstraintContext,
+    ParameterContextErrors,
+    ParametrizationErrors,
+)
+
+
+def test_constrainterror_repr():
+    c = EnsureInt()
+    ce = ConstraintError(c, 'noint', 'yeah, bullshit')
+    assert repr(ce) == \
+        f"ConstraintError({c!r}, 'noint', 'yeah, bullshit', None)"
+
+
+def test_constrainterrors():
+    c = EnsureInt()
+    ce = ConstraintError(c, 'noint', 'yeah, bullshit')
+    emap = dict(c1=ce)
+    ces = ConstraintErrors(emap)
+    assert ces.errors == emap
+    assert isinstance(ces.errors, MappingProxyType)
+    assert repr(ces) == f"ConstraintErrors({emap!r})"
+
+
+def test_parametercontext():
+    assert str(ParameterConstraintContext(('p1',))) == 'Context<p1>'
+    assert str(ParameterConstraintContext(
+        ('p1', 'p2'),
+        'some details',
+    )) == 'Context<p1, p2 (some details)>'
+
+
+def test_parametercontexterrors():
+    c = EnsureInt()
+    ce = ConstraintError(c, 'noint', 'yeah, bullshit')
+    emap = {
+        ParameterConstraintContext(('c1',)): ce,
+    }
+    pces = ParameterContextErrors(emap)
+    assert pces.items() == emap.items()
+    assert repr(pces) == repr(emap)
+
+
+def test_parameterizationerrors():
+    c = EnsureInt()
+    ce = ConstraintError(c, 'noint', 'yeah, bullshit')
+    emap = {
+        ParameterConstraintContext(('c1',)): ce,
+    }
+    pes = ParametrizationErrors(emap)
+    assert str(pes) == """\
+1 parameter constraint violation
+c1
+  yeah, bullshit"""
+
+    # CommandParametrizationError is pretty much the same thing
+    cpes = CommandParametrizationError(emap)
+    assert str(cpes) == """\
+1 command parameter constraint violation
+c1
+  yeah, bullshit"""


### PR DESCRIPTION
This exposes a, so far dormant, feature of the `Constraint` class to
parameter validation: constraint tailoring for particular datasets.

`EnsureCommandParameterization` learned a `tailor_for_dataset` parameter
that can be used to identify which parameters' constraints should be
tailored for which `Dataset` instances. Tailoring will only be actually
done under the following conditions:

- the dataset-providing parameters need to evaluate to a
  DatasetParameter instance, typically via `EnsureDataset`
  (all regular conditions apply, e.g. a default `None` not being processed
  etc)
- the to-be-tailored parameter `Constraint` needs to implement its
  `for_dataset()` method to perform a tailoring.

A test with some custom-made constraints is included. At the moment,
no production-ready constraints do implement `for_dataset()`. However,
now that a consumer for that is available, it makes more sense to
address related issues, such as:

- #193
- #131

Closes #200