### PR TITLE
Use correct return type of `ArchiveOperations.open()` to `Generator`

### DIFF
--- a/datalad_next/archive_operations/__init__.py
+++ b/datalad_next/archive_operations/__init__.py
@@ -95,7 +95,7 @@ class ArchiveOperations(ABC):
 
     @contextmanager
     @abstractmethod
-    def open(self, item: Any) -> IO:
+    def open(self, item: Any) -> Generator[IO | None]:
         """Get a file-like for an archive item
 
         Parameters

--- a/datalad_next/archive_operations/tarfile.py
+++ b/datalad_next/archive_operations/tarfile.py
@@ -77,13 +77,28 @@ class TarArchiveOperations(ArchiveOperations):
             self._tarfile = None
 
     @contextmanager
-    def open(self, item: str | PurePath) -> IO:
+    def open(self, item: str | PurePath) -> Generator[IO | None]:
         """Get a file-like for a TAR archive item
+
+        The file-like object allows to read from the archive-item specified
+        by `item`.
 
         Parameters
         ----------
         item: str | PurePath
           The identifier must be a POSIX path string, or a `PurePath` instance.
+
+        Returns
+        -------
+        IO | None
+          A file-like object to read bytes from the item, if the item is a
+          regular file, else `None`. (This is returned by the context manager
+          that is created via the decorator `@contextmanager`.)
+
+        Raises
+        ------
+        KeyError
+          If no item with the name `item` can be found in the tar-archive
         """
         with self.tarfile.extractfile(_anyid2membername(item)) as fp:
             yield fp


### PR DESCRIPTION
Fixes #406 

This PR implements solution 3. described in item #406.

It changes the return type of the method `open()` of `ArchiveOperations` and its subclasses to reflect the return type that is defined in the method code. That means the return type is changed to `Generator`.

The PR also introduces a complete doc-string for `TarArchiveOperations.open()` to describe the return types that are observed y the caller of `open()` on an instance of `TarArchiveOperations`. Due to the use of the `@contextmanager`-decorator, the return type observed by a caller is `IO | None` instead of `Generator`.
