### PR TITLE
Rough sketch for a batch(ed) command helper

### DIFF
--- a/datalad_next/runners/__init__.py
+++ b/datalad_next/runners/__init__.py
@@ -17,6 +17,13 @@ of a Git repository.
    GitRunner
    Runner
 
+..
+
+   This should also list, but it is broken
+   https://github.com/datalad/datalad/issues/7499
+
+   ThreadedRunner
+
 Additional information on the design of the subprocess execution tooling
 is available from https://docs.datalad.org/design/threaded_runner.html
 
@@ -39,6 +46,15 @@ inspired by ``asyncio.SubprocessProtocol``.
    StdOutCapture
    StdErrCapture
    StdOutErrCapture
+   protocols
+
+Higher-level tooling
+--------------------
+
+.. autosummary::
+   :toctree: generated
+
+   batch
 """
 
 # runners

--- a/datalad_next/runners/batch.py
+++ b/datalad_next/runners/batch.py
@@ -1,0 +1,135 @@
+"""Helpers to execute batch commands
+
+Some of the functionality provided by this module depends on specific
+"generator" flavors of runner protocols, and additional dedicated
+low-level tooling:
+
+.. currentmodule:: datalad_next.runners.batch
+.. autosummary::
+   :toctree: generated
+
+    StdOutCaptureGeneratorProtocol
+    GeneratorAnnexJsonProtocol
+    _ResultGenerator
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from pathlib import Path
+
+from queue import Queue
+
+from typing import (
+    Any,
+    Generator,
+)
+
+from datalad.runner.nonasyncrunner import _ResultGenerator
+from datalad.support.annexrepo import GeneratorAnnexJsonProtocol
+
+from . import (
+    Protocol,
+    ThreadedRunner,
+)
+from .protocols import StdOutCaptureGeneratorProtocol
+
+
+class BatchProcess:
+    """Representation of a (running) batch process
+
+    An instance of this type is produced by any of the context manager variants
+    in this module. It is a convenience wrapper around an instance of a
+    :class:`_ResultGenerator` that is produced by a :meth:`ThreadedRunner.run`.
+
+    A batch process instanced is used by passing ``bytes`` input to its
+    ``__call__()`` method, and receiving the batch output as return value.
+
+    While the process is still running, it ``return_code`` property will
+    be ``None``. After the has terminated, the property will contain the
+    respective exit code.
+    """
+    def __init__(self, rgen: _ResultGenerator):
+        self._rgen = rgen
+
+    def __call__(self, data: bytes) -> Any:
+        self._rgen.runner.stdin_queue.put(data)
+        return next(self._rgen)
+
+    @property
+    def return_code(self) -> None | int:
+        return self._rgen.return_code
+
+
+@contextmanager
+def batchcommand(
+    cmd: list,
+    protocol_class: Protocol,
+    cwd: Path | None = None,
+) -> Generator[BatchProcess, None, None]:
+    """Generic context manager for batch processes
+
+    ``cmd`` is an ``argv``-list specification of a command. It is executed via
+    a :class:`~datalad_next.runners.ThreadedRunner` runner instance.  This
+    runner is parameterized with ``protocol_class`` (which can take any
+    implementation of a DataLad runner protocol), responsible for
+    (pre)processing the command's output.
+
+    On leaving the context, the manager takes care of closing ``STDIN``
+    of the underlying process, typically causing it to exit normally.
+
+    While this generic context manager can be used directly, it can be
+    more convenient to use any of the more specialized implementations
+    that employ a specific protocol (e.g., :func:`stdout_batchcommand`,
+    :func:`annexjson_batchcommand`).
+    """
+    input_q = Queue()
+    proc = ThreadedRunner(
+        cmd=cmd,
+        protocol_class=protocol_class,
+        stdin=input_q,
+        cwd=cwd).run()
+    try:
+        bp = BatchProcess(proc)
+        yield bp
+    finally:
+        input_q.put(None)
+        # TODO should we block until `bp.return_code != None`?
+        # TODO should we force terminate `bp` after a grace period?
+
+
+def stdout_batchcommand(
+    cmd: list,
+    cwd: Path | None = None,
+) -> Generator[BatchProcess, None, None]:
+    """Context manager for commands that produce arbitrary output on ``stdout``
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`StdOutCaptureGeneratorProtocol` protocol implementation.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=StdOutCaptureGeneratorProtocol,
+        cwd=cwd,
+    )
+
+
+def annexjson_batchcommand(
+    cmd: list,
+    cwd: Path | None = None,
+) -> Generator[BatchProcess, None, None]:
+    """Context manager for git-annex commands that support ``--batch --json``
+
+    The given ``cmd``-list must be complete, i.e., include
+    ``git annex ... --batch --json``, and any additional flags that may be
+    needed.
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`GeneratorAnnexJsonProtocol` protocol implementation.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=GeneratorAnnexJsonProtocol,
+        cwd=cwd,
+    )

--- a/datalad_next/runners/protocols.py
+++ b/datalad_next/runners/protocols.py
@@ -1,3 +1,7 @@
+"""Additional runner protocol implementations
+
+.. currentmodule:: datalad_next.runners.protocols
+"""
 from . import (
     GeneratorMixIn,
     NoCapture,
@@ -10,6 +14,7 @@ from . import (
 # upstream
 #
 class NoCaptureGeneratorProtocol(NoCapture, GeneratorMixIn):
+    """Generator-variant of the :class:`~datalad_next.runners.NoCapture`"""
     def __init__(self, done_future=None, encoding=None):
         NoCapture.__init__(self, done_future, encoding)
         GeneratorMixIn.__init__(self)
@@ -19,6 +24,7 @@ class NoCaptureGeneratorProtocol(NoCapture, GeneratorMixIn):
 
 
 class StdOutCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
+    """Generator-variant of the :class:`~datalad_next.runners.StdOutCapture`"""
     def __init__(self, done_future=None, encoding=None):
         StdOutCapture.__init__(self, done_future, encoding)
         GeneratorMixIn.__init__(self)

--- a/datalad_next/runners/tests/test_batch.py
+++ b/datalad_next/runners/tests/test_batch.py
@@ -1,0 +1,54 @@
+import pytest
+
+from .. import CommandError
+
+from ..batch import (
+    annexjson_batchcommand,
+    stdout_batchcommand,
+)
+
+
+def test_batch_simple(existing_dataset):
+    # first with a simplistic protocol to test the basic mechanics
+    with stdout_batchcommand(
+        ['git', 'annex', 'examinekey',
+         # the \n in the format is needed to produce an output that hits
+         # the output queue after each input line
+         '--format', '${bytesize}\n',
+         '--batch'],
+        cwd=existing_dataset.pathobj,
+    ) as bp:
+        res = bp(b'MD5E-s21032--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res.rstrip(b'\r\n') == b'21032'
+        # to subprocess is still running
+        assert bp.return_code is None
+        # another batch
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res.rstrip(b'\r\n') == b'999'
+        assert bp.return_code is None
+        # we can bring the process down with stupid input
+        with pytest.raises(CommandError) as deadexc:
+            bp(b'stupid\n')
+        # process exit is detectable
+        assert bp.return_code == 1
+        # continued use raises the same exception
+        # (but stacktrace is obvs different)
+        with pytest.raises(CommandError) as stilldeadexc:
+            bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert deadexc.value.to_str() == stilldeadexc.value.to_str()
+
+    # now with a more complex protocol (decodes JSON-lines output)
+    with annexjson_batchcommand(
+        ['git', 'annex', 'examinekey', '--json', '--batch'],
+        cwd=existing_dataset.pathobj,
+    ) as bp:
+        # output is a decoded JSON object
+        res = bp(b'MD5E-s21032--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res['backend'] == "MD5E"
+        assert res['bytesize'] == "21032"
+        assert res['key'] == "MD5E-s21032--2f4e22eb05d58c21663794876dc701aa"
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res['bytesize'] == "999"
+        with pytest.raises(CommandError) as deadexc:
+            bp(b'stupid\n')
+        assert bp.return_code == 1


### PR DESCRIPTION
This aims to address a long-standing frustration: my cluelessness re efficient execution of (long-running) processes that execute some (query) helper command. My inability has caused much awkward code that gather information upfront, and leads to sluggish behavior of iterators and similar loop-based code that needs to gather information from more than one source.

This changeset includes a minimal wrapper around `ThreadedRunner` that seems to accomplish the goal of provisioning a batched command via a familiar context manager approach.

A basic test demos how the usage could/would look like.