### PR TITLE
Enhance `FileSystemItem` and `iter_tar|dir()` to provide file IO

### DIFF
--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -191,7 +191,9 @@ class LsFileCollection(ValidatedInterface):
       ``size``, ``mtime``, or ``link_target`` are included in the report.
       [PY: When hashes are computed, an ``fp`` property with a file-like
       is provided. Reading file data from it requires a ``seek(0)`` in most
-      cases. PY]
+      cases. This file handle is only open when items are yielded directly
+      by this command (``return_type='generator``) and only until the next
+      result is yielded. PY]
 
     ``tarfile``
       Reports on members of a TAR archive. The collection identifier is the
@@ -200,7 +202,9 @@ class LsFileCollection(ValidatedInterface):
       to the ``directory`` collection type.
       [PY: When hashes are computed, an ``fp`` property with a file-like
       is provided. Reading file data from it requires a ``seek(0)`` in most
-      cases. PY]
+      cases. This file handle is only open when items are yielded directly
+      by this command (``return_type='generator``) and only until the next
+      result is yielded. PY]
     """
     _validator_ = LsFileCollectionParamValidator()
 

--- a/datalad_next/iter_collections/directory.py
+++ b/datalad_next/iter_collections/directory.py
@@ -47,7 +47,8 @@ def iter_dir(
       Path of the directory to report content for (iterate over).
     fp: bool, optional
       If ``True``, each file-type item includes a file-like object
-      to access the file's content.
+      to access the file's content. This file handle will be closed
+      automatically when the next item is yielded.
 
     Yields
     ------

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -48,7 +48,8 @@ def iter_tar(
       Path of the TAR archive to report content for (iterate over).
     fp: bool, optional
       If ``True``, each file-type item includes a file-like object
-      to access the file's content.
+      to access the file's content. This file handle will be closed
+      automatically when the next item is yielded.
 
     Yields
     ------

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -80,15 +80,13 @@ def iter_tar(
                 gid=member.gid,
                 link_target=PurePath(PurePosixPath(member.linkname))
                 if member.linkname else None,
-                hash=_compute_hash(tar, member, hash)
-                if hash and mtype in (
-                    FileSystemItemType.file, FileSystemItemType.hardlink)
-                else None,
             )
-            yield item
-
-
-def _compute_hash(
-        tar: tarfile.TarFile, member: tarfile.TarInfo, hash: List[str]):
-    with tar.extractfile(member) as f:
-        return compute_multihash_from_fp(f, hash)
+            if mtype in (
+                    FileSystemItemType.file, FileSystemItemType.hardlink):
+                with tar.extractfile(member) as fp:
+                    item.fp = fp
+                    if hash:
+                        item.hash = compute_multihash_from_fp(fp, hash)
+                    yield item
+            else:
+                yield item

--- a/datalad_next/iter_collections/tarfile.py
+++ b/datalad_next/iter_collections/tarfile.py
@@ -12,15 +12,11 @@ from pathlib import (
     PurePosixPath,
 )
 import tarfile
-from typing import (
-    Generator,
-    List
-)
+from typing import Generator
 
 from .utils import (
     FileSystemItem,
     FileSystemItemType,
-    compute_multihash_from_fp,
 )
 
 
@@ -32,7 +28,7 @@ class TarfileItem(FileSystemItem):
 def iter_tar(
     path: Path,
     *,
-    hash: List[str] | None = None,
+    fp: bool = False,
 ) -> Generator[TarfileItem, None, None]:
     """Uses the standard library ``tarfile`` module to report on TAR archives
 
@@ -50,11 +46,9 @@ def iter_tar(
     ----------
     path: Path
       Path of the TAR archive to report content for (iterate over).
-    hash: list(str), optional
-      Any number of hash algorithm names (supported by the ``hashlib`` module
-      of the Python standard library. If given, an item corresponding to the
-      algorithm will be included in the ``hash`` property dict of each
-      reported file-type item.
+    fp: bool, optional
+      If ``True``, each file-type item includes a file-like object
+      to access the file's content.
 
     Yields
     ------
@@ -81,12 +75,10 @@ def iter_tar(
                 link_target=PurePath(PurePosixPath(member.linkname))
                 if member.linkname else None,
             )
-            if mtype in (
+            if fp and mtype in (
                     FileSystemItemType.file, FileSystemItemType.hardlink):
                 with tar.extractfile(member) as fp:
                     item.fp = fp
-                    if hash:
-                        item.hash = compute_multihash_from_fp(fp, hash)
                     yield item
             else:
                 yield item

--- a/datalad_next/iter_collections/tests/test_itertar.py
+++ b/datalad_next/iter_collections/tests/test_itertar.py
@@ -107,5 +107,8 @@ def test_iter_tar(sample_tar_xz):
     ires = list(iter_tar(sample_tar_xz, hash=['md5', 'SHA1']))
     # root + subdir, 2 files, softlink, hardlink
     assert 6 == len(ires)
+    # we null the file pointers to ease the comparison
+    for i in ires:
+        i.fp = None
     for t in targets:
         assert t in ires

--- a/datalad_next/iter_collections/utils.py
+++ b/datalad_next/iter_collections/utils.py
@@ -7,6 +7,7 @@ from enum import Enum
 from pathlib import PurePath
 from typing import (
     Dict,
+    IO,
     List,
 )
 
@@ -39,6 +40,7 @@ class FileSystemItem:
     gid: int | None = None
     link_target: PurePath | None = None
     hash: Dict[str, str] | None = None
+    fp: IO | None = None
 
 
 def compute_multihash_from_fp(fp, hash: List[str], bufsize=COPY_BUFSIZE):

--- a/datalad_next/iter_collections/utils.py
+++ b/datalad_next/iter_collections/utils.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
 from typing import (
-    Dict,
     IO,
     List,
 )
@@ -39,7 +38,6 @@ class FileSystemItem:
     uid: int | None = None
     gid: int | None = None
     link_target: PurePath | None = None
-    hash: Dict[str, str] | None = None
     fp: IO | None = None
 
 


### PR DESCRIPTION
This enables something like this:

```
In [1]: from pydicom import dcmread
In [2]: from datalad_next.iter_collections.tarfile import iter_tar
In [3]: for i in iter_tar('/tmp/icfstore/dl-Z03/P000624_dicom.tar'):
   ...:     if i.fp:
   ...:         with dcmread(i.fp) as dcm:
   ...:             ...
```

Or in other words, arbitrary (post-)processing of files in a collection.

Here is a concrete use case that is enabled by this change: https://github.com/psychoinformatics-de/inm-icf-utilities/pull/6/commits/01349d87d34ec415dc55dd9b432fb8ffdebf9865

I had the concern that moving the hashing logic out of the iterators would remove the ability to not compute a particular hash, if the collection readily provides it (think dataverse offering MD5s). However, that is not true. Any such collection could provide this information unconditionally (it is free from a client POV), and the item2dict adapter for that collection in `ls_file_collections` can normalize such a report to use the standard `hash=<dict>` and skip computations as necessary and possible.

TODO

- [x] Add to documentation that the file pointers are only open until the iterator produces the next item.
