### PR TITLE
Prevent undesired configuration modifications by tests

### DIFF
--- a/datalad_next/commands/tests/test_create_sibling_webdav.py
+++ b/datalad_next/commands/tests/test_create_sibling_webdav.py
@@ -33,15 +33,15 @@ from datalad_next.utils import chpwd
 webdav_cred = ('dltest-my&=webdav', 'datalad', 'secure')
 
 
-def test_common_workflow_implicit_cred():
+def test_common_workflow_implicit_cred(datalad_cfg):
     check_common_workflow(False, 'annex')
 
 
-def test_common_workflow_explicit_cred():
+def test_common_workflow_explicit_cred(datalad_cfg):
     check_common_workflow(True, 'annex')
 
 
-def test_common_workflow_export():
+def test_common_workflow_export(datalad_cfg):
     check_common_workflow(False, 'filetree')
 
 
@@ -252,6 +252,10 @@ def test_unused_storage_name_warning(path=None):
         eq_(lgr_mock.warning.call_count, len(mode_values))
 
 
+def test_existing_switch(datalad_cfg):
+    check_existing_switch()
+
+
 @with_credential(
     'dltest-mywebdav', user=webdav_cred[1], secret=webdav_cred[2],
     type='user_password')
@@ -261,7 +265,7 @@ def test_unused_storage_name_warning(path=None):
                  'f3': '3'})
 @with_tempfile
 @serve_path_via_webdav(auth=webdav_cred[1:])
-def test_existing_switch(localpath=None, remotepath=None, url=None):
+def check_existing_switch(localpath=None, remotepath=None, url=None):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(force=True, **ca)
     # use a tricky name: '3f7' will be the hashdir of the XDLRA
@@ -402,13 +406,17 @@ def test_existing_switch(localpath=None, remotepath=None, url=None):
     assert_in(new_root / 'sub2' / 'subsub', remote_content)
 
 
+def test_result_renderer(datalad_cfg):
+    check_result_renderer()
+
+
 @with_credential(
     webdav_cred[0], user=webdav_cred[1], secret=webdav_cred[2],
     type='user_password')
 @with_tempfile
 @with_tempfile
 @serve_path_via_webdav(auth=webdav_cred[1:])
-def test_result_renderer(localpath=None, remotepath=None, url=None):
+def check_result_renderer(localpath=None, remotepath=None, url=None):
     ca = dict(result_renderer='disabled')
     ds = Dataset(localpath).create(**ca)
     # need to amend the test credential, can only do after we know the URL

--- a/datalad_next/commands/tests/test_credentials.py
+++ b/datalad_next/commands/tests/test_credentials.py
@@ -183,7 +183,7 @@ def test_result_renderer():
     ))
 
 
-def test_extreme_credential_name(memory_keyring):
+def test_extreme_credential_name(memory_keyring, datalad_cfg):
     cred = Credentials()
     extreme = 'ΔЙקم๗あ |/;&%b5{}"'
     assert_in_results(

--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -104,9 +104,14 @@ def datalad_cfg():
             "only supported since Git v2.32"
         )
     from datalad import cfg
-    with NamedTemporaryFile('w') as tf:
+    with NamedTemporaryFile(
+            'w',
+            prefix='datalad_gitcfg_global_',
+            delete=False) as tf:
         tf.write(standard_gitconfig)
-        tf.flush()
+        # we must close, because windows does not like the file being open
+        # already when ConfigManager would open it for reading
+        tf.close()
         with patch.dict(os.environ, {'GIT_CONFIG_GLOBAL': tf.name}):
             cfg.reload(force=True)
             yield cfg

--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -147,7 +147,11 @@ def check_gitconfig_global():
         "a temporary configuration target. Hint: use the `datalad_cfg` fixture."
 
 
-@pytest.fixture(autouse=True, scope="function")
+# TODO this fixture is NOT used by default, because the memory_keyring
+# fixture that should prevent these kinds of errors is not sufficient,
+# because we need to be able to communicate credentials across processes
+# (datalad -> special/git remote and back)
+@pytest.fixture(autouse=False, scope="function")
 def check_plaintext_keyring():
     """No test must modify a user's keyring.
 

--- a/datalad_next/credman/tests/test_credman.py
+++ b/datalad_next/credman/tests/test_credman.py
@@ -10,7 +10,6 @@
 
 """
 import pytest
-from unittest.mock import patch
 
 from datalad.config import ConfigManager
 from ..manager import (
@@ -165,9 +164,8 @@ def test_credman_local(path=None):
     credman.remove('notstupid')
 
 
-def test_query(memory_keyring):
-    cfg = ConfigManager()
-    credman = CredentialManager(cfg)
+def test_query(memory_keyring, datalad_cfg):
+    credman = CredentialManager(datalad_cfg)
     # set a bunch of credentials with a common realm AND timestamp
     for i in range(3):
         credman.set(
@@ -200,9 +198,9 @@ def test_query(memory_keyring):
         [i[0] for i in slist])
 
 
-def test_credman_get():
+def test_credman_get(datalad_cfg):
     # we are not making any writes, any config must work
-    credman = CredentialManager(ConfigManager())
+    credman = CredentialManager(datalad_cfg)
     # must be prompting for missing properties
     res = with_testsui(responses=['myuser'])(credman.get)(
         None, _type_hint='user_password', _prompt='myprompt',
@@ -230,8 +228,8 @@ def test_credman_get_guess_type():
     }
 
 
-def test_credman_obtain(memory_keyring):
-    credman = CredentialManager(ConfigManager())
+def test_credman_obtain(memory_keyring, datalad_cfg):
+    credman = CredentialManager(datalad_cfg)
     # senseless, but valid call
     # could not possibly report a credential without any info
     with pytest.raises(ValueError):

--- a/datalad_next/credman/tests/test_credman.py
+++ b/datalad_next/credman/tests/test_credman.py
@@ -30,9 +30,8 @@ from datalad_next.datasets import Dataset
 from datalad_next.utils import chpwd
 
 
-def test_credmanager(memory_keyring):
-    cfg = ConfigManager()
-    credman = CredentialManager(cfg)
+def test_credmanager(memory_keyring, datalad_cfg):
+    credman = CredentialManager(datalad_cfg)
     # doesn't work with thing air
     assert_raises(ValueError, credman.get)
     eq_(credman.get('donotexiststest'), None)
@@ -72,15 +71,16 @@ def test_credmanager(memory_keyring):
     eq_(credman.set('changed', prop='val'), dict())
     # change secret, with value pulled from config
     try:
-        cfg.set('datalad.credential.changed.secret', 'envsec',
-                scope='override')
+        datalad_cfg.set('datalad.credential.changed.secret', 'envsec',
+                        scope='override')
         eq_(credman.set('changed', secret=None), dict(secret='envsec'))
     finally:
-        cfg.unset('datalad.credential.changed.secret', scope='override')
+        datalad_cfg.unset('datalad.credential.changed.secret',
+                          scope='override')
 
     # remove non-existing property, secret not report, because unchanged
     eq_(credman.set('mycred', dummy=None), dict(dummy=None))
-    assert_not_in(_get_cred_cfg_var("mycred", "dummy"), cfg)
+    assert_not_in(_get_cred_cfg_var("mycred", "dummy"), datalad_cfg)
 
     # set property
     eq_(credman.set('mycred', dummy='good', this='that'),

--- a/datalad_next/gitremotes/tests/test_datalad_annex.py
+++ b/datalad_next/gitremotes/tests/test_datalad_annex.py
@@ -348,6 +348,10 @@ def test_submodule_url(servepath=None, url=None, workdir=None):
     eq_(tobesubds.id, subdsclone.id)
 
 
+def test_webdav_auth(datalad_cfg):
+    check_webdav_auth()
+
+
 @with_credential(
     'dltest-mystuff', user=webdav_cred[0], secret=webdav_cred[1],
     type='user_password')
@@ -355,7 +359,7 @@ def test_submodule_url(servepath=None, url=None, workdir=None):
 @with_tempfile
 @with_tempfile
 @serve_path_via_webdav(auth=webdav_cred)
-def test_webdav_auth(preppath=None, clnpath=None, remotepath=None, webdavurl=None):
+def check_webdav_auth(preppath=None, clnpath=None, remotepath=None, webdavurl=None):
     # this is the dataset we want to roundtrip through webdav
     ds = Dataset(preppath).create(annex=False, result_renderer='disabled')
 

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -40,6 +40,7 @@ from datalad.tests.utils_pytest import (
 )
 from datalad.tests.test_utils_testrepos import BasicGitTestRepo
 from datalad.cli.tests.test_main import run_main
+from datalad.utils import md5sum
 from datalad_next.utils import (
     CredentialManager,
     optional_args,

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -1,9 +1,11 @@
 import logging
 from functools import wraps
+from os import environ
 from pathlib import Path
 
 import urllib
 
+from datalad.support.external_versions import external_versions
 # all datalad-core test utils needed for datalad-next
 from datalad.tests.utils_pytest import (
     DEFAULT_BRANCH,
@@ -202,3 +204,16 @@ def get_httpbin_urls():
         http=hburl,
         https=hbsurl,
     )
+
+
+def get_git_config_global_fpath() -> Path:
+    """Returns the file path for the "global" (aka user) Git config scope"""
+    fpath = environ.get('GIT_CONFIG_GLOBAL')
+    if fpath is None:
+        # this can happen with the datalad-core setup for Git < 2.32.
+        # we provide a fallback, but we do not aim to support all
+        # possible variants
+        fpath = Path(environ['HOME']) / '.gitconfig'
+
+    fpath = Path(fpath)
+    return fpath


### PR DESCRIPTION
The background for this is https://github.com/datalad/datalad/issues/7297

TODO

- [x] on windows, the `datalad_cfg` fixture fails, because the file cannot be opened by to different processes
- [x] also include a similar fixture for confirming that no keyring modifications are left behind
- [x] `datalad_next/commands/tests/test_create_sibling_webdav.py::test_common_workflow_implicit_cred - AssertionError: Global Git config modification detected.`
- [x] `datalad_next/commands/tests/test_create_sibling_webdav.py::test_existing_switch - AssertionError: Global Git config modification detected.`
- [x] `datalad_next/commands/tests/test_credentials.py::test_extreme_credential_name - AssertionError: Global Git config modification detected. `
- [x] `datalad_next/credman/tests/test_credman.py::test_credmanager - AssertionError: Global Git config modification detected.`
- [x] `datalad_next/credman/tests/test_credman.py::test_credman_obtain - AssertionError: Global Git config modification detected.`
- [x] `datalad_next/gitremotes/tests/test_datalad_annex.py::test_webdav_auth - AssertionError: Global Git config modification detected.`