### PR TITLE
Fix `git ls-file` parsing in `iter_gitworktree()`

### DIFF
--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -69,7 +69,7 @@ class GitWorktreeFileSystemItem(FileSystemItem):
 
 # stolen from GitRepo.get_content_info()
 _lsfiles_props_re = re.compile(
-    r'(?P<mode>[0-9]+) (?P<gitsha>.*) (.*)\t(?P<fname>.*)$'
+    r'(?P<mode>[0-9]+) (?P<gitsha>.*) ([^\t]*)\t(?P<fname>.*)$'
 )
 
 _mode_type_map = {

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -5,7 +5,6 @@ from pathlib import (
 
 import pytest
 
-from datalad_next.utils import on_windows
 from ..gitworktree import (
     GitWorktreeItem,
     GitWorktreeFileSystemItem,
@@ -81,7 +80,6 @@ def test_iter_gitworktree(existing_dataset):
     assert checked_untracked
 
 
-@pytest.mark.skipif(on_windows, reason="not applicable on windows")
 def test_name_starting_with_tab(existing_dataset):
     ds = existing_dataset
     if ds.repo.is_crippled_fs():

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -1,4 +1,11 @@
-from pathlib import PurePath
+from pathlib import (
+    PurePath,
+    PurePosixPath,
+)
+
+import pytest
+
+from datalad_next.utils import on_windows
 from ..gitworktree import (
     GitWorktreeItem,
     GitWorktreeFileSystemItem,
@@ -72,3 +79,17 @@ def test_iter_gitworktree(existing_dataset):
             checked_untracked = True
     assert checked_tracked
     assert checked_untracked
+
+
+@pytest.mark.skipif(on_windows, reason="not applicable on windows")
+def test_name_starting_with_tab(existing_dataset):
+    ds = existing_dataset
+    if ds.repo.is_crippled_fs():
+        pytest.skip("not applicable on crippled filesystems")
+    tabbed_file_name = "\ttab.txt"
+    tabbed_name = ds.pathobj / tabbed_file_name
+    tabbed_name.write_text('name of this file starts with a tab')
+    ds.save()
+
+    iter_names = [item.name for item in iter_gitworktree(ds.pathobj)]
+    assert PurePosixPath(tabbed_file_name) in iter_names


### PR DESCRIPTION
This PR modifies the regular expression that is used during execution of `iter_gitworktree()` in order to parse the output of `git ls-tree`. 

The current version ensures that only one tab-character is considered to separate the file info from the file name. That ensures that file names that start with tab-characters are properly handled (the previous version,  would consider all tab-characters, including the tab-characters belonging to the name, as file-info/file-name separator).

The PR includes a regression test that verifies correct handling of file names starting with tab-characters