### PR TITLE
DOC: Declutter the sidebar and start a developer guide

### DIFF
--- a/docs/source/annex-backends.rst
+++ b/docs/source/annex-backends.rst
@@ -1,0 +1,9 @@
+Git-annex backends
+******************
+
+.. currentmodule:: datalad_next.annexbackends
+.. autosummary::
+   :toctree: generated
+
+   base
+   xdlra

--- a/docs/source/annex-specialremotes.rst
+++ b/docs/source/annex-specialremotes.rst
@@ -1,0 +1,8 @@
+Git-annex special remotes
+*************************
+
+.. currentmodule:: datalad_next.annexremotes
+.. autosummary::
+   :toctree: generated
+
+   uncurl

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,11 @@
+High-level API commands
+***********************
+
+.. currentmodule:: datalad.api
+.. autosummary::
+   :toctree: generated
+
+   create_sibling_webdav
+   credentials
+   download
+   tree

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -1,0 +1,10 @@
+Command line reference
+**********************
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-create-sibling-webdav
+   generated/man/datalad-credentials
+   generated/man/datalad-download
+   generated/man/datalad-tree

--- a/docs/source/developer_guide/constraints.rst
+++ b/docs/source/developer_guide/constraints.rst
@@ -1,0 +1,105 @@
+.. _constraints:
+
+``datalad-next``'s Constraint System
+************************************
+
+``datalad_next.constraints`` implements a system to perform data validation, coercion, and parameter documentation for commands via a flexible set of "Constraints".
+You can find an overview of available Constraints in the respective module overview of the :ref:`pyutils`.
+
+Adding parameter validation to a command
+----------------------------------------
+
+In order to equip an existing or new command with the constraint system, the following steps are required:
+
+* Set the commands base class to ``ValidatedInterface``:
+
+.. code-block:: python
+
+   from datalad_next.commands import ValidatedInterface
+
+   @build_doc
+   class MyCommand(ValidatedInterface):
+       """Download from URLs"""
+
+* Declare a ``_validator_`` class member:
+
+.. code-block:: python
+
+   from datalad_next.commands import (
+       EnsureCommandParameterization,
+       ValidatedInterface,
+   )
+
+   @build_doc
+   class MyCommand(ValidatedInterface):
+       """Download from URLs"""
+
+   _validator_ = EnsureCommandParameterization(dict(
+        [...]
+    ))
+
+
+* Determine for each parameter of the command whether it has constraints, and what those constraints are.
+  If you're transitioning an existing command, remove any ``constraints=`` declaration in the ``_parameter_`` class member.
+* Add a fitting Constraint declaration for each parameter into the ``_validator_`` as a key-value pair where the key is the parameter and its value is a Constraint.
+  There does not need to be a Constraint per parameter; only add entries for parameters that need validation.
+
+.. code-block:: python
+
+   from datalad_next.commands import (
+       EnsureCommandParameterization,
+       ValidatedInterface,
+   )
+   from datalad_next.constraints import EnsureChoice
+   from datalad_next.constraints.dataset import EnsureDataset
+
+   @build_doc
+   class Download(ValidatedInterface):
+       """Download from URLs"""
+
+   _validator_ = EnsureCommandParameterization(dict(
+        dataset=EnsureDataset(installed=True),
+        force=EnsureChoice('yes','no','maybe'),
+    ))
+
+Combining constraints
+"""""""""""""""""""""
+
+Constraints can be combined in different ways.
+The ``|``, ``&``, and ``()`` operators allow ``AND``, ``OR``, and grouping of Constraints.
+The following example from the ``download`` command defines a chain of possible Constraints:
+
+.. code-block:: python
+
+   spec_item_constraint = url2path_constraint | (
+        (
+            EnsureJSON() | EnsureURLFilenamePairFromURL()
+        ) & url2path_constraint)
+
+Constrains can also be combined using ``AnyOf`` or ``AllOf`` MultiConstraints, which correspond almost entirely to ``|`` and ``&``.
+Here's another example from the ``download`` command:
+
+.. code-block:: python
+
+    spec_constraint = AnyOf(
+        spec_item_constraint,
+        EnsureListOf(spec_item_constraint),
+        EnsureGeneratorFromFileLike(
+            spec_item_constraint,
+            exc_mode='yield',
+        ),
+
+One can combine an arbitrary number of Constraints.
+They are evaluated in the order in which they were specified.
+Logical OR constraints will return the value from the first constraint that does not raise an exception, and logical AND constraints pass the return values of each constraint into the next.
+
+Implementing additional constraints
+-----------------------------------
+
+TODO
+
+Parameter Documentation
+-----------------------
+
+TODO
+

--- a/docs/source/developer_guide/contributing.rst
+++ b/docs/source/developer_guide/contributing.rst
@@ -1,0 +1,8 @@
+.. _contributing:
+
+Contributing to ``datalad-next``
+********************************
+
+We're happy about contributions of any kind to this project - thanks for considering making one!
+
+Please take a look at `CONTRIBUTING.md <https://github.com/datalad/datalad-next/blob/main/CONTRIBUTING.md>`_ for an overview of development principles and common questions, and `get in touch <https://github.com/datalad/datalad-next/issues/new>`_ in case of questions or to discuss features, bugs, or other issues.

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -1,0 +1,13 @@
+.. _devguide:
+
+The developer's guide to datalad-next
+*************************************
+
+This guide sheds light on new and reusable subsystems developed in ``datalad-next``.
+The target audience are developers that intend to build up on or use functionality provided by this extension.
+
+.. toctree::
+   :maxdepth: 2
+
+   constraints.rst
+   contributing.rst

--- a/docs/source/git-remote-helpers.rst
+++ b/docs/source/git-remote-helpers.rst
@@ -1,0 +1,8 @@
+Git-remote helpers
+******************
+
+.. currentmodule:: datalad_next.gitremotes
+.. autosummary::
+   :toctree: generated
+
+   datalad_annex

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,7 +100,13 @@ Patches that are automatically applied to DataLad when loading the
    patches.rst
 
 
+Developer Guide
+---------------
 
+.. toctree::
+   :maxdepth: 2
+
+   developer_guide/index.rst
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,79 +35,57 @@ API
 High-level API commands
 -----------------------
 
-.. currentmodule:: datalad.api
-.. autosummary::
-   :toctree: generated
+.. toctree::
+   :maxdepth: 2
 
-   create_sibling_webdav
-   credentials
-   download
-   tree
-
+   api.rst
 
 Command line reference
 ----------------------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   generated/man/datalad-create-sibling-webdav
-   generated/man/datalad-credentials
-   generated/man/datalad-download
-   generated/man/datalad-tree
+   cmd.rst
 
 
 Python utilities
 ----------------
 
-.. currentmodule:: datalad_next
-.. autosummary::
-   :toctree: generated
+.. toctree::
+   :maxdepth: 2
 
-   commands.ValidatedInterface
-   constraints
-   credman.manager
-   exceptions
-   url_operations
-   url_operations.any
-   url_operations.file
-   url_operations.http
-   url_operations.ssh
-   utils
-   utils.http_helpers
-   utils.requests_auth
-   tests.fixtures
+   pyutils.rst
 
 
 Git remote helpers
 ------------------
 
-.. currentmodule:: datalad_next.gitremotes
-.. autosummary::
-   :toctree: generated
+.. toctree::
+   :maxdepth: 2
 
-   datalad_annex
+   git-remote-helpers.rst
 
 
 Git-annex backends
 ------------------
 
-.. currentmodule:: datalad_next.annexbackends
-.. autosummary::
-   :toctree: generated
+.. toctree::
+   :maxdepth: 2
 
-   base
-   xdlra
+   annex-backends.rst
+
 
 
 Git-annex special remotes
 -------------------------
 
-.. currentmodule:: datalad_next.annexremotes
-.. autosummary::
-   :toctree: generated
 
-   uncurl
+.. toctree::
+   :maxdepth: 2
+
+   annex-specialremotes.rst
+
 
 
 DataLad patches
@@ -116,20 +94,12 @@ DataLad patches
 Patches that are automatically applied to DataLad when loading the
 ``datalad-next`` extension package.
 
-.. currentmodule:: datalad_next.patches
-.. autosummary::
-   :toctree: generated
+.. toctree::
+   :maxdepth: 2
 
-   annexrepo
-   common_cfg
-   configuration
-   create_sibling_ghlike
-   distribution_dataset
-   interface_utils
-   push_optimize
-   push_to_export_remote
-   test_keyring
-   siblings
+   patches.rst
+
+
 
 
 Indices and tables

--- a/docs/source/patches.rst
+++ b/docs/source/patches.rst
@@ -1,0 +1,17 @@
+DataLad patches
+***************
+
+.. currentmodule:: datalad_next.patches
+.. autosummary::
+   :toctree: generated
+
+   annexrepo
+   common_cfg
+   configuration
+   create_sibling_ghlike
+   distribution_dataset
+   interface_utils
+   push_optimize
+   push_to_export_remote
+   test_keyring
+   siblings

--- a/docs/source/pyutils.rst
+++ b/docs/source/pyutils.rst
@@ -1,0 +1,22 @@
+.. _pyutils:
+
+Python utilities
+****************
+
+.. currentmodule:: datalad_next
+.. autosummary::
+   :toctree: generated
+
+   commands.ValidatedInterface
+   constraints
+   credman.manager
+   exceptions
+   url_operations
+   url_operations.any
+   url_operations.file
+   url_operations.http
+   url_operations.ssh
+   utils
+   utils.http_helpers
+   utils.requests_auth
+   tests.fixtures


### PR DESCRIPTION
#274 highlighted the need to have developer-targeted docs on how to implement constraints. I took this opportunity to start a Developer Guide in the docs, that can serve as a place for such implementation guidelines. 

In order to better find this Guide, I decluttered the side bar into the topical headings of the index page.

![image](https://user-images.githubusercontent.com/29738718/223526454-9c63fe4b-a82b-4861-a7da-731ab46c8f43.png)


TODOs
- [ ] I haven't had a change to look at #294 and there is no content on Documentation/messaging in the doc; this needs to be added
- [ ] General feedback on what I missed and misstated.

