### PR TITLE
Test fixtured `dataset` and `existing_dataset`

### DIFF
--- a/datalad_next/annexremotes/tests/test_uncurl.py
+++ b/datalad_next/annexremotes/tests/test_uncurl.py
@@ -153,8 +153,8 @@ def test_uncurl_checkurl(tmp_path):
 
 
 # sibling of `test_uncurl_checkurl()`, but more high-level
-def test_uncurl_addurl_unredirected(tmp_path):
-    ds = EnsureDataset()(tmp_path / 'ds').ds.create(**res_kwargs)
+def test_uncurl_addurl_unredirected(existing_dataset):
+    ds = existing_dataset
     dsca = ds.repo.call_annex
     # same set as in `test_uncurl_checkurl()`
     dsca(['initremote', 'myuncurl'] + std_initargs + [
@@ -315,8 +315,8 @@ def test_uncurl_ria_access(tmp_path):
     assert (ds.pathobj / target_fname).read_text() == testfile_content
 
 
-def test_uncurl_store(tmp_path):
-    ds = EnsureDataset()(tmp_path / 'ds').ds.create(**res_kwargs)
+def test_uncurl_store(tmp_path, existing_dataset):
+    ds = existing_dataset
     testfile = ds.pathobj / 'testfile1.txt'
     testfile_content = 'uppytyup!'
     testfile.write_text(testfile_content)
@@ -326,7 +326,7 @@ def test_uncurl_store(tmp_path):
     # as annex/objects within a bare remote repo
     dsca(['initremote', 'myuncurl'] + std_initargs + [
         # intentional double-braces at the end to get templates into the template
-        f'url={(tmp_path / "upload").as_uri()}/{{annex_dirhash_lower}}{{annex_key}}/{{annex_key}}',
+        f'url={(tmp_path).as_uri()}/{{annex_dirhash_lower}}{{annex_key}}/{{annex_key}}',
     ])
     # store file at remote
     dsca(['copy', '-t', 'myuncurl', str(testfile)])
@@ -335,7 +335,7 @@ def test_uncurl_store(tmp_path):
     # doublecheck
     testfile_props = ds.status(testfile, annex='basic',
                                return_type='item-or-list', **res_kwargs)
-    assert (tmp_path / "upload" / testfile_props['hashdirlower'] /
+    assert (tmp_path / testfile_props['hashdirlower'] /
             testfile_props['key'] / testfile_props['key']
         ).read_text() == testfile_content
     # we have no URLs recorded
@@ -367,8 +367,8 @@ def test_uncurl_store(tmp_path):
 
 
 @skip_ssh
-def test_uncurl_store_via_ssh(tmp_path):
-    ds = EnsureDataset()(tmp_path / 'ds').ds.create(**res_kwargs)
+def test_uncurl_store_via_ssh(tmp_path, existing_dataset):
+    ds = existing_dataset
     testfile = ds.pathobj / 'testfile1.txt'
     testfile_content = 'uppytyup!'
     testfile.write_text(testfile_content)
@@ -378,7 +378,7 @@ def test_uncurl_store_via_ssh(tmp_path):
     # as annex/objects within a bare remote repo
     dsca(['initremote', 'myuncurl'] + std_initargs + [
         # intentional double-braces at the end to get templates into the template
-        f'url={(tmp_path / "upload").as_uri().replace("file://", "ssh://localhost")}/{{annex_key}}',
+        f'url={(tmp_path).as_uri().replace("file://", "ssh://localhost")}/{{annex_key}}',
     ])
     # store file at remote
     dsca(['copy', '-t', 'myuncurl', str(testfile)])
@@ -386,12 +386,12 @@ def test_uncurl_store_via_ssh(tmp_path):
     dsca(['fsck', '-q', '-f', 'myuncurl'])
 
 
-def test_uncurl_remove(tmp_path):
+def test_uncurl_remove(existing_dataset, tmp_path):
     testfile = tmp_path / 'testdeposit' / 'testfile1.txt'
     testfile_content = 'uppytyup!'
     testfile.parent.mkdir()
     testfile.write_text(testfile_content)
-    ds = EnsureDataset()(tmp_path / 'ds').ds.create(**res_kwargs)
+    ds = existing_dataset
     dsca = ds.repo.call_annex
     # init without URL template
     dsca(['initremote', 'myuncurl'] + std_initargs)
@@ -419,13 +419,13 @@ def test_uncurl_remove(tmp_path):
 
 
 # >30s
-def test_uncurl_testremote(tmp_path):
+def test_uncurl_testremote(tmp_path, existing_dataset):
     "Point git-annex's testremote at uncurl"
-    ds = EnsureDataset()(tmp_path / 'ds').ds.create(**res_kwargs)
+    ds = existing_dataset
     dsca = ds.repo.call_annex
     dsca(['initremote', 'myuncurl'] + std_initargs
          # file://<basepath>/key
-         + [f'url=file://{tmp_path / "remotepath"}/{{annex_key}}'])
+         + [f'url=file://{tmp_path}/{{annex_key}}'])
     # Temporarily disable this until
     # https://github.com/datalad/datalad-dataverse/issues/127
     # is sorted out. Possibly via

--- a/datalad_next/commands/tests/test_create_sibling_webdav.py
+++ b/datalad_next/commands/tests/test_create_sibling_webdav.py
@@ -143,11 +143,9 @@ def check_common_workflow(
     eq_('dummy', (dsclone.pathobj / 'testfile.dat').read_text())
 
 
-@with_tempfile
-def test_bad_url_catching(path=None):
+def test_bad_url_catching(existing_dataset):
     # Ensure that bad URLs are detected and handled
-
-    ds = Dataset(path).create()
+    ds = existing_dataset
     check_pairs = [
         (
             "http://localhost:33322/abc?a",
@@ -173,11 +171,9 @@ def test_bad_url_catching(path=None):
         assert expected_message.format(url=bad_url) in str(e.value)
 
 
-@with_tempfile
-def test_http_warning(path=None):
+def test_http_warning(existing_dataset):
     # Check that usage of http: triggers a warning.
-
-    ds = Dataset(path).create()
+    ds = existing_dataset
     url = "http://localhost:33322/abc"
 
     with patch("datalad_next.commands.create_sibling_webdav._create_sibling_webdav") as csw_mock, \
@@ -197,11 +193,9 @@ def test_http_warning(path=None):
             lgr_mock.warning.mock_calls)
 
 
-@with_tempfile
-def test_constraints_checking(path=None):
+def test_constraints_checking(existing_dataset):
     # Ensure that constraints are checked internally
-
-    ds = Dataset(path).create()
+    ds = existing_dataset
     url = "http://localhost:22334/abc"
     for key in ("existing", "mode"):
         with pytest.raises(ValueError) as e:
@@ -210,11 +204,9 @@ def test_constraints_checking(path=None):
         assert "is not one of" in str(e.value)
 
 
-@with_tempfile
-def test_name_clash_detection(path=None):
+def test_name_clash_detection(existing_dataset):
     # Ensure that constraints are checked internally
-
-    ds = Dataset(path).create()
+    ds = existing_dataset
     url = "http://localhost:22334/abc"
     for mode in ("annex", 'filetree', 'annex-only', 'filetree-only'):
         with pytest.raises(ValueError) as e:
@@ -223,11 +215,9 @@ def test_name_clash_detection(path=None):
         assert "sibling names must not be equal" in str(e.value)
 
 
-@with_tempfile
-def test_unused_storage_name_warning(path=None):
+def test_unused_storage_name_warning(existing_dataset):
     # Ensure that constraints are checked internally
-
-    ds = Dataset(path).create()
+    ds = existing_dataset
     url = "https://localhost:22334/abc"
 
     with patch("datalad_next.commands.create_sibling_webdav._create_sibling_webdav") as csw_mock, \

--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -12,4 +12,8 @@ from datalad_next.tests.fixtures import (
     datalad_cfg,
     # function-scope temporary keyring
     tmp_keyring,
+    # function-scope, Dataset instance
+    dataset,
+    #function-scope, Dataset instance with underlying repository
+    existing_dataset,
 )

--- a/datalad_next/constraints/tests/test_basic.py
+++ b/datalad_next/constraints/tests/test_basic.py
@@ -1,8 +1,6 @@
 import pathlib
 import pytest
 
-from datalad_next.datasets import Dataset
-
 from ..base import DatasetParameter
 from ..basic import (
     EnsureInt,
@@ -304,9 +302,9 @@ def test_EnsurePath(tmp_path):
         c('doesnotmatter')
 
 
-def test_EnsurePath_fordataset(tmp_path):
+def test_EnsurePath_fordataset(existing_dataset):
     P = pathlib.Path
-    ds = Dataset(tmp_path).create(result_renderer='disabled')
+    ds = existing_dataset
     # standard: relative in, relative out
     c = EnsurePath()
     assert c('relpath') == P('relpath')
@@ -314,7 +312,7 @@ def test_EnsurePath_fordataset(tmp_path):
     # (this is what would be done by EnsureCommandParameterization
     # 1. dataset given as a path -- resolve against CWD
     #    output is always absolute
-    tc = c.for_dataset(DatasetParameter(tmp_path, ds))
+    tc = c.for_dataset(DatasetParameter(None, ds))
     assert tc('relpath') == (P.cwd() / 'relpath')
     # 2. dataset is given as a dataset object
     tc = c.for_dataset(DatasetParameter(ds, ds))

--- a/datalad_next/credman/tests/test_credman.py
+++ b/datalad_next/credman/tests/test_credman.py
@@ -22,10 +22,8 @@ from datalad_next.tests.utils import (
     assert_raises,
     eq_,
     neq_,
-    with_tempfile,
     with_testsui,
 )
-from datalad_next.datasets import Dataset
 from datalad_next.utils import chpwd
 
 
@@ -149,9 +147,8 @@ def test_credmanager(tmp_keyring, datalad_cfg):
     assert res == {'name': 'auto2', 'other': 'prop', 'secret': 'dummy'}
 
 
-@with_tempfile
-def test_credman_local(path=None):
-    ds = Dataset(path).create(result_renderer='disabled')
+def test_credman_local(existing_dataset):
+    ds = existing_dataset
     credman = CredentialManager(ds.config)
 
     # deposit a credential into the dataset's config, and die trying to
@@ -289,7 +286,7 @@ type = user_password
 """
 
 
-def test_legacy_credentials(tmp_keyring, tmp_path):
+def test_legacy_credentials(tmp_keyring, tmp_path, existing_dataset):
     # - the legacy code will only ever pick up a dataset credential, when
     #   PWD is inside a dataset
     # - we want all tests to bypass the actual system keyring
@@ -300,12 +297,12 @@ def test_legacy_credentials(tmp_keyring, tmp_path):
     #   fixture does this by replacing the keyring storage for the runtime
     #   of the test
     with chpwd(tmp_path):
-        check_legacy_credentials(tmp_keyring, tmp_path)
+        check_legacy_credentials(tmp_keyring, existing_dataset)
 
 
-def check_legacy_credentials(tmp_keyring, tmp_path):
+def check_legacy_credentials(tmp_keyring, existing_dataset):
     # we will use a dataset to host a legacy provider config
-    ds = Dataset(tmp_path).create(result_renderer='disabled')
+    ds = existing_dataset
     provider_path = ds.pathobj / '.datalad' / 'providers' / 'mylegacycred.cfg'
     provider_path.parent.mkdir(parents=True, exist_ok=True)
     provider_path.write_text(legacy_provider_cfg)

--- a/datalad_next/patches/tests/test_configuration.py
+++ b/datalad_next/patches/tests/test_configuration.py
@@ -2,7 +2,6 @@ from datalad_next.tests.utils import (
     assert_in_results,
     assert_raises,
     chpwd,
-    with_tempfile,
 )
 from datalad.api import configuration
 from datalad_next.exceptions import IncompleteResultsError
@@ -30,10 +29,9 @@ def test_config_get_global(existing_dataset, tmp_path):
         in existing_dataset.configuration.__doc__
 
 
-@with_tempfile(mkdir=True)
-def test_getset_None(path=None):
+def test_getset_None(tmp_path):
     # enter a tempdir to be confident that there is no dataset around
-    with chpwd(path):
+    with chpwd(str(tmp_path)):
         # set an empty string, this is not the same as `None`
         configuration('set', 'some.item=', scope='global', **ckwa)
         assert_in_results(

--- a/datalad_next/patches/tests/test_configuration.py
+++ b/datalad_next/patches/tests/test_configuration.py
@@ -4,10 +4,7 @@ from datalad_next.tests.utils import (
     chpwd,
     with_tempfile,
 )
-from datalad.api import (
-    Dataset,
-    configuration,
-)
+from datalad.api import configuration
 from datalad_next.exceptions import IncompleteResultsError
 
 # run all -core tests
@@ -18,11 +15,10 @@ ckwa = dict(
 )
 
 
-@with_tempfile(mkdir=True)
-def test_config_get_global(path=None):
+def test_config_get_global(existing_dataset, tmp_path):
     """Make sure `get` does not require a dataset to be present"""
     # enter a tempdir to be confident that there is no dataset around
-    with chpwd(path):
+    with chpwd(str(tmp_path)):
         res = configuration('get', 'user.name', result_renderer='disabled')
         assert_in_results(
             res,
@@ -30,8 +26,8 @@ def test_config_get_global(path=None):
             status='ok',
         )
     # verify that the dataset method was replaced too
-    ds = Dataset(path).create()
-    assert "'get' action can be constrained" in ds.configuration.__doc__
+    assert "'get' action can be constrained" \
+        in existing_dataset.configuration.__doc__
 
 
 @with_tempfile(mkdir=True)

--- a/datalad_next/patches/tests/test_create_sibling_ghlike.py
+++ b/datalad_next/patches/tests/test_create_sibling_ghlike.py
@@ -16,11 +16,10 @@ from datalad.distributed.tests.test_create_sibling_gogs import *
 
 # we overwrite this one from core, because it assumed the old credential
 # system to be used
-@with_tempfile
-def test_invalid_call(path=None):
+def test_invalid_call(dataset, existing_dataset):
     # no dataset
-    assert_raises(ValueError, create_sibling_gin, 'bogus', dataset=path)
-    ds = Dataset(path).create()
+    assert_raises(ValueError, dataset.create_sibling_gin, 'bogus')
+    ds = existing_dataset
     # unsupported name
     assert_raises(
         ValueError,

--- a/datalad_next/patches/tests/test_push.py
+++ b/datalad_next/patches/tests/test_push.py
@@ -1,7 +1,6 @@
 from datalad_next.tests.utils import (
     DEFAULT_REMOTE,
     assert_result_count,
-    with_tempfile,
 )
 from datalad.core.distributed.clone import Clone
 
@@ -13,9 +12,9 @@ from datalad_next.datasets import Dataset
 
 # we override this specific test, because the original behavior is no longer
 # value, because our implementation behaves "better"
-@with_tempfile()
-@with_tempfile()
-def test_gh1811(srcpath=None, clonepath=None):
+def test_gh1811(tmp_path):
+    srcpath = tmp_path / 'src'
+    clonepath = tmp_path / 'clone'
     # `annex=false` is the only change from the -core implementation
     # of the test. For normal datasets with an annex, the problem underlying
     # gh1811 is no longer valid, because of more comprehensive analysis of

--- a/datalad_next/tests/fixtures.py
+++ b/datalad_next/tests/fixtures.py
@@ -5,6 +5,7 @@ import pytest
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
+from datalad_next.datasets import Dataset
 from datalad_next.tests.utils import (
     SkipTest,
     external_versions,
@@ -177,3 +178,25 @@ def credman(datalad_cfg, tmp_keyring):
     from datalad_next.credman import CredentialManager
     cm = CredentialManager(cfg)
     yield cm
+
+
+@pytest.fixture(autouse=False, scope="function")
+def dataset(tmp_path):
+    """Provides a ``Dataset`` instance for a not-yet-existing repository
+
+    The instance points to an existing temporary path, but ``create()``
+    has not been called on it yet.
+    """
+    ds = Dataset(tmp_path)
+    yield ds
+
+
+@pytest.fixture(autouse=False, scope="function")
+def existing_dataset(dataset):
+    """Provides a ``Dataset`` instance pointing to an existing dataset/repo
+
+    This fixture uses an instance provided by the ``dataset`` fixture and
+    calls ``create()`` on it, before it yields the ``Dataset`` instance.
+    """
+    dataset.create(result_renderer='disabled')
+    yield dataset


### PR DESCRIPTION
The can perform most dataset-related setup used in tests. Both fixtures are function-scope, to limit cross-contamination of tests.

More of the already included test-simplifications become possible, once `serve_path_via*` are also proper fixtures.

Closes #293
