### PR TITLE
`run()` context manager convenience for subprocess execution

### DIFF
--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -21,9 +21,8 @@ from typing import (
 )
 
 from datalad_next.runners import (
-    DEVNULL,
+    run,
     LineSplitter,
-    ThreadedRunner,
     StdOutCaptureGeneratorProtocol,
 )
 
@@ -251,22 +250,19 @@ def _lsfiles_line2props(
 
 def _git_ls_files(path, *args):
     # we use a plain runner to avoid the overhead of a GitRepo instance
-    runner = ThreadedRunner(
-        cmd=[
-            'git', 'ls-files',
-            # we rely on zero-byte splitting below
-            '-z',
-            # otherwise take whatever is coming in
-            *args,
-        ],
+    with run([
+        'git', 'ls-files',
+        # we rely on zero-byte splitting below
+        '-z',
+        # otherwise take whatever is coming in
+        *args],
         protocol_class=StdOutCaptureGeneratorProtocol,
-        stdin=DEVNULL,
         # run in the directory we want info on
         cwd=path,
-    )
-    line_splitter = LineSplitter('\0', keep_ends=False)
-    # for each command output chunk received by the runner
-    for content in runner.run():
-        # for each zerobyte-delimited "line" in the output
-        for line in line_splitter.process(content.decode('utf-8')):
-            yield line
+    ) as sp:
+        line_splitter = LineSplitter('\0', keep_ends=False)
+        # for each command output chunk received by the runner
+        for content in sp:
+            # for each zerobyte-delimited "line" in the output
+            for line in line_splitter.process(content.decode('utf-8')):
+                yield line

--- a/datalad_next/runners/__init__.py
+++ b/datalad_next/runners/__init__.py
@@ -62,6 +62,9 @@ from .protocols import (
     NoCaptureGeneratorProtocol,
     StdOutCaptureGeneratorProtocol,
 )
+# convenience
+from .run import run
+
 # exceptions
 from datalad.runner.exception import (
     CommandError,

--- a/datalad_next/runners/run.py
+++ b/datalad_next/runners/run.py
@@ -27,6 +27,8 @@ def run(
     *,
     cwd: Path | None = None,
     input: int | IO | bytes | Queue[bytes | None] | None = None,
+    # only generator protocols make sense for timeout, and timeouts are
+    # only checked when the generators polls
     timeout: float | None = None,
 ) -> dict | _ResultGenerator:
     runner = ThreadedRunner(

--- a/datalad_next/runners/run.py
+++ b/datalad_next/runners/run.py
@@ -9,7 +9,6 @@ from queue import Queue
 from subprocess import DEVNULL
 from typing import (
     IO,
-    Optional,
 )
 
 from datalad.runner.nonasyncrunner import _ResultGenerator
@@ -28,7 +27,7 @@ def run(
     cwd: Path | None = None,
     input: int | IO | bytes | Queue[bytes | None] | None = None,
     # only generator protocols make sense for timeout, and timeouts are
-    # only checked when the generators polls
+    # only checked when the generator polls
     timeout: float | None = None,
 ) -> dict | _ResultGenerator:
     runner = ThreadedRunner(
@@ -46,6 +45,12 @@ def run(
         # already be the case -- we make sure that now zombies
         # accumulate
         if runner.process is not None:
+            # TODO figure out what is the most graceful way to
+            # tell a process to stop. Possibly
+            # - process.terminate()
+            # - process.wait(with timeout)
+            # - catch TimeoutExpired exception and process.kill()
+            #
             # send it the KILL signal
             runner.process.kill()
             # wait till the OS has reported the process dead

--- a/datalad_next/runners/run.py
+++ b/datalad_next/runners/run.py
@@ -46,4 +46,7 @@ def run(
         # already be the case -- we make sure that now zombies
         # accumulate
         if runner.process is not None:
+            # send it the KILL signal
             runner.process.kill()
+            # wait till the OS has reported the process dead
+            runner.process.wait()

--- a/datalad_next/runners/run.py
+++ b/datalad_next/runners/run.py
@@ -1,0 +1,47 @@
+"""
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from queue import Queue
+from subprocess import DEVNULL
+from typing import (
+    IO,
+    Optional,
+)
+
+from datalad.runner.nonasyncrunner import _ResultGenerator
+
+from . import (
+    Protocol,
+    ThreadedRunner,
+)
+
+
+@contextmanager
+def run(
+    cmd: list,
+    protocol_class: Protocol,
+    *,
+    cwd: Path | None = None,
+    input: int | IO | bytes | Queue[bytes | None] | None = None,
+    timeout: float | None = None,
+) -> dict | _ResultGenerator:
+    runner = ThreadedRunner(
+        cmd=cmd,
+        protocol_class=protocol_class,
+        stdin=DEVNULL if input is None else input,
+        cwd=cwd,
+        timeout=timeout,
+    )
+    try:
+        yield runner.run()
+    finally:
+        # if we get here the subprocess has no business running
+        # anymore. When run() exited normally, this should
+        # already be the case -- we make sure that now zombies
+        # accumulate
+        if runner.process is not None:
+            runner.process.kill()

--- a/datalad_next/runners/tests/test_run.py
+++ b/datalad_next/runners/tests/test_run.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+import sys
 
 from ..protocols import StdOutCaptureGeneratorProtocol
 
@@ -7,9 +9,27 @@ from ..run import run
 
 def test_run_timeout():
     with pytest.raises(TimeoutError):
-        with run(['sleep', '3'],
-                 StdOutCaptureGeneratorProtocol,
-                 timeout=1) as sp:
+        with run([
+            sys.executable, '-c',
+            'import time; time.sleep(3)'],
+            StdOutCaptureGeneratorProtocol,
+            timeout=1
+        ) as sp:
             # must poll, or timeouts are not checked
             list(sp)
 
+
+def test_run_kill_on_exit():
+    with run([
+        sys.executable, '-c',
+        'import time; print("mike", flush=True); time.sleep(10)'],
+        StdOutCaptureGeneratorProtocol,
+    ) as sp:
+        assert next(sp).rstrip(b'\r\n') == b'mike'
+    # here the process must be killed be the exit of the contextmanager
+    if os.name == 'posix':
+        # on posix platforms a negative returncode of -X indicates
+        # a "killed by signal X"
+        assert sp.runner.process.returncode < 0
+    # on any system the process must be dead now (indicated by a return code)
+    assert sp.runner.process.returncode is not None

--- a/datalad_next/runners/tests/test_run.py
+++ b/datalad_next/runners/tests/test_run.py
@@ -1,9 +1,15 @@
 import os
 import pytest
+from queue import Queue
 import sys
 
+from .. import (
+    NoCapture,
+    StdOutCapture,
+    StdErrCapture,
+    StdOutErrCapture,
+)
 from ..protocols import StdOutCaptureGeneratorProtocol
-
 from ..run import run
 
 
@@ -14,9 +20,9 @@ def test_run_timeout():
             'import time; time.sleep(3)'],
             StdOutCaptureGeneratorProtocol,
             timeout=1
-        ) as sp:
+        ) as res:
             # must poll, or timeouts are not checked
-            list(sp)
+            list(res)
 
 
 def test_run_kill_on_exit():
@@ -24,12 +30,96 @@ def test_run_kill_on_exit():
         sys.executable, '-c',
         'import time; print("mike", flush=True); time.sleep(10)'],
         StdOutCaptureGeneratorProtocol,
-    ) as sp:
-        assert next(sp).rstrip(b'\r\n') == b'mike'
+    ) as res:
+        assert next(res).rstrip(b'\r\n') == b'mike'
     # here the process must be killed be the exit of the contextmanager
     if os.name == 'posix':
         # on posix platforms a negative returncode of -X indicates
         # a "killed by signal X"
-        assert sp.runner.process.returncode < 0
+        assert res.runner.process.returncode < 0
     # on any system the process must be dead now (indicated by a return code)
-    assert sp.runner.process.returncode is not None
+    assert res.runner.process.returncode is not None
+
+
+def test_run_cwd(tmp_path):
+    with run([
+        sys.executable, '-c',
+        'from pathlib import Path; print(Path.cwd(), end="")'],
+        StdOutCapture,
+        cwd=tmp_path,
+    ) as res:
+        assert res['stdout'] == str(tmp_path)
+
+
+def test_run_input_bytes():
+    with run([
+        sys.executable, '-c',
+        'import sys;'
+        'print(sys.stdin.read(), end="")'],
+        StdOutCapture,
+        # it only takes bytes
+        input=b'mybytes\nline',
+    ) as res:
+        # not that bytes went in, but str comes out -- it is up to
+        # the protocol.
+        # use splitlines to compensate for platform line ending
+        # differences
+        assert res['stdout'].splitlines() == ['mybytes', 'line']
+
+
+def test_run_input_queue():
+    input = Queue()
+    with run([
+        sys.executable, '-c',
+        'from fileinput import input; import sys;'
+        '[print(line, flush=True) if line.strip() else sys.exit(0)'
+        ' for line in input()]'],
+        StdOutCaptureGeneratorProtocol,
+        input=input,
+    ) as sp:
+        input.put(b'one\n')
+        assert next(sp).rstrip(b'\r\n') == b'one'
+        input.put(b'two\n')
+        assert next(sp).rstrip(b'\r\n') == b'two'
+        # an empty line should cause process exit
+        input.put(b'\n')
+        # we can wait for that even before the context manager
+        # does its thing and tears it down
+        sp.runner.process.wait()
+
+
+def test_run_nongenerator():
+    # when executed with a non-generator protocol, the process
+    # runs and returns whatever the specified protocol provides
+    # as a result.
+    # below we test the core protocols -- that all happen to
+    # report a return `code`, `stdout`, `stderr` -- but this is
+    # nowhow a given for any other protocol
+    with run([sys.executable, '--version'], NoCapture) as res:
+        assert res['code'] == 0
+    with run([sys.executable, '-c', 'import sys; sys.exit(134)'],
+             NoCapture) as res:
+        assert res['code'] == 134
+    with run([
+        sys.executable, '-c',
+        'import sys; print("print", end="", file=sys.stdout)'],
+        StdOutCapture,
+    ) as res:
+        assert res['code'] == 0
+        assert res['stdout'] == 'print'
+    with run([
+        sys.executable, '-c',
+        'import sys; print("print", end="", file=sys.stderr)'],
+        StdErrCapture,
+    ) as res:
+        assert res['code'] == 0
+        assert res['stderr'] == 'print'
+    with run([
+        sys.executable, '-c',
+        'import sys; print("outy", end="", file=sys.stdout); '
+        'print("error", end="", file=sys.stderr)'],
+        StdOutErrCapture,
+    ) as res:
+        assert res['code'] == 0
+        assert res['stdout'] == 'outy'
+        assert res['stderr'] == 'error'

--- a/datalad_next/runners/tests/test_run.py
+++ b/datalad_next/runners/tests/test_run.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ..protocols import StdOutCaptureGeneratorProtocol
+
+from ..run import run
+
+
+def test_run_timeout():
+    with pytest.raises(TimeoutError):
+        with run(['sleep', '3'],
+                 StdOutCaptureGeneratorProtocol,
+                 timeout=1) as sp:
+            # must poll, or timeouts are not checked
+            list(sp)
+


### PR DESCRIPTION
This PR aims to pick up after the failed #465 -- with me continuing to try to understand the runner usage.

This changeset introduces a `run()` convenience context manager that can be used with generator on non-generator protocols. A set of tests documents that.

The primary purpose here is to establish a uniform way to use subprocesses safely and easily, while ensuring that such processes actually terminate when they are no longer needed. Previously, a persistent runner object was the primary (only?) possibility, and cleanup would need to be implemented on a case-by-case basis. This is error-prone and needlessly verbose.

TODO:

- [x] figure out, if this works
- [x] import unpublished test from #465 attempt for handling of a process that must terminate before anything is read from it (while using a generator protocol)
- [x] determine optional take-down approach for `finally`
- [ ] figure out and test, how the context manager could handle an external STDIN closing. Presently, we require an input `Queue` to be closed manually (`put(None)`). This crashes a `communicate()`: I/O operation on closed file). However, when we do not close `stdin`, a batch/upload process has no indication that it shall stop before it received a SIGTERM, which might stop an operation that should still be completed (upload the last chunk, etc) 