### PR TITLE
Fix package installation in appveyor on debian platforms

### DIFF
--- a/tools/appveyor/install-syspkgs
+++ b/tools/appveyor/install-syspkgs
@@ -6,7 +6,7 @@ set -e
 [ -z "$1" ] && exit 0 || true
 
 if (which apt-get > /dev/null ); then
-	sudo apt-get update -qq -y
+	sudo apt-get update -qq -y --allow-releaseinfo-change
 	sudo apt-get install -q --no-install-recommends -y eatmydata
 	sudo eatmydata apt-get install -q --no-install-recommends -y $*
 else


### PR DESCRIPTION
Currently the construction of the test environment on appveyor is failing in debian-based environments. It fails during `apt-get update` due to changed release infos for debian packages. This PR allows allows `apt-get update` to continue in changes in release info. This should fix the tests on debian-based appveyor environments.
