### PR TITLE
Use PurePosixPath for names of zipfile-entries (or even better: `str`)?

### DIFF
--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -1,6 +1,6 @@
 import pytest
 import zipfile
-from pathlib import PurePath
+from pathlib import PurePosixPath
 
 from ..zipfile import (
     ZipfileItem,
@@ -47,7 +47,7 @@ def test_iter_zip(sample_zip):
         'SHA1': 'b5dfcec4d1b6166067226fae102f7fbcf6bd1bd4',
         'md5': 'd700214df5487801e8ee23d31e60382a',
     }
-    root = PurePath('test-archive')
+    root = PurePosixPath('test-archive')
     targets = [
         ZipfileItem(
             name=root,

--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -26,7 +26,7 @@ def sample_zip(tmp_path_factory):
         test-archive
         ├── onetwothree.txt
         └── subdir/
-            └── onetwothree_again.txt
+            └── onetwothree<>again.txt
     """
     path = tmp_path_factory.mktemp('zipfile') / 'sample.zip'
     file_content = b'zip-123\n'
@@ -35,7 +35,7 @@ def sample_zip(tmp_path_factory):
         zip_file.writestr('test-archive/subdir/', '')
         with zip_file.open('test-archive/onetwothree.txt', mode='w') as fp:
             fp.write(file_content)
-        with zip_file.open('test-archive/subdir/onetwothree_again.txt', mode='w') as fp:
+        with zip_file.open('test-archive/subdir/onetwothree<>again.txt', mode='w') as fp:
             fp.write(file_content)
 
     yield path
@@ -65,7 +65,7 @@ def test_iter_zip(sample_zip):
             size=0,
         ),
         ZipfileItem(
-            name=root / 'subdir' / 'onetwothree_again.txt',
+            name=root / 'subdir' / 'onetwothree<>again.txt',
             type=FileSystemItemType.file,
             size=8,
         ),

--- a/datalad_next/iter_collections/zipfile.py
+++ b/datalad_next/iter_collections/zipfile.py
@@ -11,7 +11,6 @@ import zipfile
 from dataclasses import dataclass
 from pathlib import (
     Path,
-    PurePath,
     PurePosixPath,
 )
 from typing import Generator
@@ -24,7 +23,11 @@ from .utils import (
 
 @dataclass
 class ZipfileItem(FileSystemItem):
-    pass
+    name: PurePosixPath
+    """ZIP uses POSIX paths as item identifiers from version 6.3.3 onwards.
+    Not all POSIX paths are legal paths on non-POSIX file systems or platforms.
+    Therefore we cannot use a platform-dependent ``PurePath``-instance to
+    address ZIP-file items, anq we use ``PurePosixPath``-instances instead."""
 
 
 def iter_zip(

--- a/datalad_next/iter_collections/zipfile.py
+++ b/datalad_next/iter_collections/zipfile.py
@@ -72,7 +72,7 @@ def _get_zipfile_item(zip_info: zipfile.ZipInfo) -> ZipfileItem:
         else FileSystemItemType.file
     )
     return ZipfileItem(
-        name=PurePath(PurePosixPath(zip_info.filename)),
+        name=PurePosixPath(zip_info.filename),
         type=mtype,
         size=zip_info.file_size,
         mtime=time.mktime(


### PR DESCRIPTION
This PR modifies zip-iterators to use `PurePosixPath` for names of archive members instead of `PurePath`. The rationale for this change is that according to [zip-APPNOTE.TXT version 6.3.3](https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.3.TXT) from September 1st, 2012, all slashes in file names (contained in zip) _must_ be forward slashes, i.e. '/'. From September 26th, 2006 onwards [zip-APPNOTE.TXT version 6.3.0](https://pkware.cachefly.net/webdocs/APPNOTE/APPNOTE-6.3.0.TXT) states that all slashes _should_ be forward slashes.

It seems to be safe to assume that almost all zip-files we encounter will be using forward slashes. Because `PurePath` instances are OS-specific, a `PurePath` on Windows will contain `\`-slashes and not properly represent the content of the archive. Consequently, those paths cannot be used to retrieve items from a `zipfile.ZipFile` without conversion to a POSIX-style path.

We should therefore use `PurePosixPath`-instances to represent the name of elements in a zip-archive.

This touches again on issue #402. Maybe we should introduce different base classes, one for objects with platform-dependent paths, which would use `PurePath`, and one for objects with platform-independent, fixed, path-formats, e.g.  zip-file items.
