### PR TITLE
Patch CLI to post any config overrides in Git-native fashion in ENV

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,7 +94,10 @@ environment:
         datalad.core
       # do not run tests that ensure behavior we intentionally changed
       # - test_gh1811: is included in next in an alternative implementation
-      KEYWORDS: not test_gh1811
+      # - test_librarymode: assumes that CLI config overrides end up in the
+      #   session `datalad.cfg.overrides`, but -next changes that behavior
+      #   to have `.overrides` be uniformly limited to instance overrides
+      KEYWORDS: not test_gh1811 and not test_librarymode
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       PY: 3.7
       INSTALL_SYSPKGS: python3-virtualenv

--- a/datalad_next/config/tests/test_utils.py
+++ b/datalad_next/config/tests/test_utils.py
@@ -1,0 +1,83 @@
+
+import pytest
+
+from .. import utils  # for patching environ
+
+from ..utils import get_gitconfig_items_from_env
+
+
+def test_get_gitconfig_items_from_env(monkeypatch):
+    with monkeypatch.context() as m:
+        # without the COUNT the rest does not matter and we always
+        # get an empty dict
+        m.delenv('GIT_CONFIG_COUNT', raising=False)
+        assert get_gitconfig_items_from_env() == {}
+
+    with monkeypatch.context() as m:
+        # setting zero items, also makes everything else irrelevant
+        m.setenv('GIT_CONFIG_COUNT', '0')
+        assert get_gitconfig_items_from_env() == {}
+
+    with monkeypatch.context() as m:
+        # predictable error for botched count
+        m.setenv('GIT_CONFIG_COUNT', 'rubbish')
+        with pytest.raises(ValueError) as e:
+            get_gitconfig_items_from_env()
+        assert 'bogus count in GIT_CONFIG_COUNT' in str(e)
+
+    # bunch of std error conditions
+    for env, excstr in (
+            ({'GIT_CONFIG_COUNT': 1,
+              'GIT_CONFIG_KEY_0': 'section.name'},
+             'missing config value'),
+            ({'GIT_CONFIG_COUNT': 1,
+              'GIT_CONFIG_VALUE_0': 'value'},
+             'missing config key'),
+            ({'GIT_CONFIG_COUNT': 1,
+              'GIT_CONFIG_KEY_0': '',
+              'GIT_CONFIG_VALUE_0': 'value'},
+             'empty config key'),
+            ({'GIT_CONFIG_COUNT': 1,
+              'GIT_CONFIG_KEY_0': 'nosection',
+              'GIT_CONFIG_VALUE_0': 'value'},
+             'does not contain a section'),
+    ):
+        with monkeypatch.context() as m:
+            m.setattr(utils, 'environ', env)
+            with pytest.raises(ValueError) as e:
+                get_gitconfig_items_from_env()
+            assert excstr in str(e)
+
+    # proper functioning
+    for env, target in (
+            ({'GIT_CONFIG_COUNT': 1,
+              'GIT_CONFIG_KEY_0': 'section.name',
+              'GIT_CONFIG_VALUE_0': 'value'},
+             {'section.name': 'value'}),
+            ({'GIT_CONFIG_COUNT': 2,
+              'GIT_CONFIG_KEY_0': 'section.name1',
+              'GIT_CONFIG_VALUE_0': 'value1',
+              'GIT_CONFIG_KEY_1': 'section.name2',
+              'GIT_CONFIG_VALUE_1': 'value2'},
+             {'section.name1': 'value1', 'section.name2': 'value2'}),
+            # double-specification appends
+            # ❯ GIT_CONFIG_COUNT=2 \
+            #   GIT_CONFIG_KEY_0=section.name \
+            #   GIT_CONFIG_VALUE_0=val1 \
+            #   GIT_CONFIG_KEY_1=section.name \
+            #   GIT_CONFIG_VALUE_1=val2 \
+            #   git config --list --show-origin | grep 'command line:'
+            # command line:   section.name=val1
+            # command line:   section.name=val2
+            ({'GIT_CONFIG_COUNT': 3,
+              'GIT_CONFIG_KEY_0': 'section.name',
+              'GIT_CONFIG_VALUE_0': 'value0',
+              'GIT_CONFIG_KEY_1': 'section.name',
+              'GIT_CONFIG_VALUE_1': 'value1',
+              'GIT_CONFIG_KEY_2': 'section.name',
+              'GIT_CONFIG_VALUE_2': 'value2'},
+             {'section.name': ('value0', 'value1', 'value2')}),
+    ):
+        with monkeypatch.context() as m:
+            m.setattr(utils, 'environ', env)
+            assert get_gitconfig_items_from_env() == target

--- a/datalad_next/config/utils.py
+++ b/datalad_next/config/utils.py
@@ -29,15 +29,10 @@ def get_gitconfig_items_from_env() -> Mapping[str, str | Tuple[str, ...]]:
       times, the respective values are aggregated in reported as a tuple
       for that specific key.
     """
-    try:
-        count = int(environ.get('GIT_CONFIG_COUNT', '0'))
-    except (TypeError, ValueError) as e:
-        raise ValueError("bogus count in GIT_CONFIG_COUNT") from e
-
     items: Dict[str, str | Tuple[str, ...]] = {}
     for k, v in ((_get_gitconfig_var_from_env(i, 'key'),
                   _get_gitconfig_var_from_env(i, 'value'))
-                 for i in range(count)):
+                 for i in range(_get_gitconfig_itemcount())):
         val = items.get(k)
         if val is None:
             items[k] = v
@@ -46,6 +41,13 @@ def get_gitconfig_items_from_env() -> Mapping[str, str | Tuple[str, ...]]:
         else:
             items[k] = (val, v)
     return items
+
+
+def _get_gitconfig_itemcount() -> int:
+    try:
+        return int(environ.get('GIT_CONFIG_COUNT', '0'))
+    except (TypeError, ValueError) as e:
+        raise ValueError("bogus count in GIT_CONFIG_COUNT") from e
 
 
 def _get_gitconfig_var_from_env(nid: int, kind: str) -> str:
@@ -60,3 +62,43 @@ def _get_gitconfig_var_from_env(nid: int, kind: str) -> str:
     if '.' not in var:
         raise ValueError(f"key {envname} does not contain a section: {var}")
     return var
+
+
+def set_gitconfig_items_in_env(items: Mapping[str, str | Tuple[str, ...]]):
+    """Set git-config ENV (``GIT_CONFIG_COUNT|KEY|VALUE``) from a mapping
+
+    Any existing declaration of configuration items in the environment is
+    replaced. Any ENV variable of a *valid* existing declaration is removed,
+    before the set configuration items are posted in the ENV.
+
+    Multi-value configuration keys are supported (values provided as a tuple).
+
+    No verification (e.g., of syntax compliance) is performed.
+    """
+    _clean_env_from_gitconfig_items()
+
+    count = 0
+    for key, value in items.items():
+        # homogeneous processing of multiple value items, and single values
+        values = value if isinstance(value, tuple) else (value,)
+        for v in values:
+            environ[f'GIT_CONFIG_KEY_{count}'] = key
+            environ[f'GIT_CONFIG_VALUE_{count}'] = v
+            count += 1
+    if count:
+        environ['GIT_CONFIG_COUNT'] = str(count)
+
+
+def _clean_env_from_gitconfig_items():
+    # we only care about intact specifications here, if there was cruft
+    # to start with, we have no responsibilities
+    try:
+        count = _get_gitconfig_itemcount()
+    except ValueError:
+        return
+
+    for i in range(count):
+        environ.pop(f'GIT_CONFIG_KEY_{i}', None)
+        environ.pop(f'GIT_CONFIG_VALUE_{i}', None)
+
+    environ.pop('GIT_CONFIG_COUNT', None)

--- a/datalad_next/config/utils.py
+++ b/datalad_next/config/utils.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from os import environ
+from typing import (
+    Dict,
+    Mapping,
+    Tuple,
+)
+
+
+def get_gitconfig_items_from_env() -> Mapping[str, str | Tuple[str, ...]]:
+    """Parse git-config ENV (``GIT_CONFIG_COUNT|KEY|VALUE``) and return as dict
+
+    This implementation does not use ``git-config`` directly, but aims to
+    mimic its behavior with respect to parsing the environment as much
+    as possible.
+
+    Raises
+    ------
+    ValueError
+      Whenever ``git-config`` would also error out, and includes an
+      message in the respective exception that resembles ``git-config``'s
+      for that specific case.
+
+    Returns
+    -------
+    dict
+      Configuration key-value mappings. When a key is declared multiple
+      times, the respective values are aggregated in reported as a tuple
+      for that specific key.
+    """
+    try:
+        count = int(environ.get('GIT_CONFIG_COUNT', '0'))
+    except (TypeError, ValueError) as e:
+        raise ValueError("bogus count in GIT_CONFIG_COUNT") from e
+
+    items: Dict[str, str | Tuple[str, ...]] = {}
+    for k, v in ((_get_gitconfig_var_from_env(i, 'key'),
+                  _get_gitconfig_var_from_env(i, 'value'))
+                 for i in range(count)):
+        val = items.get(k)
+        if val is None:
+            items[k] = v
+        elif isinstance(val, tuple):
+            items[k] = val + (v,)
+        else:
+            items[k] = (val, v)
+    return items
+
+
+def _get_gitconfig_var_from_env(nid: int, kind: str) -> str:
+    envname = f'GIT_CONFIG_{kind.upper()}_{nid}'
+    var = environ.get(envname)
+    if var is None:
+        raise ValueError(f"missing config {kind} {envname}")
+    if kind != 'key':
+        return var
+    if not var:
+        raise ValueError(f"empty config key {envname}")
+    if '.' not in var:
+        raise ValueError(f"key {envname} does not contain a section: {var}")
+    return var

--- a/datalad_next/patches/cli_configoverrides.py
+++ b/datalad_next/patches/cli_configoverrides.py
@@ -1,0 +1,50 @@
+from datalad.config import _update_from_env as _update_from_datalad_env
+from datalad.cli.helpers import _parse_overrides_from_cmdline
+
+from datalad_next.config.utils import (
+    get_gitconfig_items_from_env,
+    set_gitconfig_items_in_env,
+)
+
+from . import apply_patch
+
+
+def parse_overrides_from_cmdline(cmdlineargs):
+    # read from cmdlineargs first to error on any syntax issues
+    # before any other processing
+    cli_overrides = _parse_overrides_from_cmdline(cmdlineargs)
+
+    # reuse datalad-core implementation of datalad-specific ENV parsing
+    # for config items
+    overrides = {}
+    _update_from_datalad_env(overrides)
+
+    # let CLI settings override any ENV -- in-line with the behavior of Git
+    overrides.update(cli_overrides)
+
+    # read any existing GIT_CONFIG ENV vars and superimpose our
+    # overrides on them, repost in ENV using git-native approach.
+    # This will apply the overrides to any git(-config) calls
+    # in this process and any subprocess
+    gc_overrides = get_gitconfig_items_from_env()
+    gc_overrides.update(overrides)
+    set_gitconfig_items_in_env(gc_overrides)
+
+    # we do not actually disclose any of these overrides.
+    # the CLI runs a `datalad.cfg.reload(force=True)`
+    # immediately after executing this function and thereby
+    # pulls in the overrides we just posted into the ENV
+    # here. This change reduced the scope of
+    # `datalad.cfg.overrides` to be mere instance overrides
+    # and no longer process overrides. This rectifies the mismatch
+    # between appearance and actual impact of this information
+    # in the ConfigManager
+    return {}
+
+
+apply_patch(
+    'datalad.cli.helpers', None, '_parse_overrides_from_cmdline',
+    parse_overrides_from_cmdline,
+    msg='Enable posting DataLad config overrides CLI/ENV as '
+    'GIT_CONFIG items in process ENV',
+)

--- a/datalad_next/patches/enabled.py
+++ b/datalad_next/patches/enabled.py
@@ -1,4 +1,5 @@
 from . import (
+    cli_configoverrides,
     commanderror,
     common_cfg,
     annexrepo,

--- a/datalad_next/patches/tests/test_cli_configoverrides.py
+++ b/datalad_next/patches/tests/test_cli_configoverrides.py
@@ -1,0 +1,18 @@
+from datalad_next.utils import chpwd
+from datalad_next.tests.utils import run_main
+
+
+def test_cli_configoverrides(existing_dataset):
+    # test whether a `datalad -c ...` is effective within the
+    # execution environment of a subprocess (for a non-datalad
+    # configuration item
+    with chpwd(existing_dataset.path):
+        out, err = run_main(
+            [
+                '-c', 'bogusdataladtestsec.subsec=unique',
+                'run',
+                'git config bogusdataladtestsec.subsec',
+            ],
+            # git-config would fail, if the config item is unknown
+            exit_code=0,
+        )


### PR DESCRIPTION
This achieve the main goal of making any `datalad -c ...` specification
affect not just the datalad-specific config in the main Python process,
but can now handle *any* Git config, and also impact the behavior of
any subprocesses.

Furthermore this handling is extended to cover also `DATALAD_...`
ENV variables, including `DATALAD_CONFIG_OVERRIDES_JSON`.

Within the session `ConfigManager` instance the behavior is now more
uniform. `ConfigManager.overrides` are now exclusively instance-specific
overrides -- matching their description and implementation. No
configuration override coming from CLI or process ENV is reflected in
`ConfigManager.overrides` anymore.

Closes #325 -- although the scope is a bit broader.

This changeset defers the need to address #397, but does not resolve it.
Ideally there would not be a need for any CLI specific behavior and
implementation -- everything should be done by the `ConfigManager`.
However, given the numerous conceptual and design limitations, it felt
necessary to address the override impact limitation separately.

Ping

- datalad/datalad#4119
- datalad/datalad#3456
- datalad/datalad#7344