### PR TITLE
Add christian.moench@web.de to release team

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -10,3 +10,5 @@
 # Merge requests are accepted (automatically) when all (relevant)
 # status checks have passed, and RT approval was given.
 *   michael.hanke@gmail.com
+/iter_collections/ christian.moench@web.de
+/runners/ christian.moench@web.de


### PR DESCRIPTION
Adds christian.moench@web.de to the release team

This PR replaces PR #443 because the PR for branch of my fork did not get picked up by appveyor