### PR TITLE
Rectify implicit optional type annotation

### DIFF
--- a/datalad_next/commands/tree.py
+++ b/datalad_next/commands/tree.py
@@ -8,6 +8,8 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 """'tree'-like command for visualizing dataset hierarchies"""
 
+from __future__ import annotations
+
 __docformat__ = "numpy"
 
 import logging
@@ -1015,7 +1017,7 @@ class _TreeNode:
     TYPE = None  # needed for command result dict
 
     def __init__(self, path: Path, depth: int,
-                 exception: CapturedException = None):
+                 exception: CapturedException | None = None):
         """
         Parameters
         ----------

--- a/datalad_next/constraints/basic.py
+++ b/datalad_next/constraints/basic.py
@@ -126,7 +126,7 @@ class EnsureStr(Constraint):
 
     No type conversion is performed.
     """
-    def __init__(self, min_len: int = 0, match: str = None):
+    def __init__(self, min_len: int = 0, match: str | None = None):
         """
         Parameters
         ----------
@@ -341,10 +341,10 @@ class EnsurePath(Constraint):
     def __init__(self,
                  *,
                  path_type: type = Path,
-                 is_format: str or None = None,
-                 lexists: bool or None = None,
-                 is_mode: callable = None,
-                 ref: Path = None,
+                 is_format: str | None = None,
+                 lexists: bool | None = None,
+                 is_mode: callable | None = None,
+                 ref: Path | None = None,
                  ref_is: str = 'parent-or-same-as',
                  dsarg: DatasetParameter | None = None):
         """

--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Dict
+from typing import (
+    Any,
+    Dict,
+)
 
 import datalad
 from datalad_next.utils import log_progress
@@ -393,6 +396,6 @@ class UrlOperationsAuthorizationError(UrlOperationsRemoteError):
                  url: str,
                  credential: dict | None = None,
                  message: str | None = None,
-                 status_code: Any = None):
+                 status_code: Any | None = None):
         super().__init__(url, message=message, status_code=status_code)
         self.credential = credential

--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -38,7 +38,7 @@ class DataladAuth(requests.auth.AuthBase):
         'bearer': 'token',
     }
 
-    def __init__(self, cfg: CredentialManager, credential: str = None):
+    def __init__(self, cfg: CredentialManager, credential: str | None = None):
         """
         Parameters
         ----------
@@ -51,8 +51,8 @@ class DataladAuth(requests.auth.AuthBase):
         self._credential = credential
         self._entered_credential = None
 
-    def save_entered_credential(self, suggested_name: str = None,
-                                context: str = None) -> Dict | None:
+    def save_entered_credential(self, suggested_name: str | None = None,
+                                context: str | None = None) -> Dict | None:
         """Utility method to save a pending credential in the store
 
         Pending credentials have been entered manually, and were subsequently


### PR DESCRIPTION
This is now establishing a uniform PEP 604 style `X | None` notation in the code base.

Closes #153