### PR TITLE
Update TarArchiveOperations and equip with tests 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -202,6 +202,9 @@ build: off
 # init cannot use any components from the repo, because it runs prior to
 # cloning it
 init:
+  # enable external SSH access to CI worker
+  # needs APPVEYOR_SSH_KEY defined in project settings (or environment)
+  - sh: curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
   # remove windows 260-char limit on path names
   - cmd: powershell Set-Itemproperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name LongPathsEnabled -value 1
   # enable developer mode on windows
@@ -227,9 +230,6 @@ init:
   - sh: export TMPDIR=~/DLTMP
 
 install:
-  # enable external SSH access to CI worker on all other systems
-  # needs APPVEYOR_SSH_KEY defined in project settings (or environment)
-  - sh: tools/appveyor/enable-ssh-login
   # place a debug setup helper at a convenient location
   - cmd: copy tools\appveyor\env_setup.bat C:\\datalad_debug.bat
   # Missing system software

--- a/datalad_next/archive_operations/__init__.py
+++ b/datalad_next/archive_operations/__init__.py
@@ -71,6 +71,10 @@ class ArchiveOperations(ABC):
     def __str__(self) -> str:
         return f'{self.__class__.__name__}({self._location})'
 
+    def __repr__(self) -> str:
+        return \
+            f'{self.__class__.__name__}({self._location}, cfg={self._cfg!r})'
+
     @property
     def cfg(self) -> ConfigManager:
         """ConfigManager given to the constructor, or the session default"""

--- a/datalad_next/archive_operations/__init__.py
+++ b/datalad_next/archive_operations/__init__.py
@@ -1,6 +1,6 @@
 """Handler for operations on various archive types
 
-All handlers implements the API defined by :class:`ArchiveOperations`.
+All handlers implement the API defined by :class:`ArchiveOperations`.
 
 Available handlers:
 

--- a/datalad_next/archive_operations/tests/test_tarfile.py
+++ b/datalad_next/archive_operations/tests/test_tarfile.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import (
+    Path,
+    PurePath,
+    PurePosixPath,
+)
+from typing import Generator
+
+import pytest
+
+from datalad_next.iter_collections.utils import FileSystemItemType
+
+from ..tarfile import TarArchiveOperations
+
+
+@dataclass
+class TestArchive:
+    path: Path
+    item_count: int
+    content: bytes
+    target_hash: dict[str, str]
+
+
+@pytest.fixture(scope='session')
+def structured_sample_tar_xz(
+    sample_tar_xz
+) -> Generator[TestArchive, None, None]:
+    yield TestArchive(
+        path=sample_tar_xz,
+        item_count=6,
+        content=b'123\n',
+        target_hash={
+            'SHA1': 'b5dfcec4d1b6166067226fae102f7fbcf6bd1bd4',
+            'md5': 'd700214df5487801e8ee23d31e60382a',
+        }
+    )
+
+
+def test_tararchive_basics(structured_sample_tar_xz: TestArchive):
+    spec = structured_sample_tar_xz
+    # this is intentionally a hard-coded POSIX relpath
+    member_name = 'test-archive/onetwothree.txt'
+    with TarArchiveOperations(spec.path) as archive_ops:
+        with archive_ops.open(member_name) as member:
+            assert member.read() == spec.content
+        with archive_ops.open(PurePosixPath(member_name)) as member:
+            assert member.read() == spec.content
+        with archive_ops.open(PurePath(member_name)) as member:
+            assert member.read() == spec.content
+
+
+def test_tararchive_contain(structured_sample_tar_xz: TestArchive):
+    # this is intentionally a hard-coded POSIX relpath
+    member_name = 'test-archive/onetwothree.txt'
+    archive_ops = TarArchiveOperations(structured_sample_tar_xz.path)
+    # POSIX path str
+    assert member_name in archive_ops
+    # POSIX path as obj
+    assert PurePosixPath(member_name) in archive_ops
+    # platform path
+    assert PurePath(PurePosixPath(member_name)) in archive_ops
+    assert 'bogus' not in archive_ops
+
+
+def test_tararchive_iterator(structured_sample_tar_xz: TestArchive):
+    spec = structured_sample_tar_xz
+    with TarArchiveOperations(spec.path) as archive_ops:
+        items = list(archive_ops)
+        assert len(items) == spec.item_count
+        for item in items:
+            assert item.name in archive_ops
+
+
+def test_open(structured_sample_tar_xz: TestArchive):
+    spec = structured_sample_tar_xz
+    file_pointer = set()
+    with TarArchiveOperations(spec.path) as tf:
+        for item in tf:
+            if item.type == FileSystemItemType.file:
+                with tf.open(str(PurePosixPath(item.name))) as fp:
+                    file_pointer.add(fp)
+                    assert fp.read(len(spec.content)) == spec.content
+        # check the fp before we close the archive handler
+        for fp in file_pointer:
+            assert fp.closed is True


### PR DESCRIPTION
- More sensible `__repr__` for `ArchiveOperations`
- Document methods
- More flexible handling of archive item names. `open()` and all other
  such methods can now accept `item.name` from `__iter__` results
  directly. Based on the assumption that all TAR archives use member
  names in POSIX notation.
- Add unit tests with comprehensive coverage. Modelled after the
  `ZipArchiveOperations` tests in
  datalad#407 but with more
  context manager use.

<details>
<summary>Stuff from the development history of this PR</summary>

Interesting test failure pattern:

```
FAILED ../archive_operations/tests/test_tarfile.py::test_tararchive_iterator - AssertionError: assert 'test-archive/' in <datalad_next.archive_operations.tarfile.TarArchiveOperations object at 0x108f29fd0>
```

It is only happening with PY3.8, and not with PY3.9 or later. Likely a change in the `tarfile` module. Needs an investigation. The documentation is silent about such a change.

This also points out the need for a custom `__repr__` implementation.

Update: I think the trailing-slash business is not needed:

```
appveyor@appveyor-vm:~$ /home/appveyor/venv3.7/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getnames())"
['test-archive', 'test-archive/123.txt', 'test-archive/123_hard.txt', 'test-archive/subdir', 'test-archive/subdir/onetwothree_again.txt', 'test-archive/onetwothree.txt']
appveyor@appveyor-vm:~$ /home/appveyor/venv3.8/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getnames())"
['test-archive', 'test-archive/123.txt', 'test-archive/123_hard.txt', 'test-archive/subdir', 'test-archive/subdir/onetwothree_again.txt', 'test-archive/onetwothree.txt']
appveyor@appveyor-vm:~$ /home/appveyor/venv3.9/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getnames())"
['test-archive', 'test-archive/123.txt', 'test-archive/123_hard.txt', 'test-archive/subdir', 'test-archive/subdir/onetwothree_again.txt', 'test-archive/onetwothree.txt']
appveyor@appveyor-vm:~$ /home/appveyor/venv3.10/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getnames())"
['test-archive', 'test-archive/123.txt', 'test-archive/123_hard.txt', 'test-archive/subdir', 'test-archive/subdir/onetwothree_again.txt', 'test-archive/onetwothree.txt']
appveyor@appveyor-vm:~$ /home/appveyor/venv3.11/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getnames())"
['test-archive', 'test-archive/123.txt', 'test-archive/123_hard.txt', 'test-archive/subdir', 'test-archive/subdir/onetwothree_again.txt', 'test-archive/onetwothree.txt']
```

```
appveyor@appveyor-vm:~$ /home/appveyor/venv3.7/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive'))"
<TarInfo 'test-archive' at 0x7f82cbfa0bb0>
appveyor@appveyor-vm:~$ /home/appveyor/venv3.8/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive'))"
<TarInfo 'test-archive' at 0x7f380a2bf7c0>
appveyor@appveyor-vm:~$ /home/appveyor/venv3.9/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive'))"
<TarInfo 'test-archive' at 0x7fe0ec693340>
appveyor@appveyor-vm:~$ /home/appveyor/venv3.10/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive'))"
<TarInfo 'test-archive' at 0x7f221e870100>
appveyor@appveyor-vm:~$ /home/appveyor/venv3.11/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive'))"
<TarInfo 'test-archive' at 0x7fde6ee504c0>
```

```
appveyor@appveyor-vm:~$ /home/appveyor/venv3.7/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive/'))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/appveyor/.localpython3.7.16/lib/python3.7/tarfile.py", line 1754, in getmember
    raise KeyError("filename %r not found" % name)
KeyError: "filename 'test-archive/' not found"
appveyor@appveyor-vm:~$ /home/appveyor/venv3.8/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive/'))"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/appveyor/.localpython3.8.16/lib/python3.8/tarfile.py", line 1782, in getmember
    raise KeyError("filename %r not found" % name)
KeyError: "filename 'test-archive/' not found"
appveyor@appveyor-vm:~$ /home/appveyor/venv3.9/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive/'))"
<TarInfo 'test-archive' at 0x7fa7c6813340>
appveyor@appveyor-vm:~$ /home/appveyor/venv3.10/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive/'))"
<TarInfo 'test-archive' at 0x7fb3e8568100>
appveyor@appveyor-vm:~$ /home/appveyor/venv3.11/bin/python -c "import tarfile as tf; print(tf.open('test_archive.tar.xz').getmember('test-archive/'))"
<TarInfo 'test-archive' at 0x7fc59346c4c0>
```

</details>