### PR TITLE
Fix type annotation for `cfg`-parameter in `DataladAuth.__init__()`

### DIFF
--- a/changelog.d/20230527_000546_christian.moench_bf_type_error.md
+++ b/changelog.d/20230527_000546_christian.moench_bf_type_error.md
@@ -1,0 +1,5 @@
+### 🏠 Internal
+
+- Use the correct type annotation for `cfg`-parameter of
+  `datalad_next.utils.requests_auth.DataladAuth.__init__()`  
+  https://github.com/datalad/datalad-next/pull/385 (by @christian-monch)

--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 import requests
 import www_authenticate
 
+from datalad.config import ConfigManager
 from datalad_next.utils import CredentialManager
 from datalad_next.utils.http_helpers import get_auth_realm
 
@@ -38,7 +39,7 @@ class DataladAuth(requests.auth.AuthBase):
         'bearer': 'token',
     }
 
-    def __init__(self, cfg: CredentialManager, credential: str | None = None):
+    def __init__(self, cfg: ConfigManager, credential: str | None = None):
         """
         Parameters
         ----------

--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -43,8 +43,8 @@ class DataladAuth(requests.auth.AuthBase):
         """
         Parameters
         ----------
-        cfg: CredentialManager
-          Credentials are looked up in this instance.
+        cfg: ConfigManager
+          Is passed to CredentialManager() as `cfg`-parameter.
         credential: str, optional
           Name of a particular credential to be used for any operations.
         """

--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import requests
 import www_authenticate
 
-from datalad.config import ConfigManager
+from datalad_next.config import ConfigManager
 from datalad_next.utils import CredentialManager
 from datalad_next.utils.http_helpers import get_auth_realm
 


### PR DESCRIPTION
This PR replaces the faulty CredentialManager annotation for the cfg-parameter of DataladAuth.__init__() with the correct type, i.e. ConfigManager.
