### PR TITLE
Small cleanup for using existing base class helpers, when possible

### DIFF
--- a/datalad_next/annexremotes/uncurl.py
+++ b/datalad_next/annexremotes/uncurl.py
@@ -223,12 +223,6 @@ from functools import partial
 from pathlib import Path
 import re
 
-# we intentionally limit ourselves to the most basic interface
-# and even that we only need to get a `ConfigManager` instance.
-# If that class would support a plain path argument, we could
-# avoid it entirely
-from datalad_next.datasets import LeanAnnexRepo
-
 from datalad_next.exceptions import (
     CapturedException,
     UrlOperationsRemoteError,


### PR DESCRIPTION
This code removed here is merely a left-over for when this base class functionality did not exist yet.