### PR TITLE
Add a simple test for create-sibling-webdav's recursive mode

### DIFF
--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -74,7 +74,7 @@ class WebDAVPath(object):
             from cheroot import wsgi
             from wsgidav.wsgidav_app import WsgiDAVApp
         except ImportError as e:
-            raise SkipTest('No WSGI capabilities') from e
+            raise SkipTest('No WSGI capabilities. Install cheroot and/or wsgidav') from e
 
         if self.auth:
             auth = {self.auth[0]: {'password': self.auth[1]}}


### PR DESCRIPTION
This fixes #32 with a simple extension to the ``check_common_workflow`` function for a recursive invocation of ``create-sibling-webdav``, a check for the appropriate number of results, and a check for the existence of the target directories of the recursively published subdataset.

I debated whether I should create a dedicated test to not inflate the ``check_common_workflow`` function, and I narrowly decided against it: By adding it to ``check_common_workflow`` the recursive mode gets tested for every ``mode`` automatically, and the increase in time is 1.5-2 seconds over the entire test suite. In comparison, a dedicated test function adds 3-4 seconds for just setting up the dataset hierarchy (see timings below). But I'm happy to do it in a dedicated test if others prefer that.

```
# timing of the test suite without this test:
pytest -s -vv datalad_next/commands/tests/test_create_sibling_webdav.py  14.28s user 7.69s system 59% cpu 36.830 total
# timing of the test suite with the test as in this PR
(fdm-werkstatt) adina@muninn in ~/repos/datalad-next on git:main
pytest -s -vv datalad_next/commands/tests/test_create_sibling_webdav.py  15.72s user 8.99s system 63% cpu 38.869 total
# timing of the testsuite with a dedicated test function for recursive mode (just dataset setup)
pytest -s -vv datalad_next/commands/tests/test_create_sibling_webdav.py  15.55s user 11.98s system 67% cpu 40.996 total
```

This PR also adds a info about which packages are missing when some webdav tests are skipped.