### PR TITLE
`iter_collections` and `ls-file-collection`

### DIFF
--- a/datalad_next/__init__.py
+++ b/datalad_next/__init__.py
@@ -39,6 +39,10 @@ command_suite = (
         (
             'datalad_next.commands.download', 'Download', 'download',
         ),
+        (
+            'datalad_next.commands.ls_file_collection', 'LsFileCollection',
+            'ls-file-collection',
+        ),
     ]
 )
 

--- a/datalad_next/commands/__init__.py
+++ b/datalad_next/commands/__init__.py
@@ -52,7 +52,7 @@ class ValidatedInterface(Interface):
     should either be removed, or moved to the corresponding entry in
     ``_validator_``.
     """
-    _validator_ = None
+    _validator_: EnsureCommandParameterization | None = None
 
     @classmethod
     def get_parameter_validator(cls) -> EnsureCommandParameterization | None:

--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -1,0 +1,265 @@
+"""
+"""
+
+from __future__ import annotations
+
+__docformat__ = 'restructuredtext'
+
+from dataclasses import (
+    asdict,
+    dataclass,
+)
+from logging import getLogger
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+)
+
+from datalad_next.commands import (
+    EnsureCommandParameterization,
+    ValidatedInterface,
+    Parameter,
+    ParameterConstraintContext,
+    build_doc,
+    eval_results,
+    get_status_dict,
+)
+from datalad_next.constraints import (
+    EnsureChoice,
+    EnsurePath,
+    EnsureURL,
+)
+from datalad_next.uis import (
+    ansi_colors as ac,
+    ui_switcher as ui,
+)
+from datalad_next.utils import ensure_list
+
+from datalad_next.iter_collections.directory import iterdir
+from datalad_next.iter_collections.tarfile import itertar
+from datalad_next.iter_collections.utils import FileSystemItemType
+
+
+lgr = getLogger('datalad.local.ls_file_collection')
+
+
+# hand-maintain a list of collection type names that should be
+# advertized and supported. it makes little sense to auto-discover
+# them, because each collection type likely needs some custom glue
+# code, and some iterators may not even be about *file* collections
+_supported_collection_types = (
+    'directory',
+    'tarfile',
+)
+
+
+@dataclass  # sadly PY3.10+ only (kw_only=True)
+class CollectionSpec:
+    """Internal type for passing a collection specification to
+    ``ls_file_collection``. it is created by the command validator
+    transparently.
+    """
+    orig_id: Any
+    iter: Iterator
+    item2res: Callable
+
+
+class LsFileCollectionParamValidator(EnsureCommandParameterization):
+    """Parameter validator for the ``ls_file_collection`` command"""
+    _collection_types = EnsureChoice(*_supported_collection_types)
+
+    def __init__(self):
+        super().__init__(
+            param_constraints=dict(
+                type=self._collection_types,
+                collection=EnsurePath(lexists=True) | EnsureURL(),
+                # TODO EnsureHashAlgorithm
+                # https://github.com/datalad/datalad-next/issues/346
+                #hash=None,
+            ),
+            joint_constraints={
+                ParameterConstraintContext(('type', 'collection', 'hash'),
+                                           'collection iterator'):
+                self.get_collection_iter,
+            },
+        )
+
+    def get_collection_iter(self, **kwargs):
+        type = kwargs['type']
+        collection = kwargs['collection']
+        hash = ensure_list(kwargs['hash'])
+        iter_fx = None
+        iter_kwargs = None
+        if type in ('directory', 'tarfile'):
+            if not isinstance(collection, Path):
+                self.raise_for(
+                    kwargs,
+                    "{type} collection requires a Path-type identifier",
+                    type=type,
+                )
+            iter_kwargs = dict(path=collection, hash=hash)
+            item2res = fsitem_to_dict
+        if type == 'directory':
+            iter_fx = iterdir
+        elif type == 'tarfile':
+            iter_fx = itertar
+        else:
+            raise RuntimeError('unhandled condition')
+        assert iter_fx is not None
+        return dict(
+            collection=CollectionSpec(
+                orig_id=collection,
+                iter=iter_fx(**iter_kwargs),
+                item2res=item2res),
+        )
+
+
+def fsitem_to_dict(item) -> Dict:
+    keymap = {'name': 'item'}
+    # FileSystemItemType is too fine-grained to be used as result type
+    # directly, map some cases!
+    fsitem_type_to_res_type = {
+        'specialfile': 'file',
+    }
+
+    # TODO likely could be faster by moving the conditional out of the
+    # dict-comprehension and handling them separately upfront/after
+    d = {
+        keymap.get(k, k):
+        # explicit str value access, until we can use `StrEnum`
+        v if k != 'type' else fsitem_type_to_res_type.get(v.value, v.value)
+        for k, v in asdict(item).items()
+        # strip pointless symlink target reports for anything but symlinks
+        if item.type is FileSystemItemType.symlink or k != 'link_target'
+    }
+    hashes = d.pop('hash', None)
+    if hashes is not None:
+        for k, v in hashes.items():
+            d[f'hash-{k}'] = v
+    return d
+
+
+@build_doc
+class LsFileCollection(ValidatedInterface):
+    """Report information on files in a collection
+
+    This is a utility that can be used to query information on files in
+    different file collections. The type of information reported varies across
+    collection types. However, each result at minimum contains some kind of
+    identifier for the collection ('collection' property), and an identifier
+    for the respective collection item ('item' property). Each result
+    also contains a ``type`` property that indicates particular type of file
+    that is being reported on. In most cases this will be ``file``, but
+    other categories like ``symlink`` or ``directory`` are recognized too.
+
+    Regardless of the collection type this command can compute one or more
+    hashes (checksums) for any file in a collection. If the collection
+    itself does not readily provide a particular hash, file content needs
+    to be read, and possibly retrieved first.
+
+    Supported file collection types are:
+
+    ``directory``
+      Reports on the content of a given directory (non-recursively). The
+      collection identifier is the path of the directory. Item identifiers
+      are the name of a file within that directory. Standard properties like
+      ``size``, ``mtime``, or ``link_target`` are included in the report.
+
+    ``tarfile``
+      Reports on members of a TAR archive. The collection identifier is the
+      path of the TAR file. Item identifiers are the relative paths
+      of archive members within the archive. Reported properties are similar
+      to the ``directory`` collection type.
+    """
+    _validator_ = LsFileCollectionParamValidator()
+
+    # this is largely here for documentation and CLI parser building
+    _params_ = dict(
+        type=Parameter(
+            args=("type",),
+            choices=_supported_collection_types,
+            doc="""Name of the type of file collection to report on"""),
+        collection=Parameter(
+            args=('collection',),
+            metavar='ID/LOCATION',
+            doc="""identifier or location of the file collection to report on.
+            Depending on the type of collection to process, the specific
+            nature of this parameter can be different. A common identifier
+            for a file collection is a path (to a directory, to an archive),
+            but might also be a URL. See the documentation for details on
+            supported collection types."""),
+        hash=Parameter(
+            args=("--hash",),
+            action='append',
+            metavar='ALGORITHM',
+            doc="""One or more names of algorithms to be used for reporting
+            file hashes. They must be supported by the Python 'hashlib' module,
+            e.g. 'md5' or 'sha256'. Reporting file hashes typically
+            implies retrieving/reading file content. This processing
+            may also enable reporting of additional properties that
+            may otherwise not be readily available.
+            [CMD: This option can be given more than once CMD]
+            """),
+    )
+
+    _examples_: List = [
+        {'text': 'Report on the content of a directory',
+         'code_cmd': 'datalad -f json ls-file-collection directory /tmp',
+         'code_py': 'records = ls_file_collection("directory", "/tmp")'},
+        {'text': 'Report on the content of a TAR archive with '
+                 'MD5 and SHA1 file hashes',
+         'code_cmd': 'datalad -f json ls-file-collection'
+                     ' --hash md5 --hash sha1 tarfile myarchive.tar.gz',
+         'code_py': 'records = ls_file_collection("tarfile",'
+                    ' "myarchive.tar.gz", hash=["md5", "sha1"])'},
+        {'text': "Register URLs for files in a directory that is"
+                 " also reachable via HTTP. This uses ``ls-file-collection``"
+                 " for listing files and computing MD5 hashes,"
+                 " then using ``jq`` to filter and transform the output"
+                 " (just file records, and in a JSON array),"
+                 " and passes them to ``addurls``, which generates"
+                 " annex keys/files and assigns URLs."
+                 " When the command finishes, the dataset contains no"
+                 " data, but can retrieve the files after confirming"
+                 " their availability (i.e., via `git annex fsck`)",
+         'code_cmd':
+         'datalad -f json ls-file-collection directory wwwdir --hash md5 \\\n'
+         ' | jq \'. | select(.type == "file")\' \\\n'
+         ' | jq --slurp . \\\n'
+         " | datalad addurls --key 'et:MD5-s{size}--{hash-md5}' - 'https://example.com/{item}'"},
+    ]
+
+    @staticmethod
+    @eval_results
+    def __call__(
+            type: str,
+            collection: CollectionSpec,
+            *,
+            hash: str | List[str] | None = None,
+    ):
+        for item in collection.iter:
+            res = collection.item2res(item)
+            res.update(get_status_dict(
+                action='ls_file_collection',
+                status='ok',
+                collection=collection.orig_id,
+            ))
+            yield res
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        # given the to-be-expected diversity, this renderer only
+        # outputs identifiers and type info. In almost any real use case
+        # either no rendering or JSON rendering will be needed
+        ui.message('{item} ({type})'.format(
+            item=ac.color_word(
+                res.get('item', '<missing-item-identifier>'),
+                ac.BOLD),
+            type=ac.color_word(
+                res.get('type', '<missing-type>'),
+                ac.MAGENTA),
+        ))

--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -48,7 +48,7 @@ lgr = getLogger('datalad.local.ls_file_collection')
 
 
 # hand-maintain a list of collection type names that should be
-# advertized and supported. it makes little sense to auto-discover
+# advertised and supported. it makes little sense to auto-discover
 # them, because each collection type likely needs some custom glue
 # code, and some iterators may not even be about *file* collections
 _supported_collection_types = (

--- a/datalad_next/commands/tests/test_ls_file_collection.py
+++ b/datalad_next/commands/tests/test_ls_file_collection.py
@@ -1,0 +1,144 @@
+from pathlib import PurePath
+import pytest
+
+from datalad.api import ls_file_collection
+
+from datalad_next.constraints.exceptions import CommandParametrizationError
+
+from ..ls_file_collection import LsFileCollectionParamValidator
+
+
+def test_ls_file_collection_insufficient_args():
+    with pytest.raises(CommandParametrizationError):
+        ls_file_collection()
+
+    # any collection needs some kind of identifier, just the type
+    # parameter is not enough
+    with pytest.raises(CommandParametrizationError):
+        ls_file_collection('tarfile')
+
+    # individual collection types have particular requirements re
+    # the identifiers -- tarfile wants an existing path
+    with pytest.raises(CommandParametrizationError):
+        ls_file_collection('tarfile', 'http://example.com')
+
+    # not a known collection type
+    with pytest.raises(CommandParametrizationError):
+        ls_file_collection('bogus', 'http://example.com')
+
+
+def test_ls_file_collection_tarfile(sample_tar_xz):
+    kwa = dict(result_renderer='disabled')
+    # smoke test first
+    res = ls_file_collection(
+        'tarfile',
+        sample_tar_xz,
+        hash='md5',
+        **kwa
+    )
+    assert len(res) == 6
+    # test a few basic properties that should be true for any result
+    for r in res:
+        # basics of a result
+        assert r['action'] == 'ls_file_collection'
+        assert r['status'] == 'ok'
+        # a collection identifier, here the tar location
+        assert 'collection' in r
+        assert r['collection'] == sample_tar_xz
+        # an item identifier, here a path of an archive member
+        assert 'item' in r
+        assert isinstance(r['item'], PurePath)
+        # item type info, here some filesystem-related category
+        assert 'type' in r
+        assert r['type'] in ('file', 'directory', 'symlink', 'hardlink')
+
+
+def test_ls_file_collection_directory(tmp_path):
+    kwa = dict(result_renderer='disabled')
+    # smoke test on an empty dir
+    res = ls_file_collection('directory', tmp_path, **kwa)
+    assert len(res) == 0
+
+
+def test_ls_file_collection_validator():
+    val = LsFileCollectionParamValidator()
+
+    with pytest.raises(RuntimeError):
+        val.get_collection_iter(type='bogus', collection='any', hash=None)
+
+
+def test_replace_add_archive_content(sample_tar_xz, existing_dataset):
+    kwa = dict(result_renderer='disabled')
+
+    ds = existing_dataset
+    archive_path = ds.pathobj / '.datalad' / 'myarchive.tar.xz'
+    # get archive copy in dataset (not strictly needed, but
+    # add-archive-content worked like this
+    ds.download({sample_tar_xz.as_uri(): archive_path}, **kwa)
+    # properly safe to dataset (download is ignorant of datasets)
+    res = ds.save(message='add archive', **kwa)
+    # the first result has the archive addition, snatch the archive key from it
+    assert res[0]['path'] == str(archive_path)
+    archive_key = res[0]['key']
+
+    # now we can scan the archive and register keys for its content.
+    # the order and specific composition of the following steps is flexible.
+    # we could simply extract the local archive, save the content to the
+    # dataset, and then register `dl+archive` URLs.
+    # however, we will use an approach that does not require any data
+    # to be present locally (actually not even the archive that we have locally
+    # already for this test), but is instead based on some metadata
+    # that is provided by `ls-file-collection` (but could come from elsewhere,
+    # including `ls-file-collection` executed on a different host).
+    file_recs = [
+        r for r in ls_file_collection(
+            'tarfile', sample_tar_xz, hash=['md5'], **kwa
+        )
+        # ignore any non-file, would not have an annex key.
+        # Also ignores hardlinks (they consume no space (size=0), but could be
+        # represented as regular copies of a shared key. however, this
+        # requires further processing of the metadat records, in order to find
+        # the size of the item that has the same checksum as this one)
+        if r.get('type') == 'file'
+    ]
+    # we enable the `datalad-archives` special remote using a particular
+    # configuration that `add-archive-content` would use.
+    # this special remote can act on the particular URLs that we will add next
+    ds.repo.call_annex([
+        'initremote', 'datalad-archives', 'type=external',
+        'externaltype=datalad-archives', 'encryption=none', 'autoenable=true'])
+    # assign special `dl+archive` URLs to all file keys
+    # the `datalad-archives` special remote will see them and perform the
+    # extraction of file content from the archive on demand.
+    # the entire operation is not doing any extraction or data retrieval,
+    # because we have all information necessary to generate keys
+    ds.addurls(
+        # takes an iterable of dicts
+        file_recs,
+        # urlformat: handcrafted archive key, as expected by datalad-archive
+        # (double braces to keep item and size as placeholders for addurls)
+        f'dl+archive:{archive_key}#path={{item}}&size={{size}}',
+        # filenameformat
+        '{item}',
+        key='et:MD5-s{size}--{hash-md5}',
+        **kwa
+    )
+    # because we have  been adding the above URLs using a pure metadata-driven
+    # approach, git-annex does not yet know that the archives remote actually
+    # has the keys. we could use `annex setpresentkey` for that (fast local
+    # operation), but here we use `fsck` to achieve a comprehensive smoke test
+    # of compatibility with our hand-crafted and the special remote
+    # implementation
+    # (actually: without --fast the special remote crashes with a protocol
+    #  error -- a bug in the special remote probably)
+    ds.repo.call_annex(
+        ['fsck', '--fast', '-f', 'datalad-archives'],
+        files=['test-archive'],
+    )
+    # at this point we are done
+    # check retrieval for a test file, which is not yet around
+    testfile = ds.pathobj / 'test-archive' / '123_hard.txt'
+    assert ds.status(
+        testfile, annex='availability', **kwa)[0]['has_content'] is False
+    ds.get(testfile, **kwa)
+    assert testfile.read_text() == '123\n'

--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -33,3 +33,8 @@ from datalad_next.tests.fixtures import (
     # function-scope, serve a local temp-path via WebDAV
     webdav_server,
 )
+from datalad_next.iter_collections.tests.test_itertar import (
+    # session-scope, downloads a tarball with a set of standard
+    # file/dir/link types
+    sample_tar_xz,
+)

--- a/datalad_next/constraints/tests/test_cmdarg_validation.py
+++ b/datalad_next/constraints/tests/test_cmdarg_validation.py
@@ -69,10 +69,22 @@ class BasicCmdValidator(EnsureCommandParameterization):
 
 class SophisticatedCmdValidator(BasicCmdValidator):
     def _check_unique_values(self, **kwargs):
-        EnsureAllUnique()(kwargs.values())
+        try:
+            EnsureAllUnique()(kwargs.values())
+        except ConstraintError as e:
+            self.raise_for(
+                kwargs,
+                e.msg,
+            )
 
     def _check_sum_range(self, p1, p2):
-        EnsureRange(min=3)(p1 + p2)
+        try:
+            EnsureRange(min=3)(p1 + p2)
+        except ConstraintError:
+            self.raise_for(
+                dict(p1=p1, p2=p2),
+                "it's too small"
+            )
 
     def _limit_sum_range(self, p1, p2):
         # random example of a joint constraint that modifies the parameter

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -6,4 +6,5 @@
 
    directory
    tarfile
+   utils
 """

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -5,4 +5,5 @@
    :toctree: generated
 
    directory
+   tarfile
 """

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -1,5 +1,18 @@
 """Iterators for particular types of collections
 
+Most importantly this includes different collections (or containers) for files,
+such as a file system directory, or an archive (also see the
+``ls_file_collection`` command). However, this module is not per-se limited
+to file collections.
+
+Most, if not all, implementation come in the form of a function that takes
+a collection identifier or a collection location (e.g., a file system path),
+and possibly some additional options. When called, an iterator is returned
+that produces collection items in the form of data class instances of
+a given type. The particular type can be different across different
+collections.
+
+
 .. currentmodule:: datalad_next.iter_collections
 .. autosummary::
    :toctree: generated

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -1,0 +1,8 @@
+"""Iterators for particular types of collections
+
+.. currentmodule:: datalad_next.iter_collections
+.. autosummary::
+   :toctree: generated
+
+   directory
+"""

--- a/datalad_next/iter_collections/directory.py
+++ b/datalad_next/iter_collections/directory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 import os
 from pathlib import Path
 import stat
@@ -18,7 +18,12 @@ from datalad_next.utils.consts import COPY_BUFSIZE
 from datalad_next.utils.multihash import MultiHash
 
 
-class PathType(Enum):
+class PathType(StrEnum):
+    """Enumeration of path types distinguished by ``iterdir()``
+
+    The associated ``str`` values are chosen to be appropriate for
+    downstream use (e.g, as type labels in DataLad result records).
+    """
     file = 'file'
     directory = 'directory'
     symlink = 'symlink'
@@ -28,7 +33,7 @@ class PathType(Enum):
 class IterdirItem:
     path: Path
     type: PathType
-    symlink_target: Path | None = None
+    link_target: Path | None = None
     hash: Dict[str, str] | None = None
 
 
@@ -47,7 +52,7 @@ def iterdir(
     ----------
     path: Path
       Path of the directory to report content for (iterate over).
-    symlink_targets: bool, optional
+    link_targets: bool, optional
       Flag whether to read and report the target path of a symbolic link.
 
 
@@ -55,10 +60,6 @@ def iterdir(
     ------
     :class:`IterdirItem`
     """
-    # anything reported from here will be state=untracked
-    # figure out the type, as far as we need it
-    # right now we do not detect a subdir to be a dataset
-    # vs a directory, only directories
     for c in path.iterdir():
         # c could disappear while this is running. Example: temp files managed
         # by other processes.
@@ -84,7 +85,7 @@ def iterdir(
         )
         if ctype == PathType.symlink:
             # could be p.readlink() from PY3.9+
-            item.symlink_target = Path(os.readlink(c))
+            item.link_target = Path(os.readlink(c))
         yield item
 
 

--- a/datalad_next/iter_collections/directory.py
+++ b/datalad_next/iter_collections/directory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 import os
 from pathlib import Path
 import stat
@@ -18,7 +18,8 @@ from datalad_next.utils.consts import COPY_BUFSIZE
 from datalad_next.utils.multihash import MultiHash
 
 
-class PathType(StrEnum):
+# TODO Could be `StrEnum`, came with PY3.11
+class PathType(Enum):
     """Enumeration of path types distinguished by ``iterdir()``
 
     The associated ``str`` values are chosen to be appropriate for

--- a/datalad_next/iter_collections/directory.py
+++ b/datalad_next/iter_collections/directory.py
@@ -1,4 +1,7 @@
-"""Report on the content of directories"""
+"""Report on the content of directories
+
+The main functionality is provided by the :func:`iterdir()` function.
+"""
 
 from __future__ import annotations
 
@@ -30,22 +33,27 @@ class IterdirItem(FileSystemItem):
 
 def iterdir(
     path: Path,
+    *,
     hash: List[str] | None = None,
-    symlink_targets: bool = True,
 ) -> Generator[IterdirItem, None, None]:
-    """Use ``Path.iterdir()`` to iterate over a directory and report content
+    """Uses ``Path.iterdir()`` to iterate over a directory and reports content
+
+    The iterator produces an :class:`IterdirItem` instance with standard
+    information on file system elements, such as ``size``, or ``mtime``.
 
     In addition to a plain ``Path.iterdir()`` the report includes a path-type
-    label (distinguished are ``file``, ``directory``, ``symlink``), and
-    (optionally) information on the target path of a symlink.
+    label (distinguished are ``file``, ``directory``, ``symlink``). Moreover,
+    any number of checksums for file content can be computed and reported.
 
     Parameters
     ----------
     path: Path
       Path of the directory to report content for (iterate over).
-    link_targets: bool, optional
-      Flag whether to read and report the target path of a symbolic link.
-
+    hash: list(str), optional
+      Any number of hash algorithm names (supported by the ``hashlib`` module
+      of the Python standard library. If given, an item corresponding to the
+      algorithm will be included in the ``hash`` property dict of each
+      reported file-type item.
 
     Yields
     ------

--- a/datalad_next/iter_collections/directory.py
+++ b/datalad_next/iter_collections/directory.py
@@ -23,7 +23,7 @@ from .utils import (
 )
 
 
-@dataclass(kw_only=True)
+@dataclass  # sadly PY3.10+ only (kw_only=True)
 class IterdirItem(FileSystemItem):
     pass
 

--- a/datalad_next/iter_collections/directory.py
+++ b/datalad_next/iter_collections/directory.py
@@ -1,0 +1,78 @@
+"""Report on the content of directories"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import os
+from pathlib import Path
+import stat
+from typing import Generator
+
+from datalad_next.exceptions import CapturedException
+
+
+class PathType(Enum):
+    file = 'file'
+    directory = 'directory'
+    symlink = 'symlink'
+
+
+@dataclass
+class IterdirItem:
+    path: Path
+    type: PathType
+    symlink_target: Path | None = None
+
+
+def iterdir(
+    path: Path,
+    symlink_targets: bool = True,
+) -> Generator[IterdirItem, None, None]:
+    """Use ``Path.iterdir()`` to iterate over a directory and report content
+
+    In addition to a plain ``Path.iterdir()`` the report includes a path-type
+    label (distinguished are ``file``, ``directory``, ``symlink``), and
+    (optionally) information on the target path of a symlink.
+
+    Parameters
+    ----------
+    path: Path
+      Path of the directory to report content for (iterate over).
+    symlink_targets: bool, optional
+      Flag whether to read and report the target path of a symbolic link.
+
+
+    Yields
+    ------
+    :class:`IterdirItem`
+    """
+    # anything reported from here will be state=untracked
+    # figure out the type, as far as we need it
+    # right now we do not detect a subdir to be a dataset
+    # vs a directory, only directories
+    for c in path.iterdir():
+        # c could disappear while this is running. Example: temp files managed
+        # by other processes.
+        try:
+            cmode = c.lstat().st_mode
+        except FileNotFoundError as e:
+            CapturedException(e)
+            continue
+        if stat.S_ISLNK(cmode):
+            ctype = PathType.symlink
+        elif stat.S_ISDIR(cmode):
+            ctype = PathType.directory
+        else:
+            # the rest is a file
+            # there could be fifos and sockets, etc.
+            # but we do not recognize them here
+            ctype = PathType.file
+        item = IterdirItem(
+            path=c,
+            type=ctype,
+        )
+        if ctype == PathType.symlink:
+            # could be p.readlink() from PY3.9+
+            item.symlink_target = Path(os.readlink(c))
+        yield item

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 from pathlib import (
     Path,
     PurePosixPath,
@@ -19,7 +19,8 @@ from datalad_next.utils.consts import COPY_BUFSIZE
 from datalad_next.utils.multihash import MultiHash
 
 
-class TarMemberType(StrEnum):
+# TODO Could be `StrEnum`, came with PY3.11
+class TarMemberType(Enum):
     """Enumeration of member types distinguished by ``itertar()``
 
     The associated ``str`` values are chosen to be appropriate for

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -20,7 +20,7 @@ from .utils import (
 )
 
 
-@dataclass(kw_only=True)
+@dataclass  # sadly PY3.10+ only (kw_only=True)
 class ItertarItem(FileSystemItem):
     pass
 

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -1,4 +1,7 @@
-"""Report on the content of TAR archives"""
+"""Report on the content of TAR archives
+
+The main functionality is provided by the :func:`itertar()` function.
+"""
 
 from __future__ import annotations
 
@@ -28,13 +31,30 @@ class ItertarItem(FileSystemItem):
 
 def itertar(
     path: Path,
+    *,
     hash: List[str] | None = None,
 ) -> Generator[ItertarItem, None, None]:
-    """
+    """Uses the standard library ``tarfile`` module to report on TAR archives
+
+    A TAR archive can represent more or less the full bandwidth of file system
+    properties, therefore reporting on archive members is implemented
+    similar to :func:`~datalad_next.iter_collections.directory.iterdir()`.
+    The iterator produces an :class:`ItertarItem` instance with standard
+    information on file system elements, such as ``size``, or ``mtime``.
+
+    Moreover, any number of checksums for file content can be computed and
+    reported. When computing checksums, individual archive members are read
+    sequentially without extracting the full archive.
+
     Parameters
     ----------
     path: Path
       Path of the TAR archive to report content for (iterate over).
+    hash: list(str), optional
+      Any number of hash algorithm names (supported by the ``hashlib`` module
+      of the Python standard library. If given, an item corresponding to the
+      algorithm will be included in the ``hash`` property dict of each
+      reported file-type item.
 
     Yields
     ------

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import (
     Path,
+    PurePath,
     PurePosixPath,
 )
 import tarfile
@@ -55,7 +56,8 @@ def itertar(
                 size=member.size,
                 mode=member.mode,
                 mtime=member.mtime,
-                link_target=member.linkname or None,
+                link_target=PurePath(PurePosixPath(member.linkname))
+                if member.linkname else None,
                 hash=_compute_hash(tar, member, hash)
                 if hash and mtype in (
                     FileSystemItemType.file, FileSystemItemType.hardlink)

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -1,0 +1,95 @@
+"""Report on the content of TAR archives"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+import tarfile
+from typing import (
+    Dict,
+    Generator,
+    List
+)
+
+from datalad_next.utils.consts import COPY_BUFSIZE
+from datalad_next.utils.multihash import MultiHash
+
+
+class TarMemberType(StrEnum):
+    """Enumeration of member types distinguished by ``itertar()``
+
+    The associated ``str`` values are chosen to be appropriate for
+    downstream use (e.g, as type labels in DataLad result records).
+    """
+    file = 'file'
+    directory = 'directory'
+    symlink = 'symlink'
+    hardlink = 'file'
+    specialfile = 'file'
+
+
+@dataclass(kw_only=True)
+class ItertarItem:
+    name: PurePosixPath
+    type: TarMemberType
+    size: int
+    mtime: float
+    mode: int
+    link_target: Path | None = None
+    hash: Dict[str, str] | None = None
+
+
+def itertar(
+    path: Path,
+    hash: List[str] | None = None,
+) -> Generator[ItertarItem, None, None]:
+    """
+    Parameters
+    ----------
+    path: Path
+      Path of the TAR archive to report content for (iterate over).
+
+    Yields
+    ------
+    :class:`ItertarItem`
+    """
+    with tarfile.open(path, 'r') as tar:
+        for member in tar:
+            # reduce the complexity of tar member types to the desired
+            # level (ie. disregard the diversity of special files and
+            # block devices)
+            mtype = TarMemberType.file if member.isreg() \
+                else TarMemberType.directory if member.isdir() \
+                else TarMemberType.symlink if member.issym() \
+                else TarMemberType.hardlink if member.islnk() \
+                else TarMemberType.specialfile
+            item = ItertarItem(
+                name=PurePosixPath(member.name),
+                type=mtype,
+                size=member.size,
+                mode=member.mode,
+                mtime=member.mtime,
+                link_target=member.linkname or None,
+                hash=_compute_hash(tar, member, hash)
+                if hash and mtype in (
+                    TarMemberType.file, TarMemberType.hardlink)
+                else None,
+            )
+            yield item
+
+
+# TODO deduplicate with directory._compute_hash()
+def _compute_hash(
+        tar: tarfile.TarFile, member: tarfile.TarInfo, hash: List[str]):
+    with tar.extractfile(member) as f:
+        hash = MultiHash(hash)
+        while True:
+            chunk = f.read(COPY_BUFSIZE)
+            if not chunk:
+                break
+            hash.update(chunk)
+    return hash.get_hexdigest()

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -51,7 +51,7 @@ def itertar(
                 else FileSystemItemType.hardlink if member.islnk() \
                 else FileSystemItemType.specialfile
             item = ItertarItem(
-                name=PurePosixPath(member.name),
+                name=PurePath(PurePosixPath(member.name)),
                 type=mtype,
                 size=member.size,
                 mode=member.mode,

--- a/datalad_next/iter_collections/tests/test_iterdir.py
+++ b/datalad_next/iter_collections/tests/test_iterdir.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import PurePath
 import pytest
 
@@ -45,7 +46,11 @@ def test_iterdir(dir_tree):
                                 dir_tree / '__dummy2__'):
         target_paths.append((
             dir_tree / 'symlink', FileSystemItemType.symlink,
-            dict(link_target=dir_tree / 'some_dir' / "file_in_dir.txt"),
+            # how `readlink()` behaves on windows is fairly complex
+            # rather than anticipating a result (that changes with
+            # python version, see https://bugs.python.org/issue42957),
+            # we simply test that this is compatible with `os.readlink()`
+            dict(link_target=PurePath(os.readlink(dir_tree / 'symlink'))),
         ))
     target = [
         IterdirItem(

--- a/datalad_next/iter_collections/tests/test_iterdir.py
+++ b/datalad_next/iter_collections/tests/test_iterdir.py
@@ -1,3 +1,4 @@
+from pathlib import PurePath
 import pytest
 
 from datalad_next.tests.utils import (
@@ -8,7 +9,7 @@ from datalad_next.utils import check_symlink_capability
 
 from ..directory import (
     IterdirItem,
-    PathType,
+    FileSystemItemType,
     iterdir,
 )
 
@@ -37,18 +38,18 @@ def dir_tree(tmp_path_factory):
 
 def test_iterdir(dir_tree):
     target_paths = [
-        (dir_tree / 'random_file1.txt', PathType.file, {}),
-        (dir_tree / 'some_dir', PathType.directory, {}),
+        (dir_tree / 'random_file1.txt', FileSystemItemType.file, {}),
+        (dir_tree / 'some_dir', FileSystemItemType.directory, {}),
     ]
     if check_symlink_capability(dir_tree / '__dummy1__',
                                 dir_tree / '__dummy2__'):
         target_paths.append((
-            dir_tree / 'symlink', PathType.symlink,
+            dir_tree / 'symlink', FileSystemItemType.symlink,
             dict(link_target=dir_tree / 'some_dir' / "file_in_dir.txt"),
         ))
     target = [
         IterdirItem(
-            path=path,
+            name=PurePath(path.name),
             type=type,
             size=path.lstat().st_size,
             mode=path.lstat().st_mode,

--- a/datalad_next/iter_collections/tests/test_iterdir.py
+++ b/datalad_next/iter_collections/tests/test_iterdir.py
@@ -1,0 +1,66 @@
+import pytest
+
+from datalad_next.tests.utils import (
+    create_tree,
+    rmtree,
+)
+from datalad_next.utils import check_symlink_capability
+
+from ..directory import (
+    IterdirItem,
+    PathType,
+    iterdir,
+)
+
+
+@pytest.fixture(scope="function")
+def dir_tree(tmp_path_factory):
+    path = tmp_path_factory.mktemp("dir_tree")
+    create_tree(
+        path,
+        {
+            "random_file1.txt": "some content",
+            "some_dir": {
+                "file_in_dir.txt": "some content in file in dir",
+            },
+        }
+    )
+    symlink = path / 'symlink'
+    symlink_target = path / 'some_dir' / "file_in_dir.txt"
+
+    if check_symlink_capability(symlink, symlink_target):
+        symlink.symlink_to(symlink_target)
+
+    yield path
+    rmtree(path)
+
+
+def test_iterdir(dir_tree):
+    target = [
+        IterdirItem(path=dir_tree / 'random_file1.txt', type=PathType.file),
+        IterdirItem(path=dir_tree / 'some_dir', type=PathType.directory),
+    ]
+    if check_symlink_capability(dir_tree / '__dummy1__',
+                                dir_tree / '__dummy2__'):
+        target.append(
+            IterdirItem(
+                path=dir_tree / 'symlink',
+                type=PathType.symlink,
+                symlink_target=dir_tree / 'some_dir' / "file_in_dir.txt",
+            ),
+        )
+
+    iterdir_res = list(iterdir(dir_tree))
+    assert len(iterdir_res) == len(target)
+    for item in iterdir(dir_tree):
+        assert item in target
+
+    # check iterdir() to be robust to concurrent removal
+    it = iterdir(dir_tree)
+    # start iteration
+    next(it)
+    # wipe out content
+    for i in dir_tree.glob('*'):
+        rmtree(i)
+    # consume the rest of the generator, nothing more, but also no crashing
+    assert [] == list(it)

--- a/datalad_next/iter_collections/tests/test_iterdir.py
+++ b/datalad_next/iter_collections/tests/test_iterdir.py
@@ -36,19 +36,27 @@ def dir_tree(tmp_path_factory):
 
 
 def test_iterdir(dir_tree):
-    target = [
-        IterdirItem(path=dir_tree / 'random_file1.txt', type=PathType.file),
-        IterdirItem(path=dir_tree / 'some_dir', type=PathType.directory),
+    target_paths = [
+        (dir_tree / 'random_file1.txt', PathType.file, {}),
+        (dir_tree / 'some_dir', PathType.directory, {}),
     ]
     if check_symlink_capability(dir_tree / '__dummy1__',
                                 dir_tree / '__dummy2__'):
-        target.append(
-            IterdirItem(
-                path=dir_tree / 'symlink',
-                type=PathType.symlink,
-                symlink_target=dir_tree / 'some_dir' / "file_in_dir.txt",
-            ),
+        target_paths.append((
+            dir_tree / 'symlink', PathType.symlink,
+            dict(link_target=dir_tree / 'some_dir' / "file_in_dir.txt"),
+        ))
+    target = [
+        IterdirItem(
+            path=path,
+            type=type,
+            size=path.lstat().st_size,
+            mode=path.lstat().st_mode,
+            mtime=path.lstat().st_mtime,
+            **kwa
         )
+        for path, type, kwa in target_paths
+    ]
 
     iterdir_res = list(iterdir(dir_tree))
     assert len(iterdir_res) == len(target)

--- a/datalad_next/iter_collections/tests/test_iterdir.py
+++ b/datalad_next/iter_collections/tests/test_iterdir.py
@@ -39,7 +39,9 @@ def dir_tree(tmp_path_factory):
 
 def test_iterdir(dir_tree):
     target_paths = [
-        (dir_tree / 'random_file1.txt', FileSystemItemType.file, {}),
+        (dir_tree / 'random_file1.txt', FileSystemItemType.file,
+         dict(hash=dict(md5='9893532233caff98cd083a116b013c0b',
+                        SHA1='94e66df8cd09d410c62d9e0dc59d3a884e458e05'))),
         (dir_tree / 'some_dir', FileSystemItemType.directory, {}),
     ]
     if check_symlink_capability(dir_tree / '__dummy1__',
@@ -66,7 +68,8 @@ def test_iterdir(dir_tree):
 
     iterdir_res = list(iterdir(dir_tree))
     assert len(iterdir_res) == len(target)
-    for item in iterdir(dir_tree):
+    # capitalization of algorithm labels is preserved
+    for item in iterdir(dir_tree, hash=['md5', 'SHA1']):
         assert item in target
 
     # check iterdir() to be robust to concurrent removal

--- a/datalad_next/iter_collections/tests/test_itertar.py
+++ b/datalad_next/iter_collections/tests/test_itertar.py
@@ -1,0 +1,100 @@
+import os
+from pathlib import PurePath
+import pytest
+
+from datalad.api import download
+
+from ..tarfile import (
+    ItertarItem,
+    FileSystemItemType,
+    itertar,
+)
+
+
+@pytest.fixture(scope="session")
+def sample_tar_xz(tmp_path_factory):
+    """Provides a path to a tarball with file, directory, hard link,
+    and soft link. Any file content is '123\n'. The associated hashes
+    are:
+
+    md5: ba1f2511fc30423bdbb183fe33f3dd0f
+    sha1: a8fdc205a9f19cc1c7507a60c4f01b13d11d7fd0
+
+    Layout::
+
+        ❯ datalad tree --include-files test-archive
+        test-archive
+        ├── 123.txt -> subdir/onetwothree_again.txt
+        ├── 123_hard.txt
+        ├── onetwothree.txt
+        └── subdir/
+            └── onetwothree_again.txt
+    """
+    path = tmp_path_factory.mktemp("tarfile")
+    tfpath = path / 'sample.tar.xz'
+    download({
+        'https://github.com/datalad/datalad-next/releases/download/0.1.0/test_archive.tar.xz':
+        tfpath
+    })
+
+    yield tfpath
+
+    tfpath.unlink()
+
+
+def test_itertar(sample_tar_xz):
+    target_hash = {'SHA1': 'a8fdc205a9f19cc1c7507a60c4f01b13d11d7fd0',
+                   'md5': 'ba1f2511fc30423bdbb183fe33f3dd0f'}
+    targets = [
+        ItertarItem(
+            name=PurePath('test-archive'),
+            type=FileSystemItemType.directory,
+            size=0,
+            mtime=1683657433,
+            mode=509,
+            hash=None),
+        ItertarItem(
+            name=PurePath('test-archive') / '123.txt',
+            type=FileSystemItemType.symlink,
+            size=0,
+            mtime=1683657414,
+            mode=511,
+            link_target=PurePath('subdir') / 'onetwothree_again.txt',
+            hash=None),
+        ItertarItem(
+            name=PurePath('test-archive') / '123_hard.txt',
+            type=FileSystemItemType.file,
+            size=4,
+            mtime=1683657364,
+            mode=436,
+            link_target=None,
+            hash=target_hash),
+        ItertarItem(
+            name=PurePath('test-archive') / 'subdir',
+            type=FileSystemItemType.directory,
+            size=0,
+            mtime=1683657400,
+            mode=509),
+        ItertarItem(
+            name=PurePath('test-archive') / 'subdir' / 'onetwothree_again.txt',
+            type=FileSystemItemType.file,
+            size=4,
+            mtime=1683657400,
+            mode=436,
+            link_target=None,
+            hash=target_hash),
+        ItertarItem(
+            name=PurePath('test-archive') / 'onetwothree.txt',
+            type=FileSystemItemType.hardlink,
+            size=0,
+            mtime=1683657364,
+            mode=436,
+            link_target=PurePath('test-archive') / '123_hard.txt',
+            hash=target_hash),
+    ]
+    # smoke test
+    ires = list(itertar(sample_tar_xz, hash=['md5', 'SHA1']))
+    # root + subdir, 2 files, softlink, hardlink
+    assert 6 == len(ires)
+    for t in targets:
+        assert t in ires

--- a/datalad_next/iter_collections/utils.py
+++ b/datalad_next/iter_collections/utils.py
@@ -1,0 +1,51 @@
+"""Utilities and types for collection iterators"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import PurePath
+from typing import (
+    Dict,
+    List,
+)
+
+from datalad_next.utils.consts import COPY_BUFSIZE
+from datalad_next.utils.multihash import MultiHash
+
+
+# TODO Could be `StrEnum`, came with PY3.11
+class FileSystemItemType(Enum):
+    """Enumeration of file system path types
+
+    The associated ``str`` values are chosen to be appropriate for
+    downstream use (e.g, as type labels in DataLad result records).
+    """
+    file = 'file'
+    directory = 'directory'
+    symlink = 'symlink'
+    hardlink = 'file'
+    specialfile = 'file'
+
+
+@dataclass(kw_only=True)
+class FileSystemItem:
+    name: PurePath
+    type: FileSystemItemType
+    size: int
+    mtime: float
+    mode: int
+    link_target: PurePath | None = None
+    hash: Dict[str, str] | None = None
+
+
+def compute_multihash_from_fp(fp, hash: List[str], bufsize=COPY_BUFSIZE):
+    """Compute multiple hashes from a file-like
+    """
+    hash = MultiHash(hash)
+    while True:
+        chunk = fp.read(bufsize)
+        if not chunk:
+            break
+        hash.update(chunk)
+    return hash.get_hexdigest()

--- a/datalad_next/iter_collections/utils.py
+++ b/datalad_next/iter_collections/utils.py
@@ -24,8 +24,8 @@ class FileSystemItemType(Enum):
     file = 'file'
     directory = 'directory'
     symlink = 'symlink'
-    hardlink = 'file'
-    specialfile = 'file'
+    hardlink = 'hardlink'
+    specialfile = 'specialfile'
 
 
 @dataclass  # sadly PY3.10+ only (kw_only=True)
@@ -33,8 +33,8 @@ class FileSystemItem:
     name: PurePath
     type: FileSystemItemType
     size: int
-    mtime: float
-    mode: int
+    mtime: float | None = None
+    mode: int | None = None
     link_target: PurePath | None = None
     hash: Dict[str, str] | None = None
 

--- a/datalad_next/iter_collections/utils.py
+++ b/datalad_next/iter_collections/utils.py
@@ -28,7 +28,7 @@ class FileSystemItemType(Enum):
     specialfile = 'file'
 
 
-@dataclass(kw_only=True)
+@dataclass  # sadly PY3.10+ only (kw_only=True)
 class FileSystemItem:
     name: PurePath
     type: FileSystemItemType

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,4 +8,5 @@ High-level API commands
    create_sibling_webdav
    credentials
    download
+   ls_file_collection
    tree

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -7,4 +7,5 @@ Command line reference
    generated/man/datalad-create-sibling-webdav
    generated/man/datalad-credentials
    generated/man/datalad-download
+   generated/man/datalad-ls-file-collection
    generated/man/datalad-tree

--- a/docs/source/pyutils.rst
+++ b/docs/source/pyutils.rst
@@ -11,6 +11,7 @@ Python utilities
    constraints
    credman.manager
    exceptions
+   iter_collections
    url_operations
    url_operations.any
    url_operations.file


### PR DESCRIPTION
This PR is making `add-archive-content` (largely) obsolete. Closes #183 

Summary

- new module `iter_collections` to establish a location in the spirit of #323 . The idea is to use dataclasses instead of result records, and enums instead of string labels to report on collection content. Iterators also support hashing (as means to generate identifiers.
  - import `iterdir()` from `datalad-gooey` as an iterator for a directory as a collections (of directory content)
  - implemented `itertar()` for tar file archives -- reporting aligned with `iterdir()`
- `ls-file-collection` command that can drive these iterators.
  - factors any glue code necessary into a custom validator 
  - converts collection iterator items into result records and yields them

This is somewhat in conflict with #342 due to suboptimal communication. A future discussion needs to sort out how the two approaches can be consolidated.

TODO:

- [x] we need to be able hash collection items, ideally using a configurable algorithm. The command draft prepares for that. however, it is still unclear whether this would be done in a collection iterator (pretty strong requirement), or within the command itself (complicated to achieve, because it would require duplicating any possibly necessary data transport logic between the iterator implementation and the command). That being said, one could envision remote collections that can readily provide a hash -- for those it would make most sense to let the iterator report them. So maybe a `hash` parameter of `ls-file-collection` should be an instruction what to compute, if there is no hash already. If so, an iterator would no only need to report a hash, but also the type of the hash it is reporting.
  It could be a sensible middle-ground to have an iterator provide a zero-argument callable that provides a file-like that generic hash-computation can use, if the controlling command deems it necessary (e.g. a requested hash is not readily provided).
  That being said, it is unlikely that a generic implementation of a read-from-some-file-like is going to be optimal. Considering the bandwith of possibilities and necessities for `download` (i.e. anything remote; streaming, chunks size, etc) alone cries for configurability. So maybe going down the path of `UrlOperations` which can hash on the go is a better approach. Maybe factor that out into a dedicated class, and simply make it easy to use...
- [x] for #183 we need an iterator for archives (we could have two, a simple one for local archives, and a more sophisticated for remote archives (see #342) -- but they would not necessarily differ much in the end, if hashing must be perform -- rather than being able to report an existing hash.https://doi.org/10.1038/s41597-022-01163-2
- [x] #342 mentions auto-detection of collection types. I initially had the same idea, but then could not come up with a use case where one would want to (surrender to) auto-detect. What `auto` would do could/would change over time. Conflict would always be there (even if a had a gitrepo worktree, I might still just need a directory listing). `auto` could maybe provide a bit of perceived convenience for interactive use, but that convenience would need to be bough with added complexity of auto-detection and for preserving its outcome, long-term. Not worth it IMHO.
- [x] legit error on windows (symlink target looks broken)
```
       FAILED ..\iter_collections\tests\test_iterdir.py::test_iterdir - AssertionError: assert IterdirItem(path=WindowsPath('C:/DLTMP/pytest-of-appveyor/pytest-0/dir_tree0/symlink'), type=<PathType.symlink: 'symlink'>, symlink_target=WindowsPath('//?/C:/DLTMP/pytest-of-appveyor/pytest-0/dir_tree0/some_dir/file_in_dir.txt')) in [IterdirItem(path=WindowsPath('C:/DLTMP/pytest-of-appveyor/pytest-0/dir_tree0/random_file1.txt'), type=<PathType.file: 'file'>, symlink_target=None), IterdirItem(path=WindowsPath('C:/DLTMP/pytest-of-appveyor/pytest-0/dir_tree0/some_dir'), type=<PathType.directory: 'directory'>, symlink_target=None), IterdirItem(path=WindowsPath('C:/DLTMP/pytest-of-appveyor/pytest-0/dir_tree0/symlink'), type=<PathType.symlink: 'symlink'>, symlink_target=WindowsPath('C:/DLTMP/pytest-of-appveyor/pytest-0/dir_tree0/some_dir/file_in_dir.txt'))]
```
This seems to be related to the following doc snippet

> Changed in version 3.8: Added support for directory junctions, and changed to return the substitution path (which typically includes \\?\ prefix) rather than the optional “print name” field that was previously returned.

https://bugs.python.org/issue42957

- [x] report file sizes for all collection types
- [x] Stop using `StrEnum` -- only available from Python 3.11 onwards
- [x] Bring test coverage of `iter_collections` to 100%
- [x] Add tests for `ls-file-collection`
- [x] Fully document `iter_collections`
- [x] Document `ls-file-collection`. Include a demo on replacing `add-archive-content`
- [x] Make decision on representation of hardlinks (see TODO in `test_replace_add_archive_content`)
- [x] Something not correct with path type from itertar on windows yet
- [x] Add custom result renderer


Addressed issues

- Closes #348 