### PR TITLE
BF: Teach _execute_command to handle DatasetParameters

### DIFF
--- a/datalad_next/patches/interface_utils.py
+++ b/datalad_next/patches/interface_utils.py
@@ -33,7 +33,7 @@ from datalad.interface.utils import (
 )
 from datalad_next.exceptions import IncompleteResultsError
 from datalad_next.utils.patch import apply_patch
-
+from datalad_next.constraints.dataset import DatasetParameter
 
 # use same logger as -core
 lgr = logging.getLogger('datalad.interface.utils')
@@ -169,6 +169,8 @@ def _execute_command_(
         from datalad_next.datasets import Dataset
         if isinstance(dataset_arg, Dataset):
             ds = dataset_arg
+        elif isinstance(dataset_arg, DatasetParameter):
+            ds = dataset_arg.ds
         else:
             try:
                 ds = Dataset(dataset_arg)


### PR DESCRIPTION
fixes #266

This piece of code was not able to handle DatasetParameter objects, and instead crash with a ValueError. This patch should fix this.