### PR TITLE
Support missing argument reporting in `EnsureCommandParameterization`

### DIFF
--- a/datalad_next/constraints/exceptions.py
+++ b/datalad_next/constraints/exceptions.py
@@ -273,8 +273,14 @@ class ParameterConstraintContext:
         """Like ``.label`` but each parameter will also state a value"""
         # TODO truncate the values after repr() to ensure a somewhat compact
         # output
+        from .parameter import NoValue
         return '{param}{descr}'.format(
-            param=", ".join(f'{p}={values[p]!r}' for p in self.parameters),
+            param=", ".join(
+                f'{p}=<no value>'
+                if isinstance(values[p], NoValue)
+                else f'{p}={values[p]!r}'
+                for p in self.parameters
+            ),
             descr=f" ({self.description})" if self.description else '',
         )
 

--- a/datalad_next/constraints/parameter.py
+++ b/datalad_next/constraints/parameter.py
@@ -243,6 +243,7 @@ class EnsureCommandParameterization(Constraint):
         self,
         kwargs,
         at_default=None,
+        required=None,
         on_error='raise-early',
     ) -> Dict:
         """
@@ -256,6 +257,8 @@ class EnsureCommandParameterization(Constraint):
           match their respective defaults. This is used for deciding whether
           or not to process them with an associated value constraint (see the
           ``validate_defaults`` constructor argument).
+        required: set or None
+          Set of parameter names that are known to be required.
         on_error: {'raise-early', 'raise-at-end'}
           Flag how to handle constraint violation. By default, validation is
           stopped at the first error and an exception is raised. When an
@@ -272,6 +275,18 @@ class EnsureCommandParameterization(Constraint):
           pass through.
         """
         assert on_error in ('raise-early', 'raise-at-end')
+
+        exceptions = {}
+        missing_args = tuple(a for a in (required or []) if a not in kwargs)
+        if missing_args:
+            exceptions[ParameterConstraintContext(missing_args)] = \
+                ConstraintError(
+                    self,
+                    dict(zip(missing_args, [NoValue()] * len(missing_args))),
+                    'missing required arguments',
+                )
+            if on_error == 'raise-early':
+                raise CommandParametrizationError(exceptions)
 
         # validators to work with. make a copy of the dict to be able to tailor
         # them for this run only
@@ -290,7 +305,6 @@ class EnsureCommandParameterization(Constraint):
         # strip all args provider args that have not been provided
         ds_provider_params.intersection_update(kwargs)
 
-        exceptions = {}
         validated = {}
         # process all parameters. starts with those that are needed as
         # dependencies for others.

--- a/datalad_next/constraints/tests/test_cmdarg_validation.py
+++ b/datalad_next/constraints/tests/test_cmdarg_validation.py
@@ -262,6 +262,15 @@ def test_cmd_with_validation():
             return_type='item-or-list', result_renderer='disabled',
         )
 
+    # no call with a required argument missing
+    with pytest.raises(ValueError) as e:
+        CmdWithValidation.__call__()
+    exc_rendering = str(e.value)
+    # must label the issue correctly
+    assert 'missing required argument' in exc_rendering
+    # must identify the missing argument
+    assert 'spec=<no value>' in exc_rendering
+
 
 #
 # test dataset tailoring


### PR DESCRIPTION
Previously a missing argument would cause a validation error via a side-effect, and only crash once an insufficient parameterization actually hits a command. This led to confusion error messages, such as:

```
CommandParametrizationError: 0 command parameter constraint violation
```

Whereas the CLI would produce something like

```
error: the following arguments are required: ...
```

via `argparse.

With this change, missing argument detection is now explicitly supported. And looks like:

```
CommandParametrizationError: 1 command parameter constraint violation
type=<no value>, collection=<no value>
  missing arguments
```

For that a number of changes had to be implemented:

- The patch of `get_allargs_as_kwargs()` now also makes it report required arguments of a callable.
- The patch of `_execute_command_()` now passes this information on to any `EnsureCommandParameterization` instance during pre-execution validation.
- `ParameterConstraintContext` rendering received dedicated support for rendering the `NoValue` type used in parameter validation to indicate the absence of a value.

The parameter context for which such an error is reported is the set of missing required arguments.

Closes #347