### PR TITLE
Add tests for progress report on size-less http downloads

### DIFF
--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gzip
 import pytest
 import requests


### PR DESCRIPTION
This PR adds a test to verify that http-download reports progress if no content-length is provided in the http-result headers. In addition the comments w.r.t. to download size calculation are updated to reflect the code.

This is a small add-on to #365 (which was already merged) 