### PR TITLE
Add EnsureMappings constraint for input with several key-value pairs

### DIFF
--- a/datalad_next/constraints/__init__.py
+++ b/datalad_next/constraints/__init__.py
@@ -35,6 +35,7 @@ from .compound import (
     EnsureListOf,
     EnsureTupleOf,
     EnsureMapping,
+    EnsureNTuple,
     EnsureGeneratorFromFileLike,
 )
 # this is the key type, almost all consuming code will want to

--- a/datalad_next/constraints/__init__.py
+++ b/datalad_next/constraints/__init__.py
@@ -36,6 +36,7 @@ from .compound import (
     EnsureTupleOf,
     EnsureMapping,
     EnsureNTuple,
+    EnsureDict,
     EnsureGeneratorFromFileLike,
 )
 # this is the key type, almost all consuming code will want to

--- a/datalad_next/constraints/compound.py
+++ b/datalad_next/constraints/compound.py
@@ -214,6 +214,86 @@ class EnsureMapping(Constraint):
         )
 
 
+class EnsureMappings(Constraint):
+    """Ensure several mappings of keys to values of a specific nature"""
+
+    def __init__(self,
+                 key: Constraint,
+                 value: Constraint,
+                 delimiter: str = ':',
+                 pair_delimiter: str = ',',
+                 allow_length2_sequence: bool = True
+                 ):
+        """
+        Parameters
+        ----------
+        key:
+          Key constraint instance.
+        value:
+          Value constraint instance.
+        delimiter:
+          Delimiter to use for splitting a key from a value for a `str` input.
+        pair_delimiter:
+          Delimiter to use for splitting key-value pairs from another for a str
+          input.
+        """
+        super().__init__()
+        self._key_constraint = key
+        self._value_constraint = value
+        self._delimiter = delimiter
+        self._pair_delimiter = pair_delimiter
+        self._allow_length2_sequence: bool = True
+
+    def short_description(self):
+        return 'mapping of {} -> {}'.format(
+            self._key_constraint.short_description(),
+            self._value_constraint.short_description(),
+        )
+
+    def _get_keys_values(self, value) -> tuple:
+        # determine key and value from various kinds of input
+        if isinstance(value, str):
+            # split into pairs
+            # TODO: what about whitespace? e.g., 'key: val', 'morekey': moreval'
+            pairs = value.split(sep=self._pair_delimiter)
+            keys_n_values = [p.split(sep=self._delimiter, maxsplit=1) for p in pairs]
+            try:
+                keys = [p[0] for p in keys_n_values]
+                vals = [p[1] for p in keys_n_values]
+            except IndexError as e:
+                raise(ValueError('Could not cast input to key value pairs'))
+        elif isinstance(value, dict):
+            if not len(value):
+                raise ValueError('dict does not contain a key')
+            keys = list(value.keys())
+            vals = list(value.values())
+        elif self._allow_length2_sequence and isinstance(value, (list, tuple)):
+            if not len(value) % 2 == 0 or len(value) < 2:
+                raise ValueError('sequence can not be chunked into pairs by 2')
+            keys = value[::2]
+            vals = value[1::2]
+        else:
+            raise ValueError(f'Unsupported data type for mapping: {value!r}')
+
+        return keys, vals
+
+    def __call__(self, value) -> Dict:
+        keys, vals = self._get_keys_values(value)
+        keys = [self._key_constraint(k) for k in keys]
+        vals = [self._value_constraint(v) for v in vals]
+        return dict(zip(keys, vals))
+
+    def for_dataset(self, dataset: DatasetParameter) -> Constraint:
+        # tailor both constraints to the dataset and reuse delimiter
+        return EnsureMappings(
+            key=self._key_constraint.for_dataset(dataset),
+            value=self._value_constraint.for_dataset(dataset),
+            delimiter=self._delimiter,
+            pair_delimiter=self._pair_delimiter,
+            allow_length2_sequence=self._allow_length2_sequence
+        )
+
+
 class EnsureGeneratorFromFileLike(Constraint):
     """Ensure a constraint for each item read from a file-like.
 

--- a/datalad_next/constraints/tests/test_compound.py
+++ b/datalad_next/constraints/tests/test_compound.py
@@ -3,17 +3,14 @@ from io import StringIO
 import pytest
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
-from pathlib import Path
 
 from datalad_next.datasets import Dataset
 from datalad_next.utils import on_windows
 
-from ..base import DatasetParameter
 
 from ..basic import (
     EnsureInt,
     EnsureBool,
-    EnsurePath,
     EnsureStr,
 )
 from ..compound import (
@@ -22,8 +19,8 @@ from ..compound import (
     EnsureListOf,
     EnsureTupleOf,
     EnsureNTuple,
+    EnsureDict,
     EnsureMapping,
-    EnsureMappings,
     EnsureGeneratorFromFileLike,
 )
 
@@ -115,6 +112,41 @@ def test_EnsureNTuple(tmp_path):
     assert c.__repr__() == 'EnsureNTuple (itemconstraints={})'.format([const for const in [EnsureInt()]*5])
 
 
+def test_EnsureDict(tmp_path):
+    true_res = dict(some=1, more=2)
+    c = EnsureDict(key=EnsureStr(), value=EnsureInt(),
+                   allow_length2_sequence=True)
+    # test different types of input
+    for v in [
+        {'some': 1, 'more': 2},
+        ['some', 1, 'more', 2],
+        ('some', 1, 'more', 2)
+    ]:
+        assert c(v) == true_res
+    # expected failures
+    for v in [
+        # keys/vals fail constraints
+        {'some': 'thing', 'more': 'than'},
+        [1, 'some', 2, 'more'],
+        # can't work with strings
+        'some:1,more:2',
+        # too short
+        {},
+        # can't divide by two
+        [1, 'some', 2]
+    ]:
+        with pytest.raises(ValueError):
+            c(v)
+    # fails to work with sequences when not told to
+    c = EnsureDict(key=EnsureStr(), value=EnsureInt(),
+                   allow_length2_sequence=False)
+    with pytest.raises(ValueError):
+        c(['some', 1, 'more', 2])
+
+    assert c.short_description() == 'mapping of key-values to {} : {}'.format(
+            EnsureStr().short_description(), EnsureInt().short_description())
+
+
 def test_EnsureMapping(tmp_path):
     true_key = 5
     true_value = False
@@ -157,59 +189,6 @@ def test_EnsureMapping(tmp_path):
     assert cds._key_constraint == constraint._key_constraint.for_dataset(ds)
     assert cds._value_constraint == \
         constraint._value_constraint.for_dataset(ds)
-
-
-def test_EnsureMappings(tmp_path):
-    # test scenarios that should work
-    true_keys = ['one', 'two', 'three']
-    true_vals = [1, 2, 3]
-    constraint = EnsureMappings(key=EnsureStr(), value=EnsureInt())
-    assert 'mapping of str -> int' in constraint.short_description()
-
-    for v in ('one:1,two:2,three:3',  # string input
-              {'one': 1, 'two': 2, 'three': 3},   # dict input
-              dict(one=1, two=2, three=3),
-              ['one', 1, 'two', 2, 'three', 3]  # sequence input
-    ):
-        d = constraint(v)
-        assert isinstance(d, dict)
-        assert len(d) == 3
-        assert list(d.keys()) == true_keys
-        assert list(d.values()) == true_vals
-
-    # test scenarios that should crash
-    for v in (true_keys,  # non-module 2 sequence
-              '5',
-              [],  # too short sequence
-              tuple(),
-              {},
-              [5, False, False],
-              set('wtf')  # wrong data type
-              ):
-        with pytest.raises(ValueError):
-            d = constraint(v)
-
-    # test different delimiters
-    constraint = EnsureMappings(key=EnsureStr(), value=EnsureInt(),
-                                delimiter='=', pair_delimiter='.')
-    d = constraint('one=1.two=2.three=3')
-    assert isinstance(d, dict)
-    assert len(d) == 3
-    assert list(d.keys()) == true_keys
-    assert list(d.values()) == true_vals
-    # test that the paths are resolved for the dataset
-    ds = Dataset(tmp_path)
-    pathconstraint = \
-        EnsureMappings(key=EnsurePath(), value=EnsureInt()).for_dataset(
-            DatasetParameter(tmp_path, ds))
-    assert pathconstraint('some:5,somemore:6') == \
-           {(Path.cwd() / 'some'): 5, Path.cwd() / 'somemore': 6}
-    pathconstraint = \
-        EnsureMappings(key=EnsurePath(), value=EnsurePath()).for_dataset(
-            DatasetParameter(ds, ds))
-    assert pathconstraint('some:other,something:more') == \
-           {(ds.pathobj / 'some'): (ds.pathobj / 'other'),
-            (ds.pathobj / 'something'): (ds.pathobj / 'more')}
 
 
 def test_EnsureGeneratorFromFileLike():


### PR DESCRIPTION
Fixes #283

~This adds an ``EnsureMappings()`` constraint, which closely mimics ``EnsureMapping()``, but handles input consisting of multiple key value pairs. 
I'm not sure if I should take into account the fact that a mapping could get really long, though. I think I could base at least parts of this on ``itertools`` methods - what do you think about that?~

Update/Edit: Based on discussions in #290 and here, I have reworked this PR. I would be grateful if someone could check if it contains anything of use - I got entangled a bit too deep have currently lost orientation as for "why" the changes are needed. I'll make attempt to support some of the stuff that ``meta-add`` is doing, and then I might get the full picture again. 

The changes I added now are:

- I realized that ``EnsureMapping`` can not easily be replaced because ``EnsureParameterConstraint`` relies on it. The remainder of what I have implemented contains at least parts of its functionality, though, so I'm not sure if my PR adds anything of value.
- Instead of touching `EnsureMapping`, I have for now just added an additional ``EnsureNTuple`` Constraint that was supposed to replace it in #290. ``EnsureNTuple`` has the ability to take a list of Constraints, match the constraints to the input values, and returns the outcome as a tuple.  The difference between the existing ``EnsureTupleOf`` and ``EnsureNTuple`` is the ability to define different constraints for different items.
- I have added the functionality to split strings by a delimiter into the base class ``EnsureIterableOf`` in an attempt to reduce code duplication (as ``EnsureMapping`` contained this functionality first). ``EnsureNTuple`` derives from ``EnsureIterableOf`` to make use of string splitting; however that decision should receive a review because its not really elegant - I needed to initialize the super with a ``NoConstraint()`` to not violate its parameters.
- I have added the Constraint ``EnsureDict``, which returns input as a dict and can apply constraints separately to keys and values. Its similar to the previous attempts of ``EnsureMappings``, but does not do any string splitting. This constraint, too, overlaps with what ``EnsureMapping`` does, so I'm not sure if it has inherent value.


Because I'm quite uncertain about the future of any of these changes, I'm putting the PR into draft mode.