### PR TITLE
Team up `LeanGitRepo` with `LeanAnnexRepo` and other standardizations for `SpecialRemote`

### DIFF
--- a/datalad_next/annexremotes/__init__.py
+++ b/datalad_next/annexremotes/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 # import all the pieces one would need for an implementation
 # in a single place
 from annexremote import UnsupportedRequest
+from typing import Any
 
 from datalad.customremotes import (
     # this is an enhanced RemoteError that self-documents its cause
@@ -41,3 +42,59 @@ class SpecialRemote(_SpecialRemote):
         if self._remotename is None:
             self._remotename = self.annex.getgitremotename()
         return self._remotename
+
+    def get_remote_gitcfg(
+            self,
+            remotetypename: str,
+            name: str,
+            default: Any | None = None,
+            **kwargs
+    ):
+        """Get a particular Git configuration item for the special remote
+
+        This target configuration here is *not* the git-annex native
+        special remote configuration that is provided or altered with
+        ``initremote`` and ``enableremote``, and is committed to the
+        ``git-annex`` branch. Instead this is a clone and remote
+        specific configuration, declared in Git's configuration system.
+
+        The configuration items queried have the naming scheme::
+
+            remote.<remotename>.<remotetypename>-<name>
+            datalad.<remotetypename>.<name>
+
+        where ``<remotename>`` is the name of the Git remote, the special
+        remote is operating under, ``<remotetypename>`` is the name of the
+        special remote implementation (e.g., ``uncurl``), and ``<name>``
+        is the name of a particular configuration flavor.
+
+        Parameters
+        ----------
+        remotetypename: str
+          Name of the special remote implementation configuration is
+          requested for.
+        name: str
+          The name of the "naked" configuration item, without any
+          sub/sections. Must be a valid git-config variable name, i.e.,
+          case-insensitive, only alphanumeric characters and -, and
+          must start with an alphabetic character.
+        default:
+          A default value to be returned if there is no configuration.
+        **kwargs:
+          Passed on to :func:`datalad_next.config.ConfigManager.get()`
+
+        Returns
+        -------
+        Any
+          If a remote-specific configuration exists, it is reported. Otherwise
+          a remote-type specific configuration is reported, or the default
+          provided with the method call, if no configuration is found at all.
+        """
+        cfgget = self.repo.config.get
+        return cfgget(
+            f'remote.{self.remotename}.{remotetypename}-{name}',
+            default=cfgget(
+                f'datalad.{remotetypename}.{name}',
+                default=default,
+            )
+        )

--- a/datalad_next/annexremotes/__init__.py
+++ b/datalad_next/annexremotes/__init__.py
@@ -20,6 +20,7 @@ class SpecialRemote(_SpecialRemote):
         super(SpecialRemote, self).__init__(annex=annex)
 
         self._repo = None
+        self._remotename = None
 
     @property
     def repo(self) -> LeanAnnexRepo:
@@ -32,3 +33,11 @@ class SpecialRemote(_SpecialRemote):
         if self._repo is None:
             self._repo = LeanAnnexRepo(self.annex.getgitdir())
         return self._repo
+
+    @property
+    def remotename(self) -> str:
+        """Name of the (git) remote the special remote is operating under"""
+
+        if self._remotename is None:
+            self._remotename = self.annex.getgitremotename()
+        return self._remotename

--- a/datalad_next/annexremotes/__init__.py
+++ b/datalad_next/annexremotes/__init__.py
@@ -11,6 +11,24 @@ from datalad.customremotes import (
 )
 from datalad.customremotes.main import main as super_main
 
+from datalad_next.datasets import LeanAnnexRepo
+
 
 class SpecialRemote(_SpecialRemote):
-    pass
+    """Base class of all datalad-next git-annex special remotes"""
+    def __init__(self, annex):
+        super(SpecialRemote, self).__init__(annex=annex)
+
+        self._repo = None
+
+    @property
+    def repo(self) -> LeanAnnexRepo:
+        """Returns a representation of the underlying git-annex repository
+
+        An instance of :class:`~datalad_next.datasets.LeanAnnexRepo` is
+        returned, which intentionally provides a restricted API only. In order
+        to limit further proliferation of the ``AnnexRepo`` API.
+        """
+        if self._repo is None:
+            self._repo = LeanAnnexRepo(self.annex.getgitdir())
+        return self._repo

--- a/datalad_next/annexremotes/__init__.py
+++ b/datalad_next/annexremotes/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # import all the pieces one would need for an implementation
 # in a single place
 from annexremote import UnsupportedRequest

--- a/datalad_next/annexremotes/uncurl.py
+++ b/datalad_next/annexremotes/uncurl.py
@@ -227,7 +227,7 @@ import re
 # and even that we only need to get a `ConfigManager` instance.
 # If that class would support a plain path argument, we could
 # avoid it entirely
-from datalad_next.datasets import LeanGitRepo
+from datalad_next.datasets import LeanAnnexRepo
 
 from datalad_next.exceptions import (
     CapturedException,
@@ -252,7 +252,6 @@ class UncurlRemote(SpecialRemote):
             url='Python format language template composing an access URL',
             match='(whitespace-separated list of) regular expression(s) to match particular components in supported URL via named groups',
         )
-        self.repo = None
         self.url_tmpl = None
         self.match = None
         self.url_handler = None
@@ -269,8 +268,6 @@ class UncurlRemote(SpecialRemote):
         # we need the git remote name to be able to look up config about
         # that remote
         remotename = self.annex.getgitremotename()
-        # get the repo to gain access to its config
-        self.repo = LeanGitRepo(self.annex.getgitdir())
         # check the config for a URL template setting
         self.url_tmpl = self.repo.cfg.get(
             f'remote.{remotename}.uncurl-url', '')

--- a/datalad_next/annexremotes/uncurl.py
+++ b/datalad_next/annexremotes/uncurl.py
@@ -267,10 +267,9 @@ class UncurlRemote(SpecialRemote):
     def prepare(self):
         # we need the git remote name to be able to look up config about
         # that remote
-        remotename = self.annex.getgitremotename()
         # check the config for a URL template setting
         self.url_tmpl = self.repo.cfg.get(
-            f'remote.{remotename}.uncurl-url', '')
+            f'remote.{self.remotename}.uncurl-url', '')
         # only if we have no local, overriding, configuration ask git-annex
         # for the committed special remote config on the URL template
         if not self.url_tmpl:
@@ -292,7 +291,7 @@ class UncurlRemote(SpecialRemote):
         self.match = (self.match or []) + [
             re.compile(m)
             for m in ensure_list(self.repo.cfg.get(
-                f'remote.{remotename}.uncurl-match', [], get_all=True))
+                f'remote.{self.remotename}.uncurl-match', [], get_all=True))
         ]
 
         self.message(
@@ -309,7 +308,7 @@ class UncurlRemote(SpecialRemote):
         # Python symbols to work in `format()`
         self.persistent_tmpl_props.update(
             datalad_dsid=self.repo.cfg.get('datalad.dataset.id', ''),
-            git_remotename=remotename,
+            git_remotename=self.remotename,
             annex_remoteuuid=self.annex.getuuid(),
         )
 

--- a/datalad_next/annexremotes/uncurl.py
+++ b/datalad_next/annexremotes/uncurl.py
@@ -268,8 +268,7 @@ class UncurlRemote(SpecialRemote):
         # we need the git remote name to be able to look up config about
         # that remote
         # check the config for a URL template setting
-        self.url_tmpl = self.repo.cfg.get(
-            f'remote.{self.remotename}.uncurl-url', '')
+        self.url_tmpl = self.get_remote_gitcfg('uncurl', 'url', '')
         # only if we have no local, overriding, configuration ask git-annex
         # for the committed special remote config on the URL template
         if not self.url_tmpl:
@@ -290,8 +289,8 @@ class UncurlRemote(SpecialRemote):
         # extend with additional matchers from local config
         self.match = (self.match or []) + [
             re.compile(m)
-            for m in ensure_list(self.repo.cfg.get(
-                f'remote.{self.remotename}.uncurl-match', [], get_all=True))
+            for m in ensure_list(self.get_remote_gitcfg(
+                'uncurl', 'match', default=[], get_all=True))
         ]
 
         self.message(

--- a/datalad_next/datasets/__init__.py
+++ b/datalad_next/datasets/__init__.py
@@ -1,3 +1,24 @@
+"""Representations of DataLad datasets built on git/git-annex repositories
+
+Two sets of repository abstractions are available :class:`LeanGitRepo` and
+:class:`LeanAnnexRepo` vs. :class:`LegacyGitRepo` and :class:`LegacyAnnexRepo`.
+
+The latter are the classic classes providing a, now legacy, low-level API to
+repository operations. This functionality stems from the earliest days of
+DataLad and implements paradigms and behaviors that are no longer common to
+the rest of the DataLad API. :class:`LegacyGitRepo` and
+:class:`LegacyAnnexRepo` should no longer be used in new developments.
+
+:class:`LeanGitRepo` and :class:`LeanAnnexRepo` on the other hand provide
+a more modern, substantially restricted API and represent the present
+standard API for low-level repository operations. They are geared towards
+interacting with Git and git-annex more directly, and are more suitable
+for generator-like implementations, promoting low response latencies, and
+a leaner processing footprint.
+"""
+
+from pathlib import Path
+
 from datalad.distribution.dataset import (
     Dataset,
     # this does nothing but provide documentation
@@ -11,3 +32,38 @@ from datalad.dataset.gitrepo import GitRepo as LeanGitRepo
 
 from datalad.support.gitrepo import GitRepo as LegacyGitRepo
 from datalad.support.annexrepo import AnnexRepo as LegacyAnnexRepo
+
+
+class LeanAnnexRepo(LegacyAnnexRepo):
+    """git-annex repository representation with a minimized API
+
+    This is a companion of :class:`LeanGitRepo`. In the same spirit, it
+    restricts its API to a limited set of method that primarily extend
+    :class:`LeanGitRepo` with a set of ``call_annex*()`` methods.
+    """
+    # list of attributes permitted in the "lean" API. This list extends
+    # the API of LeanGitRepo
+    # TODO extend whitelist of attributed as necessary
+    _lean_attrs = [
+        '_check_git_version',
+        # used by AnnexRepo.__init__() -- should be using `is_valid()`
+        'is_valid_git',
+        'is_valid_annex',
+        '_is_direct_mode_from_config',
+    ]
+
+    # intentionally limiting to just `path` as the only constructor argument
+    def __new__(cls, path: Path):
+        for attr in dir(cls):
+            if not hasattr(LeanGitRepo, attr) \
+                    and callable(getattr(cls, attr)) \
+                    and attr not in LeanAnnexRepo._lean_attrs:
+                setattr(cls, attr, _unsupported_method)
+
+        obj = super(LegacyAnnexRepo, cls).__new__(cls)
+
+        return obj
+
+
+def _unsupported_method(self):
+    raise NotImplementedError('method unsupported by LeanAnnexRepo')

--- a/docs/source/annex-specialremotes.rst
+++ b/docs/source/annex-specialremotes.rst
@@ -5,4 +5,5 @@ Git-annex special remotes
 .. autosummary::
    :toctree: generated
 
+   SpecialRemote
    uncurl

--- a/docs/source/pyutils.rst
+++ b/docs/source/pyutils.rst
@@ -11,6 +11,7 @@ Python utilities
    config.ConfigManager
    constraints
    credman.manager
+   datasets
    exceptions
    iter_collections
    url_operations


### PR DESCRIPTION
Also includes

- `SpecialRemote.repo` property to provide `LeanAnnexRepo` instance on demand
- `SpecialRemote.remotename` property
- `SpecialRemote.get_remote_gitcfg()` as a standard method to query special remote configuration from git configuration -- set by remote, or by remote type (e.g., all `uncurl` remotes).