### PR TITLE
Centralize imports and additions to and from `datalad.runner`

### DIFF
--- a/datalad_next/constraints/git.py
+++ b/datalad_next/constraints/git.py
@@ -1,5 +1,11 @@
 """Constraints for Git-related concepts and parameters"""
 
+from datalad_next.runners import (
+    CommandError,
+    GitRunner,
+    StdOutCapture,
+)
+
 from .base import Constraint
 
 
@@ -37,8 +43,6 @@ class EnsureGitRefName(Constraint):
             # simple, do here
             self.raise_for(value, 'refname must not be empty')
 
-        from datalad.runner import GitRunner, StdOutCapture
-        from datalad_next.exceptions import CommandError
         runner = GitRunner()
         cmd = ['git', 'check-ref-format']
         cmd.append('--allow-onelevel'

--- a/datalad_next/exceptions/__init__.py
+++ b/datalad_next/exceptions/__init__.py
@@ -1,6 +1,6 @@
 """All custom exceptions used in datalad-next"""
 
-from datalad.runner import CommandError
+from datalad_next.runners import CommandError
 from datalad.support.exceptions import (
     CapturedException,
     IncompleteResultsError,

--- a/datalad_next/gitremotes/datalad_annex.py
+++ b/datalad_next/gitremotes/datalad_annex.py
@@ -197,19 +197,18 @@ from urllib.parse import (
 )
 
 from datalad.core.local.repo import repo_from_path
-from datalad.runner import (
-    NoCapture,
-    StdOutCapture,
-)
+
+from datalad_next.constraints import EnsureInt
 from datalad_next.datasets import (
     LegacyAnnexRepo as AnnexRepo,
     LegacyGitRepo as GitRepo,
 )
-from datalad_next.exceptions import (
-    CapturedException,
+from datalad_next.exceptions import CapturedException
+from datalad_next.runners import (
     CommandError,
+    NoCapture,
+    StdOutCapture,
 )
-from datalad_next.constraints import EnsureInt
 from datalad_next.uis import ui_switcher as ui
 from datalad_next.utils import (
     external_versions,

--- a/datalad_next/patches/push_optimize.py
+++ b/datalad_next/patches/push_optimize.py
@@ -43,7 +43,6 @@ import logging
 import re
 
 import datalad.core.distributed.push as mod_push
-from datalad.runner.exception import CommandError
 from datalad_next.utils import (
     ensure_list,
     log_progress,
@@ -440,7 +439,7 @@ def _sync_remote_annex_branch(repo, target, is_annex_repo):
         # from us, we just skip localsync without mutating repo into an AnnexRepo
         if is_annex_repo:
             repo.localsync(target)
-    except CommandError as e:
+    except mod_push.CommandError as e:
         # it is OK if the remote doesn't have a git-annex branch yet
         # (e.g. fresh repo)
         # TODO is this possible? we just copied? Maybe check if anything

--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -18,7 +18,6 @@ from typing import (
 from unittest.mock import patch
 
 import datalad.core.distributed.push as mod_push
-from datalad.runner.exception import CommandError
 from datalad_next.constraints import EnsureChoice
 from datalad_next.exceptions import CapturedException
 from datalad_next.commands import Parameter
@@ -111,7 +110,7 @@ def get_export_records(repo: AnnexRepo) -> Generator:
             ))
             result_dict["timestamp"] = float(result_dict["timestamp"][:-1])
             yield result_dict
-    except CommandError as command_error:
+    except mod_push.CommandError as command_error:
         # Some errors indicate that there was no export yet.
         # May depend on Git version
         expected_errors = (
@@ -242,7 +241,7 @@ def _transfer_data(repo: AnnexRepo,
                 result_adjusted['action'] = "copy"
                 yield result_adjusted
 
-        except CommandError as cmd_error:
+        except mod_push.CommandError as cmd_error:
             ce = CapturedException(cmd_error)
             yield {
                 **res_kwargs,

--- a/datalad_next/patches/tests/test_push_to_export_remote.py
+++ b/datalad_next/patches/tests/test_push_to_export_remote.py
@@ -6,7 +6,6 @@ from unittest.mock import (
     patch,
 )
 
-from datalad.runner.exception import CommandError
 from datalad_next.tests.utils import (
     SkipTest,
     assert_in,
@@ -20,6 +19,7 @@ from datalad_next.patches.push_to_export_remote import (
     _is_valid_treeish,
     _transfer_data,
     get_export_records,
+    mod_push,
 )
 
 
@@ -176,7 +176,7 @@ def test_no_special_remotes():
 def test_get_export_records_no_exports():
     class NoExportRepo:
         def call_git_items_(self, *args, **kwargs):
-            raise CommandError(
+            raise mod_push.CommandError(
                 stderr="fatal: Not a valid object name git-annex:export.log")
 
     results = tuple(get_export_records(NoExportRepo()))

--- a/datalad_next/runners/__init__.py
+++ b/datalad_next/runners/__init__.py
@@ -1,0 +1,25 @@
+# runners
+from datalad.runner import (
+    GitRunner,
+    Runner,
+)
+from datalad.runner.nonasyncrunner import ThreadedRunner
+
+# protocols
+from datalad.runner import (
+    KillOutput,
+    NoCapture,
+    Protocol,
+    StdOutCapture,
+    StdErrCapture,
+    StdOutErrCapture,
+)
+from datalad.runner.protocol import GeneratorMixIn
+from .protocols import (
+    NoCaptureGeneratorProtocol,
+    StdOutCaptureGeneratorProtocol,
+)
+# exceptions
+from datalad.runner import (
+    CommandError,
+)

--- a/datalad_next/runners/protocols.py
+++ b/datalad_next/runners/protocols.py
@@ -1,0 +1,31 @@
+from . import (
+    GeneratorMixIn,
+    NoCapture,
+    StdOutCapture,
+)
+
+
+#
+# Below are generic generator protocols that should be provided
+# upstream
+#
+class NoCaptureGeneratorProtocol(NoCapture, GeneratorMixIn):
+    def __init__(self, done_future=None, encoding=None):
+        NoCapture.__init__(self, done_future, encoding)
+        GeneratorMixIn.__init__(self)
+
+    def timeout(self, fd):
+        raise TimeoutError(f"Runner timeout: process has not terminated yet")
+
+
+class StdOutCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
+    def __init__(self, done_future=None, encoding=None):
+        StdOutCapture.__init__(self, done_future, encoding)
+        GeneratorMixIn.__init__(self)
+
+    def pipe_data_received(self, fd: int, data: bytes):
+        assert fd == 1
+        self.send_result(data)
+
+    def timeout(self, fd):
+        raise TimeoutError(f"Runner timeout {fd}")


### PR DESCRIPTION
From now on, all relevant pieces are contained in, and are to be imported from `datalad_next.runners`

Closes #355

Ping @christian-monch 