### PR TITLE
Diversify `Item` type classes

### DIFF
--- a/datalad_next/iter_collections/utils.py
+++ b/datalad_next/iter_collections/utils.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
 from typing import (
+    Any,
     IO,
     List,
 )
@@ -28,9 +29,26 @@ class FileSystemItemType(Enum):
     specialfile = 'specialfile'
 
 
-@dataclass  # sadly PY3.10+ only (kw_only=True)
-class FileSystemItem:
+@dataclass
+class NamedItem:
+    name: Any
+
+
+@dataclass
+class TypedItem:
+    type: Any
+
+
+@dataclass
+class PathBasedItem(NamedItem):
+    # a path-identifier in an appropriate context.
+    # could be a filename, a relpath, or an absolute path.
+    # should match platform conventions
     name: PurePath
+
+
+@dataclass  # sadly PY3.10+ only (kw_only=True)
+class FileSystemItem(PathBasedItem, TypedItem):
     type: FileSystemItemType
     size: int
     mtime: float | None = None


### PR DESCRIPTION
Originally introduced in
https://github.com/datalad/datalad-next/pull/361, but a need for this has also been expressed elsewhere, hence now a standalone changeset.

These types could also move into `datalad_next.types...`