### PR TITLE
Import and run datalad-core tests for `ConfigManager`

### DIFF
--- a/datalad_next/config/tests/test_core.py
+++ b/datalad_next/config/tests/test_core.py
@@ -1,0 +1,10 @@
+from datalad.tests.test_config import *
+
+
+# this datalad-core test is causing a persistent git config modification
+# this is not legal on datalad-next, we must wrap and protect
+_test_cross_cfgman_update = test_cross_cfgman_update
+
+
+def test_cross_cfgman_update(datalad_cfg, tmp_path):
+    _test_cross_cfgman_update(tmp_path)


### PR DESCRIPTION
Requires additional protection of the test config against modification. Required in datalad-next, but undetected in datalad-core.