### PR TITLE
Replacement for `with_testsui`

### DIFF
--- a/datalad_next/commands/tests/test_download.py
+++ b/datalad_next/commands/tests/test_download.py
@@ -1,6 +1,5 @@
 from io import StringIO
 import json
-from pathlib import Path
 import pytest
 
 import datalad
@@ -11,18 +10,20 @@ from datalad.api import (
 from datalad_next.tests.utils import (
     assert_result_count,
     assert_status,
-    with_testsui,
 )
 from datalad_next.utils import chpwd
 
 from datalad_next.utils import CredentialManager
+
 
 @pytest.fixture
 def hbsurl(httpbin):
     # shortcut for the standard URL
     return httpbin["standard"]
 
+
 test_cred = ('dltest-my&=http', 'datalad', 'secure')
+
 
 @pytest.fixture
 def hbscred(hbsurl):
@@ -202,12 +203,14 @@ def test_download_no_credential_leak_to_http(credman, capsys, hbscred, httpbin):
     assert_status('error', res)
 
 
-@with_testsui(responses=[
-    'token123',
-    # after download, it asks for a name
-    'dataladtest_test_download_new_bearer_token',
-])
-def test_download_new_bearer_token(tmp_keyring, capsys, hbsurl):
+def test_download_new_bearer_token(
+        tmp_keyring, capsys, hbsurl, datalad_interactive_ui):
+    ui = datalad_interactive_ui
+    ui.staged_responses.extend([
+        'token123',
+        # after download, it asks for a name
+        'dataladtest_test_download_new_bearer_token',
+    ])
     try:
         download({f'{hbsurl}/bearer': '-'})
         # and it was saved under this name
@@ -224,12 +227,14 @@ def test_download_new_bearer_token(tmp_keyring, capsys, hbsurl):
         )
 
 
-@with_testsui(responses=[
-    'datalad_uniquetoken123',
-    # after download, it asks for a name, but skip to save
-    'skip',
-])
-def test_download_new_bearer_token_nosave(capsys, hbsurl):
+def test_download_new_bearer_token_nosave(
+        capsys, hbsurl, datalad_interactive_ui):
+    ui = datalad_interactive_ui
+    ui.staged_responses.extend([
+        'datalad_uniquetoken123',
+        # after download, it asks for a name, but skip to save
+        'skip',
+    ])
     download({f'{hbsurl}/bearer': '-'})
     # and it was saved under this name
     assert_result_count(

--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -10,6 +10,10 @@ from datalad_next.tests.fixtures import (
     credman,
     # function-scope config manager
     datalad_cfg,
+    # function-scope UI wrapper that can provide staged responses
+    datalad_interactive_ui,
+    # function-scope UI wrapper that can will raise when asked for responses
+    datalad_noninteractive_ui,
     # function-scope temporary keyring
     tmp_keyring,
     # function-scope, Dataset instance

--- a/datalad_next/credman/tests/test_credman.py
+++ b/datalad_next/credman/tests/test_credman.py
@@ -20,12 +20,12 @@ from datalad_next.tests.utils import (
     assert_in,
     assert_raises,
     eq_,
-    with_testsui,
 )
 from datalad_next.utils import chpwd
 
 
-def test_credmanager(tmp_keyring, datalad_cfg):
+def test_credmanager(tmp_keyring, datalad_cfg, datalad_interactive_ui):
+    ui = datalad_interactive_ui
     credman = CredentialManager(datalad_cfg)
     # doesn't work with thing air
     assert_raises(ValueError, credman.get)
@@ -107,42 +107,47 @@ def test_credmanager(tmp_keyring, datalad_cfg):
     eq_(credman.get('mycred'), None)
 
     # test prompting for a secret when none is given
-    res = with_testsui(responses=['mysecret'])(credman.set)(
-        'mycred', other='prop')
+    ui.staged_responses.append('mysecret')
+    res = credman.set('mycred', other='prop')
     assert res == {'other': 'prop', 'secret': 'mysecret'}
 
     # test prompting for a name when None is given
-    res = with_testsui(responses=['mycustomname'])(credman.set)(
-        None, secret='dummy', other='prop')
+    ui.staged_responses.append('mycustomname')
+    res = credman.set(None, secret='dummy', other='prop')
     assert res == {'name': 'mycustomname', 'other': 'prop', 'secret': 'dummy'}
 
     # test name prompt loop in case of a name collision
-    res = with_testsui(
-        responses=['mycustomname', 'mycustomname2'])(
-            credman.set)(
-        None, secret='dummy2', other='prop2')
+    ui.staged_responses.extend(['mycustomname', 'mycustomname2'])
+    res = credman.set(None, secret='dummy2', other='prop2')
     assert res == {'name': 'mycustomname2', 'other': 'prop2',
                    'secret': 'dummy2'}
 
     # test skipping at prompt, smoke test _context arg
-    res = with_testsui(responses=['skip'])(credman.set)(
+    ui.staged_responses.append('skip')
+    res = credman.set(
         None, _context='for me', secret='dummy', other='prop')
     assert res is None
 
-    # if no name is provided and none _can_ be entered -> raise
-    with pytest.raises(ValueError):
-        credman.set(None, secret='dummy', other='prop')
-
     # accept suggested name
-    res = with_testsui(responses=[''])(credman.set)(
+    ui.staged_responses.append('')
+    res = credman.set(
         None, _suggested_name='auto1', secret='dummy', other='prop')
     assert res == {'name': 'auto1', 'other': 'prop', 'secret': 'dummy'}
 
     # a suggestion conflicting with an existing credential is like
     # not making a suggestion at all
-    res = with_testsui(responses=['', 'auto2'])(credman.set)(
+    ui.staged_responses.extend(('', 'auto2'))
+    res = credman.set(
         None, _suggested_name='auto1', secret='dummy', other='prop')
     assert res == {'name': 'auto2', 'other': 'prop', 'secret': 'dummy'}
+
+
+def test_credmanager_set_noninteractive(
+        tmp_keyring, datalad_cfg, datalad_noninteractive_ui):
+    credman = CredentialManager(datalad_cfg)
+    # if no name is provided and none _can_ be entered -> raise
+    with pytest.raises(ValueError):
+        credman.set(None, secret='dummy', other='prop')
 
 
 def test_credman_local(existing_dataset):
@@ -193,16 +198,19 @@ def test_query(tmp_keyring, datalad_cfg):
         [i[0] for i in slist])
 
 
-def test_credman_get(datalad_cfg):
+def test_credman_get(datalad_cfg, datalad_interactive_ui):
+    ui = datalad_interactive_ui
     # we are not making any writes, any config must work
     credman = CredentialManager(datalad_cfg)
     # must be prompting for missing properties
-    res = with_testsui(responses=['myuser'])(credman.get)(
+    ui.staged_responses.append('myuser')
+    res = credman.get(
         None, _type_hint='user_password', _prompt='myprompt',
         secret='dummy')
     assert 'myuser' == res['user']
     # same for the secret
-    res = with_testsui(responses=['mysecret'])(credman.get)(
+    ui.staged_responses.append('mysecret')
+    res = credman.get(
         None, _type_hint='user_password', _prompt='myprompt',
         user='dummy')
     assert 'mysecret' == res['secret']
@@ -223,7 +231,8 @@ def test_credman_get_guess_type():
     }
 
 
-def test_credman_obtain(tmp_keyring, datalad_cfg):
+def test_credman_obtain(tmp_keyring, datalad_cfg, datalad_interactive_ui):
+    ui = datalad_interactive_ui
     credman = CredentialManager(datalad_cfg)
     # senseless, but valid call
     # could not possibly report a credential without any info
@@ -236,8 +245,8 @@ def test_credman_obtain(tmp_keyring, datalad_cfg):
     with pytest.raises(ValueError):
         credman.obtain(prompt='myprompt')
     # minimal condition prompt and type-hint for manual entry
-    res = with_testsui(responses=['mytoken'])(credman.obtain)(
-        type_hint='token', prompt='myprompt')
+    ui.staged_responses.append('mytoken')
+    res = credman.obtain(type_hint='token', prompt='myprompt')
     assert res == (None,
                    {'type': 'token', 'secret': 'mytoken', '_edited': True})
 
@@ -265,7 +274,8 @@ def test_credman_obtain(tmp_keyring, datalad_cfg):
     res = credman.obtain(query_props={'realm': 'myrealm'})
     # if we are looking for a realm, we get it back even if a credential
     # had to be entered
-    res = with_testsui(responses=['mynewtoken'])(credman.obtain)(
+    ui.staged_responses.append('mynewtoken')
+    res = credman.obtain(
         type_hint='token', prompt='myprompt',
         query_props={'realm': 'mytotallynewrealm'})
     assert res == (None,

--- a/datalad_next/tests/fixtures.py
+++ b/datalad_next/tests/fixtures.py
@@ -373,3 +373,45 @@ def httpbin(httpbin_service):
             "docker-deployed instance -- too unreliable"
         )
     yield httpbin_service
+
+
+@pytest.fixture(autouse=False, scope="function")
+def datalad_interactive_ui(monkeypatch):
+    """Yields a UI replacement to query for operations and stage responses
+
+    No output will be written to STDOUT/ERR by this UI.
+
+    A standard usage pattern is to stage one or more responses, run the
+    to-be-tested code, and verify that the desired user interaction
+    took place::
+
+       > datalad_interactive_ui.staged_responses.append('skip')
+       > ...
+       > assert ... datalad_interactive_ui.log
+    """
+    from datalad_next.uis import ui_switcher
+    from datalad_next.tests.utils import InteractiveTestUI
+
+    with monkeypatch.context() as m:
+        m.setattr(ui_switcher, '_ui', InteractiveTestUI())
+        yield ui_switcher.ui
+
+
+@pytest.fixture(autouse=False, scope="function")
+def datalad_noninteractive_ui(monkeypatch):
+    """Yields a UI replacement to query for operations
+
+    No output will be written to STDOUT/ERR by this UI.
+
+    A standard usage pattern is to run the to-be-tested code, and verify that
+    the desired user messaging took place::
+
+       > ...
+       > assert ... datalad_interactive_ui.log
+    """
+    from datalad_next.uis import ui_switcher
+    from datalad_next.tests.utils import TestUI
+
+    with monkeypatch.context() as m:
+        m.setattr(ui_switcher, '_ui', TestUI())
+        yield ui_switcher.ui

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -1,7 +1,10 @@
+
+from collections import deque
 import logging
 from functools import wraps
 from os import environ
 from pathlib import Path
+from typing import Any
 
 from datalad.support.external_versions import external_versions
 # all datalad-core test utils needed for datalad-next
@@ -28,10 +31,10 @@ from datalad.tests.utils_pytest import (
     skip_ssh,
     skip_wo_symlink_capability,
     swallow_logs,
-    with_testsui,
 )
 from datalad.tests.test_utils_testrepos import BasicGitTestRepo
 from datalad.cli.tests.test_main import run_main
+from datalad.ui.progressbars import SilentProgressBar
 from datalad.utils import (
     create_tree,
     md5sum,
@@ -158,3 +161,87 @@ def get_git_config_global_fpath() -> Path:
 
     fpath = Path(fpath)
     return fpath
+
+
+class TestUI:
+    """Drop-in replacement for the DataLad UI to protocol any calls"""
+
+    is_interactive = False
+    """Flag is inspected in generic UI code to check for the possibility
+    of interactivity"""
+
+    def __init__(self):
+        # this member will hold a log of all calls made to the UI wrapper
+        self._log = []
+
+    def __str__(self) -> str:
+        return "{cls}(\n{log}\n)".format(
+            cls=self.__class__.__name__,
+            log='\n'.join(f'  {i[0]}: {i[1]}' for i in self.log),
+        )
+
+    @property
+    def log(self) -> list:
+        """Call log
+
+        Returns
+        -------
+        list
+          Each item is a two-tuple with the label of the UI operation
+          as first element, and the verbatim parameters/values of the
+          respective operation.
+        """
+        return self._log
+
+    @property
+    def operation_sequence(self) -> list:
+        """Same as ``.log()``, but limited to just the operation labels"""
+        return [i[0] for i in self.log]
+
+    def question(self, *args, **kwargs) -> Any:
+        """Raise ``RuntimeError`` when a question needs to be asked"""
+        self._log.append(('question', (args, kwargs)))
+        raise RuntimeError(
+            'non-interactive test UI was asked for a response to a question')
+
+    def message(self, msg, cr='\n'):
+        """Post a message"""
+        self._log.append(('message', (msg, cr)))
+
+    def get_progressbar(self, *args, **kwargs):
+        """Return a progress handler"""
+        self._log.append(('get_progressbar', (args, kwargs)))
+        return SilentProgressBar(*args, **kwargs)
+
+
+class InteractiveTestUI(TestUI):
+    """DataLad UI that can also provide staged user responses"""
+
+    is_interactive = True
+
+    def __init__(self):
+        super().__init__()
+        # queue to provision responses
+        self._responses = deque()
+
+    def __str__(self) -> str:
+        return "{cls}(\n{log}\n  (unused responses: {res})\n)".format(
+            cls=self.__class__.__name__,
+            log='\n'.join(f'  {i[0]}: {i[1]}' for i in self.log),
+            res=list(self.staged_responses),
+        )
+
+    @property
+    def staged_responses(self) -> deque:
+        """``deque`` for staging user responses and retrieving them"""
+        return self._responses
+
+    def question(self, *args, **kwargs) -> Any:
+        """Report a provisioned response when a question is asked"""
+        self._log.append(('question', (args, kwargs)))
+        if not self.staged_responses:
+            raise AssertionError(
+                "UI response requested, but no further are provisioned")
+        response = self.staged_responses.popleft()
+        self._log.append(('response', response))
+        return response


### PR DESCRIPTION
Replacement for `with_testsui`
    
This provides two fixtures
    
- `datalad_interactive_ui`
- `datalad_noninteractive_ui`
    
    that can be used to test user interaction or communication sequences.
    Unlike the datalad-core test UI, this is not only provisioning
    user input. In addition, it allows for inspecting a detailed UI
    call log, and offers a text-rendering to easy debugging:
    
 ```
(Pdb) print(ui)
InteractiveTestUI(
  question: (('attr1',), {'title': 'dummyquestion'})
  response: attr1
  question: (('attr2',), {'title': None})
  response: attr2
  question: (('secret',), {'title': None, 'repeat': True, 'hidden': True})
  response: secret
  (unused responses: [])
)
```




Closes #423

TODO

- [x] actually use it to test more
- [x] document