### PR TITLE
Show realm in credential prompt

### DIFF
--- a/datalad_next/url_operations/http.py
+++ b/datalad_next/url_operations/http.py
@@ -117,7 +117,7 @@ class HttpUrlOperations(UrlOperations):
             try:
                 props['content-length'] = int(props['content-length'])
             except (TypeError, ValueError):
-                # but be resonably robust against unexpected responses
+                # but be reasonably robust against unexpected responses
                 pass
         return props
 

--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -96,3 +96,19 @@ def test_compressed_file_stay_compressed(tmp_path):
     # make sure it ends up on disk compressed!
     with gzip.open(dpath, 'rb') as f:
         f.read(1000)
+
+
+def test_header_adding():
+    default_headers = dict(key_1='value_1')
+    added_headers = dict(key_2='value_2')
+    url_ops = HttpUrlOperations(headers=default_headers)
+    assert 'key_1' in url_ops.get_headers()
+
+    # ensure that header entries from `headers` show up in result
+    combined_keys = {'key_1', 'key_2'}
+    result_1 = url_ops.get_headers(headers=dict(added_headers))
+    assert combined_keys.issubset(set(result_1))
+
+    # ensure that `headers` did not change the stored headers
+    result_2 = url_ops.get_headers()
+    assert 'key_2' not in set(result_2)

--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -156,8 +156,7 @@ class DataladAuth(requests.auth.AuthBase):
             realm = get_auth_realm(url, auth_schemes)
             cred = self._credman.get(
                 name=None,
-                _prompt=f'Credential needed for realm ``{realm}´´ '
-                        f'(which controls access to {url})',
+                _prompt=f'Credential needed for accessing {url} (authentication realm {realm!r})',
                 _type_hint=ctype,
                 type=ctype,
                 # include the realm in the credential to avoid asking for it

--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -153,16 +153,18 @@ class DataladAuth(requests.auth.AuthBase):
         ctype = DataladAuth._supported_auth_schemes[ascheme]
 
         try:
+            realm = get_auth_realm(url, auth_schemes)
             cred = self._credman.get(
                 name=None,
-                _prompt=f'Credential needed for access to {url}',
+                _prompt=f'Credential needed for realm ``{realm}´´ '
+                        f'(which controls access to {url})',
                 _type_hint=ctype,
                 type=ctype,
                 # include the realm in the credential to avoid asking for it
                 # interactively (it is a server-specified property
                 # users would generally not know, if they do, they can use the
                 # `credentials` command upfront.
-                realm=get_auth_realm(url, auth_schemes)
+                realm=realm
             )
             self._entered_credential = cred
             return ascheme, None, cred


### PR DESCRIPTION
This PR inserts information about the protection realm into the credential prompt for 401-error handling. This allows a user to enter a credential matching the protection realm.

RFC 2617 defines the protection realm as follows:

> The realm directive (case-insensitive) is required for all
> authentication schemes that issue a challenge. The realm value
> (case-sensitive), in combination with the canonical root URL (the
> absoluteURI for the server whose abs_path is empty; see section 5.1.[2](https://datatracker.ietf.org/doc/html/rfc2617#ref-2)
> of [2]) of the server being accessed, defines the protection space.
> These realms allow the protected resources on a server to be
> partitioned into a set of protection spaces, each with its own
> authentication scheme and/or authorization database. The realm value
> is a string, generally assigned by the origin server, which may have
> additional semantics specific to the authentication scheme. Note that
> there may be multiple challenges with the same auth-scheme but
> different realms.

That means, the realm, i.e. realm value, is a *name* that identifies a set of resources on the server. It cannot generally be determined from the URL, but only from the *WWW-Authenticate*-header. The realm might be identical to a prefix of the resource's local path, but that is not required.

For example, the fixture `http_server_with_basicauth` will always report the realm `Protected`, while the local path will typically be something like `/testfile.txt`.  Another example is the URL `https://docs.inm7.de/`. All paths in this host, e.g. `https://docs.inm7.de/learning`, are protected by a realm with the name `INM-7 Documentation`. Yet, another example would be the realm `Online Service Portal (Prodsystem)` for a local path `/Prod/InfoSystem/eTravel/Neu/Uebersicht.pl`, which is used in an employee-management portal that the authors use.

If we want to enable users to enter credentials for a realm via `datalad credentials set`, it would be helpful for them to report the realm in the protection prompt.
