### PR TITLE
BF: cache archivist handler for later reuse

### DIFF
--- a/datalad_next/annexremotes/archivist.py
+++ b/datalad_next/annexremotes/archivist.py
@@ -498,9 +498,11 @@ class _ArchiveHandlers:
             assert ainfo.handler is None
             try:
                 handler = self._get_remote_handler(akey, ainfo)
-                yield handler, [loc for loc in locs if loc.akey == akey]
             except Exception as e:
                 exc.append(e)
+            # store the handler for later
+            ainfo.handler = handler
+            yield handler, [loc for loc in locs if loc.akey == akey]
 
         # if we get here we can stop -- everything was tried. If there were
         # exceptions, make sure to report them

--- a/datalad_next/annexremotes/archivist.py
+++ b/datalad_next/annexremotes/archivist.py
@@ -500,7 +500,8 @@ class _ArchiveHandlers:
                 handler = self._get_remote_handler(akey, ainfo)
             except Exception as e:
                 exc.append(e)
-            # store the handler for later
+                continue
+            # if this worked, store the handler for later
             ainfo.handler = handler
             yield handler, [loc for loc in locs if loc.akey == akey]
 
@@ -566,6 +567,10 @@ class _ArchiveHandlers:
         # with that URL
         # instead we retrieve the archive
         res = self._repo.get(str(akey), key=True)
+        # if the akey was already around, `res` could be an empty list.
+        # however, under these circumstances we should not have ended
+        # up here. assert to alert on logic error in that case
+        assert isinstance(res, dict)
         if res.pop('success', None) is not True:
             # TODO better error
             raise RuntimeError(f'Failed to download archive key: {res!r}')

--- a/datalad_next/annexremotes/tests/test_archivist.py
+++ b/datalad_next/annexremotes/tests/test_archivist.py
@@ -208,6 +208,26 @@ def _check_archivist_retrieval(archivist_dataset):
         status='ok',
         type='file',
     )
+    # and now get again, this time with no archives around locally
+    # no ZIP just yet
+    #res = ads.get(['azip', 'atar'], **nonoise)
+    res = ads.get(['atar'], **nonoise)
+    assert_result_count(
+        res,
+        # no ZIP just yet
+        # len(dscontent),
+        2,
+        action='get',
+        status='ok',
+        type='file',
+    )
+    for fpath, fcontent in dscontent:
+        # no ZIP just yet
+        if 'zip' in fpath:
+            continue
+        assert (ads.pathobj / fpath).read_text() == fcontent
+    # and drop everything again to leave the dataset empty
+    res = ads.drop(['.'], **nonoise)
 
 
 def test_archivist_retrieval(populated_archivist_dataset):


### PR DESCRIPTION
In INM-ICF-utilities, a get operations on a directory with many files from the same tarball failed after the first file was successfully retrieved. Debugging revealed that the internal retrieval of the tar archive was attempted for this first try successfully. Later files retried retrieval unnecessarily, resulting in cryptic errors downstream


ping @mih 

Backstory: INM-ICF-utilities can operate on files indexed with the archivist special remote from a tarball. When none of the files or archive content was locally present yet, a ``get`` of several files at once resulted in errors like this:

```
id not complete successfully")
E           datalad.support.exceptions.IncompleteResultsError: Command did not complete successfully. 22 failed:
E           [{'action': 'get',
E             'annexkey': 'MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm',
E             'error_message': 'Could not obtain '
E                              "'MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm' "
E                              '-caused by- Exhausted all candidate archive handlers '
E                              "(previous failures [TypeError('pop expected at most 1 "
E                              "argument, got 2')])",
E             'path': '/tmp/pytest-of-appveyor/pytest-0/test_pipeline0/ds_study_1_visit_a/study_1_visit_a/incoming/study_1_7T8088/incoming/study_1/654321_7T8088/SCANS/1/DICOM/1.3.12.2.1107.5.2.0.79109.30000021070907115904000000007-1-11-MTAyOTEK.dcm',
``` 

Poor man's debugging with the following patch in next:
```diff
diff --git a/datalad_next/annexremotes/archivist.py b/datalad_next/annexremotes/archivist.py
index a4037b6..03a7bd6 100644
--- a/datalad_next/annexremotes/archivist.py
+++ b/datalad_next/annexremotes/archivist.py
@@ -565,7 +565,11 @@ class _ArchiveHandlers:
         # would be available and select a remote handler to work
         # with that URL
         # instead we retrieve the archive
+        import sys
+        print(f'*************  {akey!r}', file=sys.stderr)
         res = self._repo.get(str(akey), key=True)
+
+        print(f'##############  {res!r}', file=sys.stderr)
         if res.pop('success', None) is not True:
             # TODO better error
             raise RuntimeError(f'Failed to download archive key: {res!r}')
```

and an interactive ``dataset.repo.call_annex(['--debug', 'get', f' {study}_{visit}'])`` in a debugger revealed this:

```
[...]
[2023-05-31 16:38:00.909588974] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] <-- TRANSFER RETRIEVE MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm .git/annex/tmp/MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm
[2023-05-31 16:38:00.909738879] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> GETURLS MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm dl+archive:
[2023-05-31 16:38:00.910042643] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] <-- VALUE dl+archive:MD5E-s2365440--da61396bda2280eb8a20d21afb000557.tar#path=study_1_visit_a/mock_icf/incoming/study-1_7T8088/incoming/study-1/654321_7T8088/SCANS/1/DICOM/1.3.12.2.1107.5.2.0.79109.30000021070907115904000000007-1-10-OTkyNgo=.dcm&size=211994
[2023-05-31 16:38:00.910084971] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] <-- VALUE 
*************  AnnexKey(name='da61396bda2280eb8a20d21afb000557.tar', backend='MD5E', size='2365440', mtime=None, chunksize=None, chunknumber=None)
[2023-05-31 16:38:00.939274192] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> PROGRESS 0
[2023-05-31 16:38:01.241898551] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> PROGRESS 0
[2023-05-31 16:38:01.242064778] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> PROGRESS 2365440
##############  {'command': 'get', 'error-messages': [], 'file': None, 'input': [], 'key': 'MD5E-s2365440--da61396bda2280eb8a20d21afb000557.tar', 'note': 'from uncurl...\nchecksum...', 'success': True}
[2023-05-31 16:38:01.35850448] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> TRANSFER-SUCCESS RETRIEVE MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm
[2023-05-31 16:38:01.359888832] (Annex.Perms) freezing content .git/annex/objects/4G/Gv/MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm/MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm
[2023-05-31 16:38:01.360946605] (Annex.Perms) freezing content directory .git/annex/objects/4G/Gv/MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm
[2023-05-31 16:38:01.361068731] (Annex.Branch) read 1d0/9f7/MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm.log
[2023-05-31 16:38:01.361757485] (Annex.Branch) set 1d0/9f7/MD5E-s211994--f65a3c8e6c40595cfdc8e5902e7e0742.dcm.log
[2023-05-31 16:38:01.362582036] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] <-- TRANSFER RETRIEVE MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm .git/annex/tmp/MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm
[2023-05-31 16:38:01.362781997] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> GETURLS MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm dl+archive:
[2023-05-31 16:38:01.366295512] (Annex.Branch) read c4c/713/MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm.log.web
[2023-05-31 16:38:01.366640467] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] <-- VALUE dl+archive:MD5E-s2365440--da61396bda2280eb8a20d21afb000557.tar#path=study_1_visit_a/mock_icf/incoming/study-1_7T8088/incoming/study-1/654321_7T8088/SCANS/1/DICOM/1.3.12.2.1107.5.2.0.79109.30000021070907115904000000007-1-11-MzI1MjIK.dcm&size=211994
[2023-05-31 16:38:01.366698913] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] <-- VALUE 
*************  AnnexKey(name='da61396bda2280eb8a20d21afb000557.tar', backend='MD5E', size='2365440', mtime=None, chunksize=None, chunknumber=None)
[2023-05-31 16:38:01.368160363] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> PROGRESS 0
##############  []
[2023-05-31 16:38:01.403502539] (Annex.ExternalAddonProcess) /home/adina/env/icf/bin/git-annex-remote-archivist[1] --> TRANSFER-FAILURE RETRIEVE MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm Could not obtain 'MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm' -caused by- Exhausted all candidate archive handlers (previous failures [TypeError('pop expected at most 1 argument, got 2')])
[2023-05-31 16:38:01.40400599] (Annex.Branch) read c4c/713/MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm.log.cnk
  Could not obtain 'MD5E-s211994--c70259bdfdc057647ffd64afe6aa5eb6.dcm' -caused by- Exhausted all candidate archive handlers (previous failures [TypeError('pop expected at most 1 argument, got 2')])
[...]
```
While the first file in the directory got a ``success=True``, the following files, strangely, received only an empty list as a result record. The empty list is the origin of the ``pop()`` TypeErrors, and the result of re-attempting a download of the archive which is already present.
 