### PR TITLE
Give up on httpbin access from appveyor

### DIFF
--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -24,8 +24,10 @@ from datalad_next.tests.fixtures import (
     http_server,
     # function-scope, HTTP server with required authentication
     http_server_with_basicauth,
-    # session-scope HTTPBIN URLs
+    # function-scope relay httpbin_service, unless undesired and skips instead
     httpbin,
+    # session-scope HTTPBIN instance startup and URLs
+    httpbin_service,
     # session-scope, standard webdav credential (full dict)
     webdav_credential,
     # function-scope, serve a local temp-path via WebDAV


### PR DESCRIPTION
It appears that these workers are more or less constantly blocked. There
is little point in all these false-positive failures.

The respective tests will continue to run on appveyor, but limited to
deployments with a dedicated docker-instance of httpbin running as
part of the CI setup (this is ubuntu for now).