### PR TITLE
We depend on datalad 0.18.4, no need to account for pre 0.18

### DIFF
--- a/datalad_next/commands/__init__.py
+++ b/datalad_next/commands/__init__.py
@@ -9,12 +9,7 @@ from datalad.interface.base import (
 )
 from datalad.interface.results import get_status_dict
 from datalad.interface.utils import generic_result_renderer
-try:
-    # datalad 0.17.10+
-    from datalad.interface.base import eval_results
-except ImportError:
-    # older datalad
-    from datalad.interface.utils import eval_results
+from datalad.interface.base import eval_results
 from datalad.support.param import Parameter
 
 from datalad_next.constraints.parameter import (

--- a/datalad_next/patches/interface_utils.py
+++ b/datalad_next/patches/interface_utils.py
@@ -292,10 +292,5 @@ def _execute_command_(
 # apply patch
 patch_msg = \
     'Apply datalad-next patch to interface.(utils|base).py:_execute_command_'
-try:
-    apply_patch('datalad.interface.utils', None, '_execute_command_',
-                _execute_command_, msg=patch_msg)
-except AttributeError:
-    # we have datalad 0.17.10+ and the target has moved
-    apply_patch('datalad.interface.base', None, '_execute_command_',
-                _execute_command_, msg=patch_msg)
+apply_patch('datalad.interface.base', None, '_execute_command_',
+            _execute_command_, msg=patch_msg)


### PR DESCRIPTION
This avoids a deprecation warning on each and every load.