### PR TITLE
Implement EnsurePath.for_dataset() and resolve against that dataset

### DIFF
--- a/datalad_next/constraints/base.py
+++ b/datalad_next/constraints/base.py
@@ -5,19 +5,25 @@ from __future__ import annotations
 
 __docformat__ = 'restructuredtext'
 
-__all__ = ['Constraint', 'Constraints', 'AltConstraints']
-
-from typing import (
-    TYPE_CHECKING,
-    TypeVar,
-)
+__all__ = ['Constraint', 'Constraints', 'AltConstraints',
+           'DatasetParameter']
 
 from .exceptions import ConstraintError
 
-if TYPE_CHECKING:  # pragma: no cover
-    from datalad_next.datasets import Dataset
 
-DatasetDerived = TypeVar('DatasetDerived', bound='Dataset')
+class DatasetParameter:
+    """Utitlity class to report an original and resolve dataset parameter value
+
+    This is used by `EnsureDataset` to be able to report the original argument
+    semantics of a dataset parameter to a receiving command. It is consumed
+    by any ``Constraint.for_dataset()``.
+
+    The original argument is provided via the `original` property.
+    A corresponding `Dataset` instance is provided via the `ds` property.
+    """
+    def __init__(self, original, ds):
+        self.original = original
+        self.ds = ds
 
 
 class Constraint:
@@ -67,7 +73,7 @@ class Constraint:
         # used as a condensed primer for the parameter lists
         raise NotImplementedError("abstract class")
 
-    def for_dataset(self, dataset: DatasetDerived) -> Constraint:
+    def for_dataset(self, dataset: DatasetParameter) -> Constraint:
         """Return a constraint-variant for a specific dataset context
 
         The default implementation returns the unmodified, identical

--- a/datalad_next/constraints/compound.py
+++ b/datalad_next/constraints/compound.py
@@ -13,7 +13,7 @@ from typing import (
 
 from .base import (
     Constraint,
-    DatasetDerived,
+    DatasetParameter,
 )
 
 
@@ -187,7 +187,7 @@ class EnsureMapping(Constraint):
         val = self._value_constraint(val)
         return {key: val}
 
-    def for_dataset(self, dataset: DatasetDerived):
+    def for_dataset(self, dataset: DatasetParameter) -> Constraint:
         # tailor both constraints to the dataset and reuse delimiter
         return EnsureMapping(
             key=self._key_constraint.for_dataset(dataset),
@@ -309,7 +309,7 @@ class ConstraintWithPassthrough(Constraint):
         return f'{self.__class__.__name__}' \
                f'({self._constraint!r}, passthrough={self._passthrough!r})'
 
-    def for_dataset(self, dataset: DatasetDerived) -> Constraint:
+    def for_dataset(self, dataset: DatasetParameter) -> Constraint:
         """Wrap the wrapped constraint again after tailoring it for the dataset
 
         The pass-through value is re-used.

--- a/datalad_next/constraints/dataset.py
+++ b/datalad_next/constraints/dataset.py
@@ -1,5 +1,7 @@
 """Constraints for DataLad datasets"""
 
+from __future__ import annotations
+
 from pathlib import (
     Path,
     PurePath,
@@ -7,22 +9,11 @@ from pathlib import (
 
 from datalad_next.datasets import Dataset
 
-from .base import Constraint
+from .base import (
+    Constraint,
+    DatasetParameter,
+)
 from .exceptions import NoDatasetFound
-
-
-class DatasetParameter:
-    """Utitlity class to report an original and resolve dataset parameter value
-
-    This is used by `EnsureDataset` to be able to report the original argument
-    semantics of a dataset parameter to a receiving command.
-
-    The original argument is provided via the `original` property.
-    A corresponding `Dataset` instance is provided via the `ds` property.
-    """
-    def __init__(self, original, ds):
-        self.original = original
-        self.ds = ds
 
 
 class EnsureDataset(Constraint):
@@ -50,7 +41,9 @@ class EnsureDataset(Constraint):
     the DataLad core package). With ``installed=False`` no exception is
     raised and a dataset instances matching PWD is returned.
     """
-    def __init__(self, installed: bool = None, purpose: str = None):
+    def __init__(self,
+                 installed: bool | None = None,
+                 purpose: str | None = None):
         """
         Parameters
         ----------

--- a/datalad_next/constraints/parameter.py
+++ b/datalad_next/constraints/parameter.py
@@ -510,7 +510,7 @@ class EnsureCommandParameterization(Constraint):
             tailor_for = self._tailor_for_dataset.get(argname)
             if tailor_for and isinstance(validated.get(tailor_for),
                                          DatasetParameter):
-                validator = validator.for_dataset(validated[tailor_for].ds)
+                validator = validator.for_dataset(validated[tailor_for])
 
             try:
                 validated[argname] = validator(arg)

--- a/datalad_next/constraints/tests/test_basic.py
+++ b/datalad_next/constraints/tests/test_basic.py
@@ -1,6 +1,9 @@
 import pathlib
 import pytest
 
+from datalad_next.datasets import Dataset
+
+from ..base import DatasetParameter
 from ..basic import (
     EnsureInt,
     EnsureFloat,
@@ -299,3 +302,20 @@ def test_EnsurePath(tmp_path):
     c = EnsurePath(ref=target, ref_is='stupid')
     with pytest.raises(ValueError):
         c('doesnotmatter')
+
+
+def test_EnsurePath_fordataset(tmp_path):
+    P = pathlib.Path
+    ds = Dataset(tmp_path).create(result_renderer='disabled')
+    # standard: relative in, relative out
+    c = EnsurePath()
+    assert c('relpath') == P('relpath')
+    # tailor constraint for our dataset
+    # (this is what would be done by EnsureCommandParameterization
+    # 1. dataset given as a path -- resolve against CWD
+    #    output is always absolute
+    tc = c.for_dataset(DatasetParameter(tmp_path, ds))
+    assert tc('relpath') == (P.cwd() / 'relpath')
+    # 2. dataset is given as a dataset object
+    tc = c.for_dataset(DatasetParameter(ds, ds))
+    assert tc('relpath') == (ds.pathobj / 'relpath')

--- a/datalad_next/constraints/tests/test_cmdarg_validation.py
+++ b/datalad_next/constraints/tests/test_cmdarg_validation.py
@@ -255,8 +255,8 @@ class EnsureUUID(Constraint):
 class EnsureDatasetID(EnsureUUID):
     """Makes sure that something is a dataset ID (UUID), or the dataset UUID
     of a particular dataset when tailored"""
-    def for_dataset(self, ds):
-        return EnsureValue(UUID(ds.id))
+    def for_dataset(self, dsarg):
+        return EnsureValue(UUID(dsarg.ds.id))
 
 
 class DsTailoringValidator(EnsureCommandParameterization):


### PR DESCRIPTION
This implements DataLad's standard path resolution approach (relative
is relative to CWD, unless a `Dataset` instance is given).

This now makes it possible to perform this standard resolution pattern
during command parameter validation, like so:

```py
# example validator for a command with two args
EnsureCommandParameterization(
    param_constraints=dict(
        dataset=EnsureDataset(),
        path=EnsurePath(),
    ),
    tailor_for_dataset=dict(path='dataset'),
)
```

This will:

- cause the 'dataset' validator to run first
- auto-generate an `EnsurePath` variant that resolves against that
  dataset
- ensures that the command always receives absolute paths, resolved
  against the dataset whenever the rules require it.

Closes #270