### PR TITLE
Structured error reporting and customized rendering of parameter violations

### DIFF
--- a/datalad_next/__init__.py
+++ b/datalad_next/__init__.py
@@ -48,7 +48,10 @@ import datalad_next.patches
 
 # register additional configuration items in datalad-core
 from datalad.support.extensions import register_config
-from datalad_next.constraints import EnsureBool
+from datalad_next.constraints import (
+    EnsureBool,
+    EnsureChoice,
+)
 register_config(
     'datalad.credentials.repeat-secret-entry',
     'Require entering secrets twice for interactive specification?',
@@ -73,6 +76,13 @@ register_config(
     default=(
         r',^webdav([s]*)://([^?]+)$,datalad-annex::http\1://\2?type=webdav&encryption=none&exporttree=yes&url={noquery}',
     ),
+)
+register_config(
+    'datalad.runtime.parameter-violation',
+    'Perform exhaustive command parameter validation, or fail on first error?',
+    type=EnsureChoice('raise-early', 'raise-at-end'),
+    default='raise-early',
+    dialog='question',
 )
 
 

--- a/datalad_next/commands/tests/test_create_sibling_webdav.py
+++ b/datalad_next/commands/tests/test_create_sibling_webdav.py
@@ -158,7 +158,7 @@ def test_bad_url_catching(existing_dataset):
         ),
         (
             "xxx://localhost:33322/abc",
-            "URL does not match expression '^(http|https)://'"
+            "url={url!r}\n  does not match expression '^(http|https)://'"
         ),
     ]
 

--- a/datalad_next/constraints/base.py
+++ b/datalad_next/constraints/base.py
@@ -191,7 +191,8 @@ class AnyOf(_MultiConstraint):
         self.raise_for(
             value,
             # plural OK, no sense in having 1 "alternative"
-            'not any of {n_alternatives} alternatives\n{__itemized_causes__}',
+            'does not match any of {n_alternatives} alternatives\n'
+            '{__itemized_causes__}',
             # if any exception would be a ConstraintError
             # this would not be needed, because they
             # know the underlying constraint

--- a/datalad_next/constraints/base.py
+++ b/datalad_next/constraints/base.py
@@ -191,7 +191,7 @@ class AnyOf(_MultiConstraint):
         self.raise_for(
             value,
             # plural OK, no sense in having 1 "alternative"
-            'not any of {n_alternatives} alternatives',
+            'not any of {n_alternatives} alternatives\n{__itemized_causes__}',
             # if any exception would be a ConstraintError
             # this would not be needed, because they
             # know the underlying constraint

--- a/datalad_next/constraints/base.py
+++ b/datalad_next/constraints/base.py
@@ -189,8 +189,15 @@ class AnyOf(_MultiConstraint):
             except Exception as e:
                 e_list.append(e)
         self.raise_for(
-            value, 'not any of {constraints}',
+            value,
+            # plural OK, no sense in having 1 "alternative"
+            'not any of {n_alternatives} alternatives',
+            # if any exception would be a ConstraintError
+            # this would not be needed, because they
+            # know the underlying constraint
             constraints=self.constraints,
+            n_alternatives=len(self.constraints),
+            __caused_by__=e_list,
         )
 
     def long_description(self):

--- a/datalad_next/constraints/compound.py
+++ b/datalad_next/constraints/compound.py
@@ -15,6 +15,7 @@ from datalad_next.exceptions import CapturedException
 
 from .base import (
     Constraint,
+    ConstraintError,
     DatasetParameter,
 )
 
@@ -386,8 +387,10 @@ class WithDescription(Constraint):
                  *,
                  input_synopsis: str | None = None,
                  input_description: str | None = None,
+                 error_message: str | None = None,
                  input_synopsis_for_ds: str | None = None,
                  input_description_for_ds: str | None = None,
+                 error_message_for_ds: str | None = None,
     ):
         """
         Parameters
@@ -402,23 +405,34 @@ class WithDescription(Constraint):
           If given, text to be returned as the constraint's
           ``input_description``. Otherwise the wrapped constraint's
           ``input_description`` is returned.
+        error_message: optional
+          If given, replaces the error message of a ``ConstraintError``
+          raised by the wrapped ``Constraint``. Only the message
+          (template) is replaced, not the error context dictionary.
         input_synopsis_for_ds: optional
-          If either this or ``input_description_for_ds`` are given, the
-          result of tailoring a constraint for a particular dataset
-          (``for_dataset()``) will also be wrapped with this custom
-          synopsis.
+          If either this, or ``input_description_for_ds``, or
+          ``error_message_for_ds`` are given, the result of tailoring a
+          constraint for a particular dataset (``for_dataset()``) will
+          also be wrapped with this custom synopsis.
         input_description_for_ds: optional
-          If either this or ``input_synopsis_for_ds`` are given, the
-          result of tailoring a constraint for a particular dataset
-          (``for_dataset()``) will also be wrapped with this custom
-          description.
+          If either this, or ``input_synopsis_for_ds``, or
+          ``error_message_for_ds`` are given, the result of tailoring a
+          constraint for a particular dataset (``for_dataset()``) will
+          also be wrapped with this custom description.
+        error_message: optional
+          If either this, or ``input_synopsis_for_ds``, or
+          ``input_description_for_ds`` are given, the result of tailoring a
+          constraint for a particular dataset (``for_dataset()``) will
+          also be wrapped with this custom error message (template).
         """
         super().__init__()
         self._constraint = constraint
         self._synopsis = input_synopsis
         self._description = input_description
+        self._error_message = error_message
         self._synopsis_for_ds = input_synopsis_for_ds
         self._description_for_ds = input_description_for_ds
+        self._error_message_for_ds = error_message_for_ds
 
     @property
     def constraint(self) -> Constraint:
@@ -426,7 +440,18 @@ class WithDescription(Constraint):
         return self._constraint
 
     def __call__(self, value) -> Any:
-        return self._constraint(value)
+        try:
+            return self._constraint(value)
+        except ConstraintError as e:
+            # rewrap the error to get access to the top-level
+            # self-description.
+            msg, cnstr, value, ctx = e.args
+            raise ConstraintError(
+                self,
+                value,
+                self._error_message or msg,
+                ctx,
+            ) from e
 
     def __str__(self) -> str:
         return \
@@ -443,13 +468,16 @@ class WithDescription(Constraint):
     def for_dataset(self, dataset: DatasetParameter) -> Constraint:
         """Wrap the wrapped constraint again after tailoring it for the dataset
         """
-        if self._synopsis_for_ds is not None \
-                or self._description_for_ds is not None:
+        if any(x is not None for x in (
+                self._synopsis_for_ds,
+                self._description_for_ds,
+                self._error_message_for_ds)):
             # we also want to wrap the tailored constraint
             return self.__class__(
                 self._constraint.for_dataset(dataset),
                 input_synopsis=self._synopsis_for_ds,
                 input_description=self._description_for_ds,
+                error_message=self._error_message_for_ds,
             )
         else:
             return self._constraint.for_dataset(dataset)

--- a/datalad_next/constraints/compound.py
+++ b/datalad_next/constraints/compound.py
@@ -189,16 +189,16 @@ class EnsureMapping(Constraint):
             key, val = value.split(sep=self._delimiter, maxsplit=1)
         elif isinstance(value, dict):
             if not len(value):
-                raise ValueError('dict does not contain a key')
+                self.raise_for(value, 'dict does not contain a key')
             elif len(value) > 1:
-                raise ValueError(f'{value} contains more than one key')
+                self.raise_for(value, 'dict contains more than one key')
             key, val = value.copy().popitem()
         elif self._allow_length2_sequence and isinstance(value, (list, tuple)):
             if not len(value) == 2:
-                raise ValueError('key/value sequence does not have length 2')
+                self.raise_for(value, 'key/value sequence does not have length 2')
             key, val = value
         else:
-            raise ValueError(f'Unsupported data type for mapping: {value!r}')
+            self.raise_for(value, 'not a recognized mapping')
 
         return key, val
 
@@ -276,7 +276,10 @@ class EnsureGeneratorFromFileLike(Constraint):
             # we covered the '-' special case, so this must be a Path
             path = Path(value) if not isinstance(value, Path) else value
             if not path.is_file():
-                raise ValueError(f'{value} is not an existing file')
+                self.raise_for(
+                    value,
+                    "not '-', or a path to an existing file",
+                )
             value = path.open()
             opened_file = True
         return self._item_yielder(value, opened_file)

--- a/datalad_next/constraints/exceptions.py
+++ b/datalad_next/constraints/exceptions.py
@@ -261,6 +261,15 @@ class ParameterConstraintContext:
             descr=f" ({self.description})" if self.description else '',
         )
 
+    def get_label_with_parameter_values(self, values: dict) -> str:
+        """Like ``.label`` but each parameter will also state a value"""
+        # TODO truncate the values after repr() to ensure a somewhat compact
+        # output
+        return '{param}{descr}'.format(
+            param=", ".join(f'{p}={values[p]!r}' for p in self.parameters),
+            descr=f" ({self.description})" if self.description else '',
+        )
+
 
 class ParametrizationErrors(ConstraintErrors):
     """Exception type raised on violating parameter constraints
@@ -301,7 +310,11 @@ class ParametrizationErrors(ConstraintErrors):
             p='s' if violations > 1 else '',
             el='\n'.join(
                 '{ctx}\n{msg}'.format(
-                    ctx=ctx.label,
+                    ctx=ctx.get_label_with_parameter_values(
+                        c.value
+                        if isinstance(c.value, dict)
+                        else {ctx.parameters[0]: c.value}
+                    ),
                     msg=indent(str(c), '  '),
                 )
                 for ctx, c in self.errors.items()

--- a/datalad_next/constraints/exceptions.py
+++ b/datalad_next/constraints/exceptions.py
@@ -81,7 +81,8 @@ class ConstraintError(ValueError):
         """
         msg_tmpl = self.args[0]
         # get interpolation values for message formatting
-        ctx = self.args[3] or {}
+        # we need a copy, because we need to mutate the dict
+        ctx = dict(self.context)
         # support a few standard placeholders
         # the verbatim value that caused the error: with !r and !s both
         # types of stringifications are accessible
@@ -100,14 +101,21 @@ class ConstraintError(ValueError):
 
     @property
     def caused_by(self):
-        if not self.args[3]:
-            return
-        return self.args[3].get('__caused_by__', None)
+        return self.context.get('__caused_by__', None)
 
     @property
     def value(self):
         """Get the value that violated the constraint"""
         return self.args[2]
+
+    @property
+    def context(self) -> MappingProxyType:
+        """Get a constraint violation's context
+
+        This is a mapping of key/value-pairs matching the ``ctx`` constructor
+        argument.
+        """
+        return MappingProxyType(self.args[3] or {})
 
     def __str__(self):
         return self.msg

--- a/datalad_next/constraints/parameter.py
+++ b/datalad_next/constraints/parameter.py
@@ -537,6 +537,15 @@ class EnsureCommandParameterization(Constraint):
                 if on_error == 'raise-early':
                     raise CommandParametrizationError(exceptions)
 
+        # do not bother with joint validation when the set of expected
+        # arguments is not complete
+        expected_for_joint_validation = set()
+        for jv in self._joint_constraints or []:
+            expected_for_joint_validation.update(jv.parameters)
+
+        if not expected_for_joint_validation.issubset(validated):
+            raise CommandParametrizationError(exceptions)
+
         try:
             # call (subclass) method to perform holistic, cross-parameter
             # validation of the full parameterization

--- a/datalad_next/constraints/parameter.py
+++ b/datalad_next/constraints/parameter.py
@@ -520,6 +520,19 @@ class EnsureCommandParameterization(Constraint):
             # it may be an indication of something being wrong with validation
             # itself
             except ConstraintError as e:
+                # standard exception type, record and proceed
+                exceptions[ParameterConstraintContext((argname,))] = e
+                if on_error == 'raise-early':
+                    raise CommandParametrizationError(exceptions)
+            except Exception as e:
+                # non-standard exception type
+                # we need to achieve uniform CommandParametrizationError
+                # raising, so let's create a ConstraintError for this
+                # exception
+                e = ConstraintError(
+                    validator, arg, '{__caused_by__}',
+                    ctx=dict(__caused_by__=e),
+                )
                 exceptions[ParameterConstraintContext((argname,))] = e
                 if on_error == 'raise-early':
                     raise CommandParametrizationError(exceptions)

--- a/datalad_next/constraints/tests/test_cmdarg_validation.py
+++ b/datalad_next/constraints/tests/test_cmdarg_validation.py
@@ -140,7 +140,7 @@ def test_multi_validation():
     errors = e.value.errors
     assert len(errors) == 3
     # the spec-param-only error
-    assert errors.messages[0].startswith('not any of')
+    assert errors.messages[0].startswith('does not match any of')
     # higher-order issue traces (their order is deterministic)
     assert 'not all values are unique' == errors.messages[1]
     assert 'p1, p2 (identity)' == errors.context_labels[1]
@@ -152,7 +152,7 @@ def test_multi_validation():
     # and we only get one!
     assert len(errors) == 1
     # the spec-param-only error
-    assert errors.messages[0].startswith('not any of')
+    assert errors.messages[0].startswith('does not match any of')
     assert 'not all values are unique' not in errors.messages
     # now we do it again, but with a valid spec, such that the first
     # and only error is a higher order error

--- a/datalad_next/constraints/tests/test_exceptions.py
+++ b/datalad_next/constraints/tests/test_exceptions.py
@@ -56,12 +56,12 @@ def test_parameterizationerrors():
     pes = ParametrizationErrors(emap)
     assert str(pes) == """\
 1 parameter constraint violation
-c1
+c1='noint'
   yeah, bullshit"""
 
     # CommandParametrizationError is pretty much the same thing
     cpes = CommandParametrizationError(emap)
     assert str(cpes) == """\
 1 command parameter constraint violation
-c1
+c1='noint'
   yeah, bullshit"""

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -11,7 +11,10 @@ from ..basic import (
 )
 from ..compound import EnsureGeneratorFromFileLike
 from ..dataset import EnsureDataset
-from ..exceptions import NoDatasetFound
+from ..exceptions import (
+    ConstraintError,
+    NoDatasetFound,
+)
 from ..formats import (
     EnsureJSON,
     EnsureURL,
@@ -260,9 +263,9 @@ def test_EnsureURL():
         cnotag_parsed = EnsureParsedURL(forbidden=[t])
         for url, tags in url_testcases.items():
             if t in tags:
-                with pytest.raises(ValueError) as e:
+                with pytest.raises(ConstraintError) as e:
                     cnotag(url)
-                assert f"forbidden '{t}'" in str(e)
+                assert f"forbidden '{t}'" in str(e.value)
             else:
                 cnotag(url)
                 cnotag_parsed(url)
@@ -270,9 +273,9 @@ def test_EnsureURL():
         ctag_parsed = EnsureParsedURL(required=[t])
         for url, tags in url_testcases.items():
             if t not in tags:
-                with pytest.raises(ValueError) as e:
+                with pytest.raises(ConstraintError) as e:
                     ctag(url)
-                assert f"missing '{t}'" in str(e)
+                assert f"missing '{t}'" in str(e.value)
             else:
                 ctag(url)
                 ctag_parsed(url)

--- a/datalad_next/patches/interface_utils.py
+++ b/datalad_next/patches/interface_utils.py
@@ -131,12 +131,19 @@ def _execute_command_(
             interface)
     else:
         lgr.debug('Command parameter validation for %s', interface)
+        validator_kwargs = dict(
+            at_default=at_default,
+        )
+        # make immediate vs exhaustive parameter validation
+        # configurable
+        raise_on_error = dlcfg.get(
+            'datalad.runtime.parameter-violation', None)
+        if raise_on_error:
+            validator_kwargs['on_error'] = raise_on_error
+
         allkwargs = param_validator(
             allkwargs,
-            at_default=at_default,
-            # TODO make immediate vs exhaustive parameter validation
-            # configurable here
-            #on_error='raise-at-end',
+            **validator_kwargs
         )
         lgr.debug('Command parameter validation ended for %s', interface)
 

--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -346,6 +346,7 @@ class UrlOperations:
 # Exceptions to be used by all handlers
 #
 
+
 class UrlOperationsRemoteError(Exception):
     def __init__(self, url, message=None, status_code: Any = None):
         # use base exception feature to store all arguments in a tuple
@@ -355,6 +356,21 @@ class UrlOperationsRemoteError(Exception):
             message,
             status_code,
         )
+
+    def __str__(self):
+        url, message, status_code = self.args
+        if message:
+            return message
+
+        if status_code:
+            return f"error {status_code} for {url!r}"
+
+        return f"{self.__class__.__name__} for {url!r}"
+
+    def __repr__(self) -> str:
+        url, message, status_code = self.args
+        return f"{self.__class__.__name__}(" \
+               f"{url!r}, {message!r}, {status_code!r})"
 
     @property
     def url(self):


### PR DESCRIPTION
Elevate level of possible error message customizations. This is best demo'ed using the included update of the `download` command.

Prior to this PR, a typical error for the violation of a complex constraint would look like this:

```
❯ datalad download wurst
[ERROR  ] 1 command parameter constraint violation
spec
  not any of [AnyOf(EnsureMapping(key=EnsureURL(), value=AnyOf(EnsureValue(), EnsurePath()), delimiter=' '), AllOf(AnyOf(EnsureJSON(), EnsureURLFilenamePairFromURL()), EnsureMapping(key=EnsureURL(), value=AnyOf(EnsureValue(), EnsurePath()), delimiter=' '))), EnsureListOf(item_constraint=AnyOf(EnsureMapping(key=EnsureURL(), value=AnyOf(EnsureValue(), EnsurePath()), delimiter=' '), AllOf(AnyOf(EnsureJSON(), EnsureURLFilenamePairFromURL()), EnsureMapping(key=EnsureURL(), value=AnyOf(EnsureValue(), EnsurePath()), delimiter=' '))), min_len=None, max_len=None), EnsureGeneratorFromFileLike(item_constraint=AnyOf(EnsureMapping(key=EnsureURL(), value=AnyOf(EnsureValue(), EnsurePath()), delimiter=' '), AllOf(AnyOf(EnsureJSON(), EnsureURLFilenamePairFromURL()), EnsureMapping(key=EnsureURL(), value=AnyOf(EnsureValue(), EnsurePath()), delimiter=' '))))] 
```

A technically correct, and utterly incomprehensible monster.

With the series of feature additions and adjustments in this PR, the "same" error turns into:

```
❯ datalad download wurst
[ERROR  ] 1 command parameter constraint violation
spec=['wurst']
  does not provide URL->(PATH|-) mapping(s)
    - not a single item
      - not a dict, length-2-iterable, or space-delimited str
      - not a URL with a path component from which a filename can be derived
      - not a JSON-encoded str with an object or length-2-array
    - not a list of any such item
    - not a path to a file with one such item per-line, nor '-' to read any such item from STDIN 
```
The improvement is noticable.

Summary of significant changes included here:

- `WithDescription` support error message customization, using the standard `format`-like templating
- New config `datalad.runtime.parameter-violation=raise-early|raise-end-end` to enable exhaustive parameter validation (still off by default)

#308 is presently still contained in here.