### PR TITLE
Fix directory name handling in zip-iterator

### DIFF
--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -4,7 +4,7 @@ from pathlib import PurePosixPath
 
 from ..zipfile import (
     FileSystemItemType,
-    ZipFileDirPath,
+    _ZipFileDirPath,
     ZipfileItem,
     iter_zip,
 )
@@ -51,7 +51,7 @@ def test_iter_zip(sample_zip):
     root = PurePosixPath('test-archive')
     targets = [
         ZipfileItem(
-            name=ZipFileDirPath(root),
+            name=_ZipFileDirPath(root),
             type=FileSystemItemType.directory,
             size=0,
         ),
@@ -61,7 +61,7 @@ def test_iter_zip(sample_zip):
             size=8,
         ),
         ZipfileItem(
-            name=ZipFileDirPath(root, 'subdir'),
+            name=_ZipFileDirPath(root, 'subdir'),
             type=FileSystemItemType.directory,
             size=0,
         ),
@@ -92,9 +92,9 @@ def test_iter_zip(sample_zip):
 
 
 def test_zip_dir_path():
-    zp1 = ZipFileDirPath("a/b")
-    zp2 = ZipFileDirPath("a/b")
-    zp3 = ZipFileDirPath("a/c")
+    zp1 = _ZipFileDirPath("a/b")
+    zp2 = _ZipFileDirPath("a/b")
+    zp3 = _ZipFileDirPath("a/c")
     pp = PurePosixPath("a/b")
 
     assert zp1.as_posix()[-1] == '/'

--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -97,6 +97,7 @@ def test_zip_dir_path():
     zp3 = ZipFileDirPath("a/c")
     pp = PurePosixPath("a/b")
 
+    assert zp1.as_posix()[-1] == '/'
     assert zp1 == zp2
     assert zp1 != zp3
     assert zp1 != pp

--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -90,3 +90,14 @@ def test_iter_zip(sample_zip):
     for t in targets:
         print(t.name)
         assert t in ires
+
+
+def test_zip_dir_path():
+    zp1 = ZipFileDirPath("a/b")
+    zp2 = ZipFileDirPath("a/b")
+    zp3 = ZipFileDirPath("a/c")
+    pp = PurePosixPath("a/b")
+
+    assert zp1 == zp2
+    assert zp1 != zp3
+    assert zp1 != pp

--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -3,8 +3,9 @@ import zipfile
 from pathlib import PurePosixPath
 
 from ..zipfile import (
-    ZipfileItem,
     FileSystemItemType,
+    ZipFileDirPath,
+    ZipfileItem,
     iter_zip,
 )
 
@@ -50,7 +51,7 @@ def test_iter_zip(sample_zip):
     root = PurePosixPath('test-archive')
     targets = [
         ZipfileItem(
-            name=root,
+            name=ZipFileDirPath(root),
             type=FileSystemItemType.directory,
             size=0,
         ),
@@ -60,7 +61,7 @@ def test_iter_zip(sample_zip):
             size=8,
         ),
         ZipfileItem(
-            name=root / 'subdir',
+            name=ZipFileDirPath(root, 'subdir'),
             type=FileSystemItemType.directory,
             size=0,
         ),
@@ -87,4 +88,5 @@ def test_iter_zip(sample_zip):
         # do not compare mtime
         r.mtime = None
     for t in targets:
+        print(t.name)
         assert t in ires

--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -88,7 +88,6 @@ def test_iter_zip(sample_zip):
         # do not compare mtime
         r.mtime = None
     for t in targets:
-        print(t.name)
         assert t in ires
 
 

--- a/datalad_next/iter_collections/zipfile.py
+++ b/datalad_next/iter_collections/zipfile.py
@@ -80,18 +80,16 @@ def iter_zip(
 
 
 def _get_zipfile_item(zip_info: zipfile.ZipInfo) -> ZipfileItem:
-    mtype = (
-        FileSystemItemType.directory
-        if zip_info.is_dir()
-        else FileSystemItemType.file
-    )
     return ZipfileItem(
-        name=(
-            ZipFileDirPath(zip_info.filename)
+        **(
+            dict(
+                name=ZipFileDirPath(zip_info.filename),
+                type=FileSystemItemType.directory)
             if zip_info.is_dir()
-            else PurePosixPath(zip_info.filename)
+            else dict(
+                name=PurePosixPath(zip_info.filename),
+                type=FileSystemItemType.file)
         ),
-        type=mtype,
         size=zip_info.file_size,
         mtime=time.mktime(
             datetime.datetime(*zip_info.date_time).timetuple()

--- a/datalad_next/iter_collections/zipfile.py
+++ b/datalad_next/iter_collections/zipfile.py
@@ -72,8 +72,8 @@ def iter_zip(
         for zip_info in zip_file.infolist():
             item = _get_zipfile_item(zip_info)
             if fp and item.type == FileSystemItemType.file:
-                with zip_file.open(zip_info) as fp:
-                    item.fp = fp
+                with zip_file.open(zip_info) as amfp:
+                    item.fp = amfp
                     yield item
             else:
                 yield item

--- a/datalad_next/iter_collections/zipfile.py
+++ b/datalad_next/iter_collections/zipfile.py
@@ -21,6 +21,17 @@ from .utils import (
 )
 
 
+class ZipFileDirPath(PurePosixPath):
+    """Used to create proper names for directories in zip-archives"""
+    def __str__(self) -> str:
+        return PurePosixPath.__str__(self) + '/'
+
+    def __eq__(self, other):
+        if not isinstance(other, ZipFileDirPath):
+            return False
+        return PurePosixPath.__eq__(self, other)
+
+
 @dataclass
 class ZipfileItem(FileSystemItem):
     name: PurePosixPath
@@ -75,7 +86,11 @@ def _get_zipfile_item(zip_info: zipfile.ZipInfo) -> ZipfileItem:
         else FileSystemItemType.file
     )
     return ZipfileItem(
-        name=PurePosixPath(zip_info.filename),
+        name=(
+            ZipFileDirPath(zip_info.filename)
+            if zip_info.is_dir()
+            else PurePosixPath(zip_info.filename)
+        ),
         type=mtype,
         size=zip_info.file_size,
         mtime=time.mktime(

--- a/datalad_next/iter_collections/zipfile.py
+++ b/datalad_next/iter_collections/zipfile.py
@@ -21,15 +21,21 @@ from .utils import (
 )
 
 
-class ZipFileDirPath(PurePosixPath):
-    """Used to create proper names for directories in zip-archives"""
+class _ZipFileDirPath(PurePosixPath):
+    """PurePosixPath variant that appends a '/' to the str-representation
+
+    This is used by class:`ZipfileItem` to represent directory members in
+    ZIP archives, in order to streamline archive member tests via a
+    ``item.name in zipfile.ZipFile(...)`` pattern. ``ZipFile`` requires
+    directory members to be identified with a trailing slash.
+    """
     def __str__(self) -> str:
-        return PurePosixPath.__str__(self) + '/'
+        return f'{super().__str__()}/'
 
     def __eq__(self, other):
-        if not isinstance(other, ZipFileDirPath):
+        if not isinstance(other, _ZipFileDirPath):
             return False
-        return PurePosixPath.__eq__(self, other)
+        return super().__eq__(other)
 
 
 @dataclass
@@ -83,7 +89,7 @@ def _get_zipfile_item(zip_info: zipfile.ZipInfo) -> ZipfileItem:
     return ZipfileItem(
         **(
             dict(
-                name=ZipFileDirPath(zip_info.filename),
+                name=_ZipFileDirPath(zip_info.filename),
                 type=FileSystemItemType.directory)
             if zip_info.is_dir()
             else dict(


### PR DESCRIPTION
This PR keeps the seemingly neverending iterator item name story alive. 

The problem is that directory names in zip-archives possess a trailing '/'. We currently use `PurePosixPath` instances to represent file- and directory-entries in all types of collections. This leads to the necessity of special handling in ZipArchiveOperations, for example, when checking for containment (because `ZipFileItem.name` cannot be used directly):

```python
...
for item in iter_zip(...):
    if (str(item.name) + '/' if item.type == FileSystemItemType.directory else item.name) in zip_archive:
        ...
``` 

Instead of the "canonical" way that is used in TarArchiveOperations:
```python
...
for item in iter_tar(...):
    if item.name in tar_archive:
        ...
``` 

This PR adds the class `ZipFileDirPath`, which is a direct subclass of `PurePosixPath`. Instances of the class represent directory names in zip-archives. The difference to `PurePosixPath` is that rendering appends a '/' to the name.

This allows us to use the "canonical" way of testing for containment in ZipArchiveOperations, i.e.
```python
...
for item in iter_zip(...):
    if item.name in zip_archive:
        ...
``` 
