### PR TITLE
Adapt tar-archive name type to type of `TarFileItem.name`, i.e. `PurePosixPath`

### DIFF
--- a/datalad_next/archive_operations/tarfile.py
+++ b/datalad_next/archive_operations/tarfile.py
@@ -8,10 +8,9 @@ import tarfile
 from contextlib import contextmanager
 from pathlib import (
     Path,
-    PurePath,
+    PurePosixPath,
 )
 from typing import (
-    Any,
     Generator,
     IO,
 )
@@ -77,7 +76,7 @@ class TarArchiveOperations(ArchiveOperations):
             self._tarfile = None
 
     @contextmanager
-    def open(self, item: str | PurePath) -> Generator[IO | None]:
+    def open(self, item: str | PurePosixPath) -> Generator[IO | None]:
         """Get a file-like for a TAR archive item
 
         The file-like object allows to read from the archive-item specified
@@ -103,7 +102,7 @@ class TarArchiveOperations(ArchiveOperations):
         with self.tarfile.extractfile(_anyid2membername(item)) as fp:
             yield fp
 
-    def __contains__(self, item: str | PurePath) -> bool:
+    def __contains__(self, item: str | PurePosixPath) -> bool:
         try:
             self.tarfile.getmember(_anyid2membername(item))
             return True
@@ -116,8 +115,8 @@ class TarArchiveOperations(ArchiveOperations):
         yield from iter_tar(self._tarfile_path, fp=False)
 
 
-def _anyid2membername(item_id: str | PurePath) -> str:
-    if isinstance(item_id, PurePath):
+def _anyid2membername(item_id: str | PurePosixPath) -> str:
+    if isinstance(item_id, PurePosixPath):
         return item_id.as_posix()
     else:
         return item_id

--- a/datalad_next/archive_operations/tests/test_tarfile.py
+++ b/datalad_next/archive_operations/tests/test_tarfile.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import (
     Path,
-    PurePath,
     PurePosixPath,
 )
 from typing import Generator
@@ -47,8 +46,6 @@ def test_tararchive_basics(structured_sample_tar_xz: TestArchive):
             assert member.read() == spec.content
         with archive_ops.open(PurePosixPath(member_name)) as member:
             assert member.read() == spec.content
-        with archive_ops.open(PurePath(member_name)) as member:
-            assert member.read() == spec.content
 
 
 def test_tararchive_contain(structured_sample_tar_xz: TestArchive):
@@ -59,8 +56,6 @@ def test_tararchive_contain(structured_sample_tar_xz: TestArchive):
     assert member_name in archive_ops
     # POSIX path as obj
     assert PurePosixPath(member_name) in archive_ops
-    # platform path
-    assert PurePath(PurePosixPath(member_name)) in archive_ops
     assert 'bogus' not in archive_ops
 
 

--- a/tools/appveyor/install-syspkgs
+++ b/tools/appveyor/install-syspkgs
@@ -6,7 +6,7 @@ set -e
 [ -z "$1" ] && exit 0 || true
 
 if (which apt-get > /dev/null ); then
-	sudo apt-get update -qq -y
+	sudo apt-get update -qq -y --allow-releaseinfo-change
 	sudo apt-get install -q --no-install-recommends -y eatmydata
 	sudo eatmydata apt-get install -q --no-install-recommends -y $*
 else


### PR DESCRIPTION
This PR adapts tararchive-operations to the recently updated type of `TarFileItem.name` to `PurePosixPath`.
