### PR TITLE
Add gitworktree to ls-file-collection's docstring

### DIFF
--- a/changelog.d/20231004_180525_mslw.md
+++ b/changelog.d/20231004_180525_mslw.md
@@ -1,0 +1,6 @@
+### 📝 Documentation
+
+- Include `gitworktree` among the available file collection types
+  listed in `ls-file-collection`'s docstring.  Fixes
+  https://github.com/datalad/datalad-next/issues/470 via
+  https://github.com/datalad/datalad-next/pull/471 (by @mslw)

--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -234,6 +234,20 @@ class LsFileCollection(ValidatedInterface):
       by this command (``return_type='generator``) and only until the next
       result is yielded. PY]
 
+    ``gitworktree``
+      Reports on all tracked and untracked content of a Git repository's
+      work tree. The collection identifier is a path of a directory in a Git
+      repository (which can, but needs not be, its root). Item identifiers
+      are the relative paths of items within that directory. Reported
+      properties include ``gitsha`` and ``gittype``; note that the
+      ``gitsha`` is not equivalent to a SHA1 hash of a file's content, but
+      is the SHA-type blob identifier as reported and used by Git.
+      [PY: When hashes are computed, an ``fp`` property with a file-like is
+      provided. Reading file data from it requires a ``seek(0)`` in most
+      cases. This file handle is only open when items are yielded directly
+      by this command (``return_type='generator``) and only until the next
+      result is yielded. PY]
+
     ``tarfile``
       Reports on members of a TAR archive. The collection identifier is the
       path of the TAR file. Item identifiers are the relative paths

--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -226,7 +226,7 @@ class LsFileCollection(ValidatedInterface):
     ``directory``
       Reports on the content of a given directory (non-recursively). The
       collection identifier is the path of the directory. Item identifiers
-      are the name of a file within that directory. Standard properties like
+      are the names of items within that directory. Standard properties like
       ``size``, ``mtime``, or ``link_target`` are included in the report.
       [PY: When hashes are computed, an ``fp`` property with a file-like
       is provided. Reading file data from it requires a ``seek(0)`` in most


### PR DESCRIPTION
This PR will include `gitworktree` among the available file collection types listed in `ls-file-collection`'s docstring. Fixes #470 

The proposed docstring favours brevity, but does not cover nuances which could be included:
- `hash` being required for `size` to be reported
- reporting being based on `git ls-files --stage --cached --exclude-standard --others`