### PR TITLE
Given `UrlOperationsRemoteError` (and derived) a dedicated str-rendering

### DIFF
--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -346,6 +346,7 @@ class UrlOperations:
 # Exceptions to be used by all handlers
 #
 
+
 class UrlOperationsRemoteError(Exception):
     def __init__(self, url, message=None, status_code: Any = None):
         # use base exception feature to store all arguments in a tuple
@@ -355,6 +356,21 @@ class UrlOperationsRemoteError(Exception):
             message,
             status_code,
         )
+
+    def __str__(self):
+        url, message, status_code = self.args
+        if message:
+            return message
+
+        if status_code:
+            return f"error {status_code} for {url!r}"
+
+        return f"{self.__class__.__name__} for {url!r}"
+
+    def __repr__(self) -> str:
+        url, message, status_code = self.args
+        return f"{self.__class__.__name__}(" \
+               f"{url!r}, {message!r}, {status_code!r})"
 
     @property
     def url(self):


### PR DESCRIPTION
If an error provides a message, use that as-is.

If there is just an error code, render that together with the URL.

Otherwise render the error class name and the URL to give minimal, but critical insight.