### PR TITLE
More properly present docs on the repo classes

### DIFF
--- a/datalad_next/datasets/__init__.py
+++ b/datalad_next/datasets/__init__.py
@@ -3,18 +3,18 @@
 Two sets of repository abstractions are available :class:`LeanGitRepo` and
 :class:`LeanAnnexRepo` vs. :class:`LegacyGitRepo` and :class:`LegacyAnnexRepo`.
 
-The latter are the classic classes providing a, now legacy, low-level API to
-repository operations. This functionality stems from the earliest days of
-DataLad and implements paradigms and behaviors that are no longer common to
-the rest of the DataLad API. :class:`LegacyGitRepo` and
-:class:`LegacyAnnexRepo` should no longer be used in new developments.
+:class:`LeanGitRepo` and :class:`LeanAnnexRepo` provide a more modern,
+small-ish interface and represent the present standard API for low-level
+repository operations. They are geared towards interacting with Git and
+git-annex more directly, and are more suitable for generator-like
+implementations, promoting low response latencies, and a leaner processing
+footprint.
 
-:class:`LeanGitRepo` and :class:`LeanAnnexRepo` on the other hand provide
-a more modern, substantially restricted API and represent the present
-standard API for low-level repository operations. They are geared towards
-interacting with Git and git-annex more directly, and are more suitable
-for generator-like implementations, promoting low response latencies, and
-a leaner processing footprint.
+The ``Legacy*Repo`` classes provide a, now legacy, low-level API to repository
+operations. This functionality stems from the earliest days of DataLad and
+implements paradigms and behaviors that are no longer common to the rest of the
+DataLad API. :class:`LegacyGitRepo` and :class:`LegacyAnnexRepo` should no
+longer be used in new developments, and are not documented here.
 """
 
 from pathlib import Path
@@ -38,18 +38,33 @@ class LeanAnnexRepo(LegacyAnnexRepo):
     """git-annex repository representation with a minimized API
 
     This is a companion of :class:`LeanGitRepo`. In the same spirit, it
-    restricts its API to a limited set of method that primarily extend
+    restricts its API to a limited set of method that extend
     :class:`LeanGitRepo` with a set of ``call_annex*()`` methods.
+
+    .. autosummary::
+
+       call_annex
+       call_annex_oneline
+       call_annex_success
     """
     # list of attributes permitted in the "lean" API. This list extends
     # the API of LeanGitRepo
-    # TODO extend whitelist of attributed as necessary
+    # TODO extend whitelist of attributes as necessary
     _lean_attrs = [
+        # these are the ones we intend to provide
+        'call_annex',
+        'call_annex_oneline',
+        'call_annex_success',
+        # and here are the ones that we need to permit in order to get them
+        # to run
         '_check_git_version',
+        '_check_git_annex_version',
         # used by AnnexRepo.__init__() -- should be using `is_valid()`
         'is_valid_git',
         'is_valid_annex',
         '_is_direct_mode_from_config',
+        '_call_annex',
+        'call_annex_items_',
     ]
 
     # intentionally limiting to just `path` as the only constructor argument
@@ -65,5 +80,5 @@ class LeanAnnexRepo(LegacyAnnexRepo):
         return obj
 
 
-def _unsupported_method(self):
+def _unsupported_method(self, *args, **kwargs):
     raise NotImplementedError('method unsupported by LeanAnnexRepo')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,12 @@ from os import pardir
 
 import datalad_next
 
+# this cheats sphinx into thinking that LeanGit repo is not
+# merely imported, and convinces it to document it
+import datalad_next.datasets as dnd
+dnd.LeanGitRepo.__module__ = dnd.__name__
+dnd.LeanGitRepo.__name__ = 'LeanGitRepo'
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
Explicitly list the few `call_annex()` methods we aim to support. Most others (`annex_records()` etc) are better covered by iterators.
