### PR TITLE
`repr(CommandError(...))` now informative

### DIFF
--- a/changelog.d/20230530_084701_michael.hanke.md
+++ b/changelog.d/20230530_084701_michael.hanke.md
@@ -1,0 +1,7 @@
+### 🐛 Bug Fixes
+
+- Patch `CommandError`, the standard exception raised for any non-zero exit
+  command execution to now reports which command failed with `repr()` too.
+  Previously, only `str()` would produce an informative message about a failure,
+  while `repr()` would report `CommandError('')`, unless a dedicated message was
+  provided. (by @mih)

--- a/datalad_next/patches/__init__.py
+++ b/datalad_next/patches/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    commanderror,
     common_cfg,
     annexrepo,
     configuration,

--- a/datalad_next/patches/commanderror.py
+++ b/datalad_next/patches/commanderror.py
@@ -1,0 +1,11 @@
+from datalad.runner.exception import CommandError
+
+
+def commanderror_repr(self) -> str:
+    return self.to_str()
+
+
+# without overwriting __repr__ it would use RuntimeError's variant
+# with ignore all info but `.msg` which will be empty frequently
+# and confuse people with `CommandError('')`
+CommandError.__repr__ = commanderror_repr

--- a/datalad_next/patches/tests/test_commanderror.py
+++ b/datalad_next/patches/tests/test_commanderror.py
@@ -1,0 +1,10 @@
+from datalad_next.runners import CommandError
+
+
+def test_repr_str():
+    # standard case of a command that failed with non-zero exit
+    # many git/git-annex plumbing commands purposefully signal
+    # statuses like this
+    e = CommandError('some command', code=1)
+    assert 'some command' in str(e)
+    assert 'some command' in repr(e)

--- a/datalad_next/runners/__init__.py
+++ b/datalad_next/runners/__init__.py
@@ -20,6 +20,6 @@ from .protocols import (
     StdOutCaptureGeneratorProtocol,
 )
 # exceptions
-from datalad.runner import (
+from datalad.runner.exception import (
     CommandError,
 )


### PR DESCRIPTION
`CommandError`, the standard exception raised for any non-zero exit command execution now reports which command failed with `repr()` too. Previously, only `str()` would produce an informative message about a failure, while `repr()` would report `CommandError('')`, unless a dedicated message was provided.

Changes:

```
Could not obtain 'MD5E-s20--7fecdac24beaba574b1e9d7ff9da67f8.csv' -caused by- Exhausted all candidate archive handlers (previous failures [CommandError('')])
```

to

```
Could not obtain 'MD5E-s20--7fecdac24beaba574b1e9d7ff9da67f8.csv' -caused by- CommandError: 'git -c diff.ignoreSubmodules=none annex contentlocation MD5E-s391--15a48a2cb9efbdedece04ff16be413e9.tar.gz -c annex.dotfiles=true' failed with exitcode 1
```

Ping @christian-monch -- should likely also be done in datalad-core.

TODO:

- [ ] Transform into a patch of datalad-core. With the subclass approach any `except CommandError` using this subclass would not be catch a `CommandError` raised by datalad-core.