### PR TITLE
Establish `datalad_next.config` for `ConfigManager`

### DIFF
--- a/datalad_next/config/__init__.py
+++ b/datalad_next/config/__init__.py
@@ -1,0 +1,1 @@
+from datalad.config import ConfigManager

--- a/datalad_next/credman/manager.py
+++ b/datalad_next/credman/manager.py
@@ -26,6 +26,7 @@ from typing import (
 )
 
 import datalad
+from datalad_next.config import ConfigManager
 from datalad_next.exceptions import (
     CapturedException,
     CommandError,
@@ -78,7 +79,7 @@ class CredentialManager(object):
         'user_password': 'password',
     }
 
-    def __init__(self, cfg=None):
+    def __init__(self, cfg: ConfigManager | None = None):
         """
 
         Parameters

--- a/datalad_next/credman/tests/test_credman.py
+++ b/datalad_next/credman/tests/test_credman.py
@@ -11,7 +11,7 @@
 """
 import pytest
 
-from datalad.config import ConfigManager
+from datalad_next.config import ConfigManager
 from ..manager import (
     CredentialManager,
     _get_cred_cfg_var,

--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -11,6 +11,7 @@ from typing import (
 )
 
 import datalad
+from datalad_next.config import ConfigManager
 from datalad_next.utils import log_progress
 from datalad_next.utils.multihash import (
     MultiHash,
@@ -35,7 +36,7 @@ class UrlOperations:
     This class provides a range of helper methods to aid computation of
     hashes and progress reporting.
     """
-    def __init__(self, *, cfg=None):
+    def __init__(self, *, cfg: ConfigManager | None = None):
         """
         Parameters
         ----------
@@ -46,7 +47,7 @@ class UrlOperations:
         self._cfg = cfg
 
     @property
-    def cfg(self):
+    def cfg(self) -> ConfigManager:
 
         if self._cfg is None:
             self._cfg = datalad.cfg

--- a/datalad_next/url_operations/any.py
+++ b/datalad_next/url_operations/any.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import re
 from typing import Dict
 
+from datalad_next.config import ConfigManager
 from datalad_next.exceptions import CapturedException
 
 from . import UrlOperations
@@ -59,7 +60,7 @@ class AnyUrlOperations(UrlOperations):
     operations, such that held connections or cached credentials can be reused
     efficiently.
     """
-    def __init__(self, cfg=None):
+    def __init__(self, cfg: ConfigManager | None = None):
         """
         Parameters
         ----------

--- a/docs/source/pyutils.rst
+++ b/docs/source/pyutils.rst
@@ -8,6 +8,7 @@ Python utilities
    :toctree: generated
 
    commands.ValidatedInterface
+   config.ConfigManager
    constraints
    credman.manager
    exceptions


### PR DESCRIPTION
This will be the cannonical import location. This changeset starts using that for imports that are presently focused on type-annotation.

Closes #337 

This change was pulled from https://github.com/datalad/datalad-next/pull/339 -- which stalled and is now blocking this fix.