### PR TITLE
New EnsureRemoteName Constraint

### DIFF
--- a/datalad_next/commands/create_sibling_webdav.py
+++ b/datalad_next/commands/create_sibling_webdav.py
@@ -260,8 +260,8 @@ class CreateSiblingWebDAV(ValidatedInterface):
         ),
         dataset=EnsureDataset(
             installed=True, purpose='create WebDAV sibling(s)'),
-        name=EnsureRemoteName(exists=False),
-        storage_name=EnsureRemoteName(exists=False),
+        name=EnsureRemoteName(),
+        storage_name=EnsureRemoteName(),
         mode=EnsureChoice(
             'annex', 'filetree', 'annex-only', 'filetree-only', 'git-only'
         ),

--- a/datalad_next/commands/create_sibling_webdav.py
+++ b/datalad_next/commands/create_sibling_webdav.py
@@ -260,8 +260,8 @@ class CreateSiblingWebDAV(ValidatedInterface):
         ),
         dataset=EnsureDataset(
             installed=True, purpose='create WebDAV sibling(s)'),
-        name=EnsureRemoteName(preexists=False),
-        storage_name=EnsureRemoteName(preexists=False),
+        name=EnsureRemoteName(exists=False),
+        storage_name=EnsureRemoteName(exists=False),
         mode=EnsureChoice(
             'annex', 'filetree', 'annex-only', 'filetree-only', 'git-only'
         ),

--- a/datalad_next/commands/create_sibling_webdav.py
+++ b/datalad_next/commands/create_sibling_webdav.py
@@ -38,6 +38,7 @@ from datalad_next.constraints import (
     EnsureInt,
     EnsureParsedURL,
     EnsureRange,
+    EnsureRemoteName,
     EnsureStr,
 )
 from datalad_next.constraints.dataset import EnsureDataset
@@ -259,8 +260,8 @@ class CreateSiblingWebDAV(ValidatedInterface):
         ),
         dataset=EnsureDataset(
             installed=True, purpose='create WebDAV sibling(s)'),
-        name=EnsureStr(),
-        storage_name=EnsureStr(),
+        name=EnsureRemoteName(existing=False),
+        storage_name=EnsureRemoteName(existing=False),
         mode=EnsureChoice(
             'annex', 'filetree', 'annex-only', 'filetree-only', 'git-only'
         ),

--- a/datalad_next/commands/create_sibling_webdav.py
+++ b/datalad_next/commands/create_sibling_webdav.py
@@ -9,9 +9,6 @@
 """High-level interface for creating a combi-target on a WebDAV capable server
  """
 import logging
-from typing import (
-    Dict,
-)
 from unittest.mock import patch
 from urllib.parse import (
     quote as urlquote,
@@ -41,10 +38,16 @@ from datalad_next.constraints import (
     EnsureRemoteName,
     EnsureStr,
 )
-from datalad_next.constraints.dataset import EnsureDataset
+from datalad_next.constraints.dataset import (
+    DatasetParameter,
+    EnsureDataset,
+)
+from datalad_next.constraints.exceptions import (
+    ConstraintError,
+    ParameterConstraintContext,
+)
 from datalad_next.utils import CredentialManager
 from datalad_next.utils import (
-    ParamDictator,
     get_specialremote_credential_properties,
     update_specialremote_credential,
     _yield_ds_w_matching_siblings,
@@ -57,37 +60,119 @@ lgr = logging.getLogger('datalad.distributed.create_sibling_webdav')
 
 
 class CreateSiblingWebDAVParamValidator(EnsureCommandParameterization):
-    def joint_validation(self, params: Dict, on_error: str) -> Dict:
-        p = ParamDictator(params)
-        if p.url.scheme == "http":
+    def __init__(self):
+        super().__init__(
+            param_constraints=dict(
+                url=EnsureParsedURL(
+                    required=['scheme', 'netloc'],
+                    forbidden=['query', 'fragment'],
+                    match='^(http|https)://',
+                ),
+                dataset=EnsureDataset(
+                    installed=True, purpose='create WebDAV sibling(s)'),
+                name=EnsureRemoteName(),
+                storage_name=EnsureRemoteName(),
+                mode=EnsureChoice(
+                    'annex', 'filetree', 'annex-only', 'filetree-only',
+                    'git-only',
+                ),
+                # TODO https://github.com/datalad/datalad-next/issues/131
+                credential=EnsureStr(),
+                existing=EnsureChoice('skip', 'error', 'reconfigure'),
+                recursive=EnsureBool(),
+                recursion_limit=EnsureInt() & EnsureRange(min=0),
+            ),
+            validate_defaults=('dataset',),
+            joint_constraints={
+                ParameterConstraintContext(('url',), 'url'):
+                self._validate_param_url,
+                ParameterConstraintContext(
+                    ('url', 'name'), 'default name'):
+                self._validate_default_name,
+                ParameterConstraintContext(
+                    ('mode', 'name', 'storage_name'), 'default storage name'):
+                self._validate_default_storage_name,
+                ParameterConstraintContext(
+                    ('mode', 'name', 'storage_name'), 'default storage name'):
+                self._validate_default_storage_name,
+                ParameterConstraintContext(
+                    ('existing', 'recursive', 'name', 'storage_name',
+                     'dataset', 'mode')):
+                self._validate_existing_names,
+            },
+        )
+
+    def _validate_param_url(self, url):
+        if url.scheme == "http":
             lgr.warning(
-                f"Using 'http:' ({p.url.geturl()!r}) means that WebDAV "
+                f"Using 'http:' ({url.geturl()!r}) means that WebDAV "
                 "credentials are sent unencrypted over network links. "
                 "Consider using 'https:'.")
 
-        if not params['name']:
+    def _validate_default_name(self, url, name):
+        if not name:
             # not using .netloc to avoid ports to show up in the name
-            params['name'] = p.url.hostname
+            return {'name': url.hostname}
 
-        if p.mode in ('annex-only', 'filetree-only') and p.storage_name:
+    def _validate_default_storage_name(self, mode, name, storage_name):
+        if mode in ('annex-only', 'filetree-only') and storage_name:
             lgr.warning(
                 "Sibling name will be used for storage sibling in "
                 "storage-sibling-only mode, but a storage sibling name "
                 "was provided"
             )
-        if p.mode == 'git-only' and p.storage_name:
+        if mode == 'git-only' and storage_name:
             lgr.warning(
                 "Storage sibling setup disabled, but a storage sibling name "
                 "was provided"
             )
-        if p.mode != 'git-only' and not p.storage_name:
-            p.storage_name = f"{p.name}-storage"
+        if mode != 'git-only' and not storage_name:
+            storage_name = f"{name}-storage"
 
-        if p.mode != 'git-only' and p.name == p.storage_name:
+        if mode != 'git-only' and name == storage_name:
             # leads to unresolvable, circular dependency with publish-depends
-            raise ValueError("sibling names must not be equal")
+            self.raise_for(
+                dict(mode=mode, name=name, storage_name=storage_name),
+                "sibling names must not be equal",
+            )
+        return dict(mode=mode, name=name, storage_name=storage_name)
 
-        return params
+    def _validate_existing_names(
+            self, existing, recursive, name, storage_name, dataset,
+            mode):
+        if recursive:
+            # we don't do additional validation for recursive processing,
+            # this has to be done when things are running, because an
+            # upfront validation would require an expensive traversal
+            return
+
+        if existing != 'error':
+            # nothing to check here
+            return
+
+        if not isinstance(dataset, DatasetParameter):
+            # we did not get a proper dataset parameter,
+            # hence cannot tailor to a dataset to check a remote
+            # name against
+            return
+
+        validator = EnsureRemoteName(known=False, dsarg=dataset)
+        try:
+            if mode != 'annex-only':
+                validator(name)
+            if mode != 'git-only':
+                validator(storage_name)
+        except ConstraintError as e:
+            self.raise_for(
+                dict(existing=existing,
+                     recursive=recursive,
+                     name=name,
+                     storage_name=storage_name,
+                     dataset=dataset,
+                     mode=mode),
+                e.msg,
+            )
+        return
 
 
 @build_doc
@@ -252,29 +337,7 @@ class CreateSiblingWebDAV(ValidatedInterface):
             """),
     )
 
-    _validators = dict(
-        url=EnsureParsedURL(
-            required=['scheme', 'netloc'],
-            forbidden=['query', 'fragment'],
-            match='^(http|https)://',
-        ),
-        dataset=EnsureDataset(
-            installed=True, purpose='create WebDAV sibling(s)'),
-        name=EnsureRemoteName(),
-        storage_name=EnsureRemoteName(),
-        mode=EnsureChoice(
-            'annex', 'filetree', 'annex-only', 'filetree-only', 'git-only'
-        ),
-        # TODO https://github.com/datalad/datalad-next/issues/131
-        credential=EnsureStr(),
-        existing=EnsureChoice('skip', 'error', 'reconfigure'),
-        recursive=EnsureBool(),
-        recursion_limit=EnsureInt() & EnsureRange(min=0),
-    )
-    _validator_ = CreateSiblingWebDAVParamValidator(
-        _validators,
-        validate_defaults=('dataset',),
-    )
+    _validator_ = CreateSiblingWebDAVParamValidator()
 
     @staticmethod
     @datasetmethod(name='create_sibling_webdav')

--- a/datalad_next/commands/create_sibling_webdav.py
+++ b/datalad_next/commands/create_sibling_webdav.py
@@ -260,8 +260,8 @@ class CreateSiblingWebDAV(ValidatedInterface):
         ),
         dataset=EnsureDataset(
             installed=True, purpose='create WebDAV sibling(s)'),
-        name=EnsureRemoteName(existing=False),
-        storage_name=EnsureRemoteName(existing=False),
+        name=EnsureRemoteName(preexists=False),
+        storage_name=EnsureRemoteName(preexists=False),
         mode=EnsureChoice(
             'annex', 'filetree', 'annex-only', 'filetree-only', 'git-only'
         ),

--- a/datalad_next/commands/tests/test_create_sibling_webdav.py
+++ b/datalad_next/commands/tests/test_create_sibling_webdav.py
@@ -74,6 +74,26 @@ def check_common_workflow(
             if declare_credential else None,
             mode=mode,
         )
+        # Ensure that remote name constraint check works
+        # second time should raise because the sibling exists already
+        with pytest.raises(ValueError) as e:
+            create_sibling_webdav(
+                url,
+                credential=webdav_credential['name']
+                if declare_credential else None,
+                mode=mode,
+                name='127.0.0.1',
+            )
+        with pytest.raises(ValueError) as e:
+            create_sibling_webdav(
+                url,
+                credential=webdav_credential['name']
+                if declare_credential else None,
+                mode=mode,
+                name='other',
+                storage_name='127.0.0.1-storage',
+            )
+
     assert_in_results(
         res,
         action='create_sibling_webdav.storage',

--- a/datalad_next/constraints/__init__.py
+++ b/datalad_next/constraints/__init__.py
@@ -85,3 +85,8 @@ from .formats import (
     EnsureURL,
     EnsureParsedURL,
 )
+
+from .git import (
+    EnsureGitRefName,
+    EnsureRemoteName
+)

--- a/datalad_next/constraints/git.py
+++ b/datalad_next/constraints/git.py
@@ -93,6 +93,7 @@ class EnsureRemoteName(EnsureGitRefName):
         existing: bool
            If true, validates that the remote exists, fails otherwise.
            If false, validates that the remote doesn't exist, fails otherwise.
+           If None, just checks that a sibling name was provided.
 
         """
         self._existing = existing
@@ -111,7 +112,6 @@ class EnsureRemoteName(EnsureGitRefName):
             return value
 
         from datalad.runner import GitRunner, StdOutCapture
-        from datalad_next.exceptions import CommandError
         runner = GitRunner()
         cmd = ['git', 'remote'] if not self._dsarg else \
               ['git', '-C', f'{self._dsarg.ds.path}', 'remote']
@@ -120,7 +120,7 @@ class EnsureRemoteName(EnsureGitRefName):
             raise ValueError(
                 f'Sibling {value} is not among available remotes {remotes}'
             )
-        elif not self._existing and value in remotes:
+        elif self._existing is False and value in remotes:
             raise ValueError(
                 f'Sibling {value} is already among available remotes {remotes}'
             )

--- a/datalad_next/constraints/git.py
+++ b/datalad_next/constraints/git.py
@@ -85,18 +85,18 @@ class EnsureRemoteName(EnsureGitRefName):
     requirements"""
 
     def __init__(self,
-                 existing: bool | None = None,
+                 preexists: bool | None = None,
                  dsarg: DatasetParameter | None = None):
         """
         Parameters
         ----------
-        existing: bool
+        preexists: bool
            If true, validates that the remote exists, fails otherwise.
            If false, validates that the remote doesn't exist, fails otherwise.
            If None, just checks that a sibling name was provided.
 
         """
-        self._existing = existing
+        self._preexists = preexists
         self._dsarg = dsarg
         super().__init__(allow_onelevel=True,
                          refspec_pattern=False)
@@ -107,7 +107,7 @@ class EnsureRemoteName(EnsureGitRefName):
             raise ValueError('must state a sibling name')
         super().__call__(value)
 
-        if self._existing is None:
+        if self._preexists is None:
             # we only need to know that something was provided, no further check
             return value
 
@@ -116,11 +116,11 @@ class EnsureRemoteName(EnsureGitRefName):
         cmd = ['git', 'remote'] if not self._dsarg else \
               ['git', '-C', f'{self._dsarg.ds.path}', 'remote']
         remotes = runner.run(cmd, protocol=StdOutCapture)['stdout'].split()
-        if self._existing and value not in remotes:
+        if self._preexists and value not in remotes:
             raise ValueError(
                 f'Sibling {value} is not among available remotes {remotes}'
             )
-        elif self._existing is False and value in remotes:
+        elif self._preexists is False and value in remotes:
             raise ValueError(
                 f'Sibling {value} is already among available remotes {remotes}'
             )
@@ -128,8 +128,8 @@ class EnsureRemoteName(EnsureGitRefName):
             return value
 
     def short_description(self):
-        if self._existing is not None:
-            desc = ' that exists' if self._existing else ' that does not yet exist'
+        if self._preexists is not None:
+            desc = ' that exists' if self._preexists else ' that does not yet exist'
         else:
             desc = ''
         return "Sibling name{}".format(desc)
@@ -141,6 +141,6 @@ class EnsureRemoteName(EnsureGitRefName):
 
         """
         return self.__class__(
-            existing=self._existing,
+            preexists=self._preexists,
             dsarg=dataset,
         )

--- a/datalad_next/constraints/git.py
+++ b/datalad_next/constraints/git.py
@@ -85,18 +85,17 @@ class EnsureRemoteName(EnsureGitRefName):
     requirements"""
 
     def __init__(self,
-                 preexists: bool | None = None,
+                 exists: bool | None = None,
                  dsarg: DatasetParameter | None = None):
         """
         Parameters
         ----------
-        preexists: bool
+        exists: bool, optional
            If true, validates that the remote exists, fails otherwise.
            If false, validates that the remote doesn't exist, fails otherwise.
            If None, just checks that a sibling name was provided.
-
         """
-        self._preexists = preexists
+        self._exists = exists
         self._dsarg = dsarg
         super().__init__(allow_onelevel=True,
                          refspec_pattern=False)
@@ -107,7 +106,7 @@ class EnsureRemoteName(EnsureGitRefName):
             raise ValueError('must state a sibling name')
         super().__call__(value)
 
-        if self._preexists is None:
+        if self._exists is None:
             # we only need to know that something was provided, no further check
             return value
 
@@ -116,11 +115,11 @@ class EnsureRemoteName(EnsureGitRefName):
         cmd = ['git', 'remote'] if not self._dsarg else \
               ['git', '-C', f'{self._dsarg.ds.path}', 'remote']
         remotes = runner.run(cmd, protocol=StdOutCapture)['stdout'].split()
-        if self._preexists and value not in remotes:
+        if self._exists and value not in remotes:
             raise ValueError(
                 f'Sibling {value} is not among available remotes {remotes}'
             )
-        elif self._preexists is False and value in remotes:
+        elif self._exists is False and value in remotes:
             raise ValueError(
                 f'Sibling {value} is already among available remotes {remotes}'
             )
@@ -128,8 +127,8 @@ class EnsureRemoteName(EnsureGitRefName):
             return value
 
     def short_description(self):
-        if self._preexists is not None:
-            desc = ' that exists' if self._preexists else ' that does not yet exist'
+        if self._exists is not None:
+            desc = ' that exists' if self._exists else ' that does not yet exist'
         else:
             desc = ''
         return "Sibling name{}".format(desc)
@@ -141,6 +140,6 @@ class EnsureRemoteName(EnsureGitRefName):
 
         """
         return self.__class__(
-            preexists=self._preexists,
+            exists=self._exists,
             dsarg=dataset,
         )

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -58,13 +58,13 @@ def test_EnsureRemoteName(existing_dataset):
     # empty sibling name must raise
     with pytest.raises(ValueError):
         EnsureRemoteName()('')
-    assert EnsureRemoteName().short_description() == 'Sibling name'
+    assert EnsureRemoteName().short_description() == 'Name of a remote'
     assert EnsureRemoteName(
-        exists=True).short_description() == 'Sibling name that exists'
+        known=True).short_description() == 'Name of a known remote'
     assert EnsureRemoteName(
-        exists=False).short_description() == 'Sibling name that does not yet exist'
+        known=False).short_description() == 'Name of a not-yet-known remote'
     ds = existing_dataset
-    c = EnsureRemoteName(exists=False)
+    c = EnsureRemoteName(known=False)
     tc = c.for_dataset(DatasetParameter(None, ds))
     assert tc('newremotename') == 'newremotename'
     # add a remote
@@ -73,12 +73,13 @@ def test_EnsureRemoteName(existing_dataset):
     with pytest.raises(ValueError):
         tc('my-remote')
     # should work when it should exist
-    c = EnsureRemoteName(exists=True)
+    c = EnsureRemoteName(known=True)
     tc = c.for_dataset(DatasetParameter(None, ds))
     assert tc('my-remote') == 'my-remote'
     # but fail with non-existing remote
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as e:
         tc('not-my-remote')
+    assert str(e.value) == "is not one of the known remote(s) ['my-remote']"
     # return sibling name with no existence checks
     assert EnsureRemoteName()('anything') == 'anything'
 

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -60,11 +60,11 @@ def test_EnsureRemoteName(existing_dataset):
         EnsureRemoteName()('')
     assert EnsureRemoteName().short_description() == 'Sibling name'
     assert EnsureRemoteName(
-        preexists=True).short_description() == 'Sibling name that exists'
+        exists=True).short_description() == 'Sibling name that exists'
     assert EnsureRemoteName(
-        preexists=False).short_description() == 'Sibling name that does not yet exist'
+        exists=False).short_description() == 'Sibling name that does not yet exist'
     ds = existing_dataset
-    c = EnsureRemoteName(preexists=False)
+    c = EnsureRemoteName(exists=False)
     tc = c.for_dataset(DatasetParameter(None, ds))
     assert tc('newremotename') == 'newremotename'
     # add a remote
@@ -73,7 +73,7 @@ def test_EnsureRemoteName(existing_dataset):
     with pytest.raises(ValueError):
         tc('my-remote')
     # should work when it should exist
-    c = EnsureRemoteName(preexists=True)
+    c = EnsureRemoteName(exists=True)
     tc = c.for_dataset(DatasetParameter(None, ds))
     assert tc('my-remote') == 'my-remote'
     # but fail with non-existing remote

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -79,7 +79,7 @@ def test_EnsureRemoteName(existing_dataset):
     # but fail with non-existing remote
     with pytest.raises(ValueError) as e:
         tc('not-my-remote')
-    assert str(e.value) == "is not one of the known remote(s) ['my-remote']"
+    assert str(e.value) == "is not a known remote"
     # return sibling name with no existence checks
     assert EnsureRemoteName()('anything') == 'anything'
 

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -57,7 +57,7 @@ def test_EnsureGitRefName():
 def test_EnsureRemoteName(existing_dataset):
     # empty sibling name must raise
     with pytest.raises(ValueError):
-        c = EnsureRemoteName()('')
+        EnsureRemoteName()('')
     assert EnsureRemoteName().short_description() == 'Sibling name'
     assert EnsureRemoteName(
         existing=True).short_description() == 'Sibling name that exists'

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -60,11 +60,11 @@ def test_EnsureRemoteName(existing_dataset):
         EnsureRemoteName()('')
     assert EnsureRemoteName().short_description() == 'Sibling name'
     assert EnsureRemoteName(
-        existing=True).short_description() == 'Sibling name that exists'
+        preexists=True).short_description() == 'Sibling name that exists'
     assert EnsureRemoteName(
-        existing=False).short_description() == 'Sibling name that does not yet exist'
+        preexists=False).short_description() == 'Sibling name that does not yet exist'
     ds = existing_dataset
-    c = EnsureRemoteName(existing=False)
+    c = EnsureRemoteName(preexists=False)
     tc = c.for_dataset(DatasetParameter(None, ds))
     assert tc('newremotename') == 'newremotename'
     # add a remote
@@ -73,7 +73,7 @@ def test_EnsureRemoteName(existing_dataset):
     with pytest.raises(ValueError):
         tc('my-remote')
     # should work when it should exist
-    c = EnsureRemoteName(existing=True)
+    c = EnsureRemoteName(preexists=True)
     tc = c.for_dataset(DatasetParameter(None, ds))
     assert tc('my-remote') == 'my-remote'
     # but fail with non-existing remote

--- a/datalad_next/constraints/tests/test_special_purpose.py
+++ b/datalad_next/constraints/tests/test_special_purpose.py
@@ -4,6 +4,7 @@ import pytest
 from datalad_next.commands import Parameter
 from datalad_next.utils import chpwd
 
+from ..base import DatasetParameter
 from ..basic import (
     EnsureInt,
     EnsureStr,
@@ -22,6 +23,7 @@ from ..formats import (
 )
 from ..git import (
     EnsureGitRefName,
+    EnsureRemoteName
 )
 from ..parameter_legacy import EnsureParameterConstraint
 
@@ -50,6 +52,35 @@ def test_EnsureGitRefName():
         EnsureGitRefName()('refs/heads/*')
     assert EnsureGitRefName(refspec_pattern=True)(
         'refs/heads/*') == 'refs/heads/*'
+
+
+def test_EnsureRemoteName(existing_dataset):
+    # empty sibling name must raise
+    with pytest.raises(ValueError):
+        c = EnsureRemoteName()('')
+    assert EnsureRemoteName().short_description() == 'Sibling name'
+    assert EnsureRemoteName(
+        existing=True).short_description() == 'Sibling name that exists'
+    assert EnsureRemoteName(
+        existing=False).short_description() == 'Sibling name that does not yet exist'
+    ds = existing_dataset
+    c = EnsureRemoteName(existing=False)
+    tc = c.for_dataset(DatasetParameter(None, ds))
+    assert tc('newremotename') == 'newremotename'
+    # add a remote
+    ds._repo.add_remote('my-remote', 'here')
+    # check should fail when it shouldn't exist
+    with pytest.raises(ValueError):
+        tc('my-remote')
+    # should work when it should exist
+    c = EnsureRemoteName(existing=True)
+    tc = c.for_dataset(DatasetParameter(None, ds))
+    assert tc('my-remote') == 'my-remote'
+    # but fail with non-existing remote
+    with pytest.raises(ValueError):
+        tc('not-my-remote')
+    # return sibling name with no existence checks
+    assert EnsureRemoteName()('anything') == 'anything'
 
 
 def test_EnsureParameterConstraint():


### PR DESCRIPTION
This PR is an initial approach to fix #193. It adds a new Constraint ``EnsureRemoteName`` that derives from ``EnsureGitRefName``. The Constraint checks that a sibling name is given, and, optionally, can check if the sibling already exists or not using the boolean ``existing`` flag. If ``existing=True`` the remote must exist, if ``existing=False`` it shouldn't exist. The Constraint can be tuned to a specific dataset.

Let me know if something like this is what you had in mind for #193.
