### PR TITLE
Bumpy minimal Python dep to 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.8
 install_requires =
     annexremote
     datalad >= 0.18.4


### PR DESCRIPTION
This is the oldest Python version not EOL. Moreover, datalad-next happens to already rely on 3.8 API (e.g. `gzip.BadZipFile`).

Closes #481