### PR TITLE
`serve_path_via_http` -> `http_server` pytest fixture

### DIFF
--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -18,6 +18,12 @@ from datalad_next.tests.fixtures import (
     existing_dataset,
     #function-scope, Dataset instance with underlying Git-only repository
     existing_noannex_dataset,
+    # session-scope, standard http credential (full dict)
+    http_credential,
+    # function-scope, auth-less HTTP server
+    http_server,
+    # function-scope, HTTP server with required authentication
+    http_server_with_basicauth,
     # session-scope, standard webdav credential (full dict)
     webdav_credential,
     # function-scope, serve a local temp-path via WebDAV

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -10,6 +10,7 @@ from datalad.support.external_versions import external_versions
 from datalad.tests.utils_pytest import (
     DEFAULT_BRANCH,
     DEFAULT_REMOTE,
+    HTTPPath,
     SkipTest,
     assert_equal,
     assert_false,
@@ -31,7 +32,6 @@ from datalad.tests.utils_pytest import (
     ok_exists,
     ok_good_symlink,
     rmtree,
-    serve_path_via_http,
     skip_if_on_windows,
     skip_ssh,
     skip_wo_symlink_capability,


### PR DESCRIPTION
This removes the last traces of its usage and simplifies associated tests.

Closes #295