### PR TITLE
NF: Add EnsureSet to test for a required set of elements

### DIFF
--- a/datalad_next/constraints/__init__.py
+++ b/datalad_next/constraints/__init__.py
@@ -25,7 +25,7 @@ from .basic import (
     EnsureKeyChoice,
     EnsureNone,
     EnsurePath,
-    EnsureSet,
+    EnsureContainsSet,
     EnsureStr,
     EnsureRange,
     EnsureValue,

--- a/datalad_next/constraints/__init__.py
+++ b/datalad_next/constraints/__init__.py
@@ -25,6 +25,7 @@ from .basic import (
     EnsureKeyChoice,
     EnsureNone,
     EnsurePath,
+    EnsureSet,
     EnsureStr,
     EnsureRange,
     EnsureValue,

--- a/datalad_next/constraints/basic.py
+++ b/datalad_next/constraints/basic.py
@@ -283,6 +283,39 @@ class EnsureKeyChoice(EnsureChoice):
         return '%s:{%s}' % (self._key, ', '.join([repr(c) for c in self._allowed]))
 
 
+class EnsureSet(Constraint):
+    """Ensure an input contains all elements of a set of required values"""
+
+    def __init__(self, *values):
+        """
+        Parameters
+        ----------
+        *values
+           required values.
+        """
+        self._required = set(values)
+        super(EnsureSet, self).__init__()
+
+    def __call__(self, value):
+        if not self._required.issubset(set(value)):
+            self.raise_for(
+                value,
+                "missing {required}",
+                required=self._required,
+            )
+        return value
+
+    def long_description(self):
+        return 'All following fields are required: [CMD: %s CMD][PY: %s PY]' % (
+            str(tuple(i for i in self._required if i is not None)),
+            str(self._required)
+        )
+
+    def short_description(self):
+        return '{%s}' % ', '.join([repr(c) for c in sorted(self._required)])
+
+
+
 class EnsureRange(Constraint):
     """Ensure an input is within a particular range
 

--- a/datalad_next/constraints/basic.py
+++ b/datalad_next/constraints/basic.py
@@ -283,7 +283,7 @@ class EnsureKeyChoice(EnsureChoice):
         return '%s:{%s}' % (self._key, ', '.join([repr(c) for c in self._allowed]))
 
 
-class EnsureSet(Constraint):
+class EnsureContainsSet(Constraint):
     """Ensure an input contains all elements of a set of required values"""
 
     def __init__(self, *values):
@@ -294,7 +294,7 @@ class EnsureSet(Constraint):
            required values.
         """
         self._required = set(values)
-        super(EnsureSet, self).__init__()
+        super(EnsureContainsSet, self).__init__()
 
     def __call__(self, value):
         if not self._required.issubset(set(value)):

--- a/datalad_next/constraints/tests/test_basic.py
+++ b/datalad_next/constraints/tests/test_basic.py
@@ -8,6 +8,7 @@ from ..basic import (
     EnsureInt,
     EnsureFloat,
     EnsureBool,
+    EnsureSet,
     EnsureStr,
     EnsureStrPrefix,
     EnsureNone,
@@ -218,6 +219,23 @@ def test_keychoice():
         c({'some': 'None'})
     with pytest.raises(ValueError):
         c({'some': ('a', 'b')})
+
+
+def test_set():
+    c = EnsureSet('req1', 'req2')
+    descr = c.long_description()
+    for i in ('req1', 'req2'):
+        assert i in descr
+    assert c.short_description() == "{'req1', 'req2'}"
+    assert c(value=['req1', 'req2']) == ['req1', 'req2']
+    # not all required elements included
+    with pytest.raises(ValueError):
+        c(('req1'))
+    # unknown elements included
+    with pytest.raises(ValueError):
+        c(('req3', 'nonreq'))
+    # additional elements on top of all required elements should be ok
+    assert c(value=['req1', 'req2', 'req3']) == ['req1', 'req2', 'req3']
 
 
 def test_range():

--- a/datalad_next/constraints/tests/test_basic.py
+++ b/datalad_next/constraints/tests/test_basic.py
@@ -8,7 +8,7 @@ from ..basic import (
     EnsureInt,
     EnsureFloat,
     EnsureBool,
-    EnsureSet,
+    EnsureContainsSet,
     EnsureStr,
     EnsureStrPrefix,
     EnsureNone,
@@ -221,8 +221,8 @@ def test_keychoice():
         c({'some': ('a', 'b')})
 
 
-def test_set():
-    c = EnsureSet('req1', 'req2')
+def test_containsset():
+    c = EnsureContainsSet('req1', 'req2')
     descr = c.long_description()
     for i in ('req1', 'req2'):
         assert i in descr


### PR DESCRIPTION
Here's an attempt to write a new Constraint. Its name is not yet perfect, but so far the best I've come up with. I think the messaging also isn't yet ideal - any feedback is very welcome. My usecase for this constraint is a check whether all required keys in an input dictionary are set. Unlike EnsureChoice(), this constraint allows for more than one item. This constraint also allows additional elements to be present, as long as all requirement elements are found. Fixes #282
