### PR TITLE
`HttpUrlOperations` decompresses download with appropriate encoding

### DIFF
--- a/datalad_next/url_operations/http.py
+++ b/datalad_next/url_operations/http.py
@@ -268,13 +268,17 @@ class HttpUrlOperations(UrlOperations):
             downloaded_bytes = 0
             # TODO make chunksize a config item, 65536 is the default in
             # requests_toolbelt
+            tell = 0
             for chunk in r.raw.stream(amt=65536, decode_content=True):
                 # update how much data was transferred from the remote server,
                 # but we cannot use the size of the chunk for that,
                 # because content might be downloaded with transparent
                 # (de)compression. ask the download stream itself for its
                 # "position"
-                tell = r.raw.tell()
+                if expected_size:
+                    tell = r.raw.tell()
+                else:
+                    tell = tell + len(chunk)
                 self._progress_report_update(
                     progress_id,
                     ('Downloaded chunk',),

--- a/datalad_next/url_operations/http.py
+++ b/datalad_next/url_operations/http.py
@@ -9,7 +9,6 @@ import sys
 from typing import Dict
 import requests
 from requests_toolbelt import user_agent
-from requests_toolbelt.downloadutils.tee import tee as requests_tee
 import www_authenticate
 
 import datalad
@@ -247,6 +246,8 @@ class HttpUrlOperations(UrlOperations):
         progress_id = self._get_progress_id(from_url, to_path)
         # get download size, but not every server provides it
         try:
+            # for compressed downloads the content length refers to the
+            # compressed content
             expected_size = int(r.headers.get('content-length'))
         except (ValueError, TypeError):
             expected_size = None
@@ -260,11 +261,27 @@ class HttpUrlOperations(UrlOperations):
         fp = None
         props = {}
         try:
+            # we can only write to file-likes opened in bytes mode
             fp = sys.stdout.buffer if to_path is None else open(to_path, 'wb')
-            # TODO make chunksize a config item
-            for chunk in requests_tee(r, fp):
+            # we need to track how much came down the pipe for progress
+            # reporting
+            downloaded_bytes = 0
+            # TODO make chunksize a config item, 65536 is the default in
+            # requests_toolbelt
+            for chunk in r.raw.stream(amt=65536, decode_content=True):
+                # update how much data was transferred from the remote server,
+                # but we cannot use the size of the chunk for that,
+                # because content might be downloaded with transparent
+                # (de)compression. ask the download stream itself for its
+                # "position"
+                tell = r.raw.tell()
                 self._progress_report_update(
-                    progress_id, ('Downloaded chunk',), len(chunk))
+                    progress_id,
+                    ('Downloaded chunk',),
+                    tell - downloaded_bytes,
+                )
+                fp.write(chunk)
+                downloaded_bytes = tell
                 # compute hash simultaneously
                 hasher.update(chunk)
             props.update(hasher.get_hexdigest())

--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -57,3 +57,17 @@ def test_custom_http_headers_via_config(datalad_cfg):
     auo = AnyUrlOperations()
     huo = auo._get_handler(f'http://example.com')
     assert huo._headers['X-Funky'] == 'Stuff'
+
+
+def test_transparent_decompression(tmp_path):
+    # this file is offered with transparent compression/decompression
+    # by the github webserver
+    url = 'https://raw.githubusercontent.com/datalad/datalad-next/' \
+          'd0c4746425a48ef20e3b1c218e68954db9412bee/pyproject.toml'
+    dpath = tmp_path / 'test.txt'
+    ops = HttpUrlOperations()
+    ops.download(from_url=url, to_path=dpath)
+
+    # make sure it ends up on disk uncompressed
+    assert dpath.read_text() == \
+        '[build-system]\nrequires = ["setuptools >= 43.0.0", "wheel"]\n'

--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import gzip
 import pytest
 
 from ..any import AnyUrlOperations
@@ -71,3 +71,28 @@ def test_transparent_decompression(tmp_path):
     # make sure it ends up on disk uncompressed
     assert dpath.read_text() == \
         '[build-system]\nrequires = ["setuptools >= 43.0.0", "wheel"]\n'
+
+
+def test_compressed_file_stay_compressed(tmp_path):
+    # this file is offered with transparent compression/decompression
+    # by the github webserver, but is also actually gzip'ed
+    url = \
+        'https://github.com/datalad/datalad-neuroimaging/raw/' \
+        '05b45c8c15d24b6b894eb59544daa17159a88945/' \
+        'datalad_neuroimaging/tests/data/files/nifti1.nii.gz'
+
+    # first confirm validity of the test approach, opening an
+    # uncompressed file should raise an exception
+    with pytest.raises(gzip.BadGzipFile):
+        testpath = tmp_path / 'uncompressed'
+        testpath.write_text('some')
+        with gzip.open(testpath, 'rb') as f:
+            f.read(1000)
+
+    # and now with a compressed file
+    dpath = tmp_path / 'test.nii.gz'
+    ops = HttpUrlOperations()
+    ops.download(from_url=url, to_path=dpath)
+    # make sure it ends up on disk compressed!
+    with gzip.open(dpath, 'rb') as f:
+        f.read(1000)


### PR DESCRIPTION
Previously, a file downloaded from a server that supported `deflate`, or other types of compressions would end up in compressed form on disk. This is undesirable, as it changes the nature of files on download.

This change:

- adds a test that documents the faulty behavior, and the fix
- enables transparent decoding of compressed streams on download
- adjusts progress reporting to focus on bytes transferred, not bytes decompressed
- discontinued the use of `requests_toolbelt.downloadutils.tee`, arguably, using this (minimal) helper just makes things more opaque

Closes #364