### PR TITLE
Revert the API extension of `LeanAnnexRepo`

### DIFF
--- a/datalad_next/datasets/__init__.py
+++ b/datalad_next/datasets/__init__.py
@@ -39,32 +39,32 @@ class LeanAnnexRepo(LegacyAnnexRepo):
 
     This is a companion of :class:`LeanGitRepo`. In the same spirit, it
     restricts its API to a limited set of method that extend
-    :class:`LeanGitRepo` with a set of ``call_annex*()`` methods.
+    :class:`LeanGitRepo`.
 
-    .. autosummary::
-
-       call_annex
-       call_annex_oneline
-       call_annex_success
     """
+    #CA .. autosummary::
+
+    #CA    call_annex
+    #CA    call_annex_oneline
+    #CA    call_annex_success
     # list of attributes permitted in the "lean" API. This list extends
     # the API of LeanGitRepo
     # TODO extend whitelist of attributes as necessary
     _lean_attrs = [
-        # these are the ones we intend to provide
-        'call_annex',
-        'call_annex_oneline',
-        'call_annex_success',
+        #CA # these are the ones we intend to provide
+        #CA 'call_annex',
+        #CA 'call_annex_oneline',
+        #CA 'call_annex_success',
         # and here are the ones that we need to permit in order to get them
         # to run
         '_check_git_version',
-        '_check_git_annex_version',
+        #CA '_check_git_annex_version',
         # used by AnnexRepo.__init__() -- should be using `is_valid()`
         'is_valid_git',
         'is_valid_annex',
         '_is_direct_mode_from_config',
-        '_call_annex',
-        'call_annex_items_',
+        #CA '_call_annex',
+        #CA 'call_annex_items_',
     ]
 
     # intentionally limiting to just `path` as the only constructor argument


### PR DESCRIPTION
This was prematurly done in
https://github.com/datalad/datalad-next/pull/479 without an actual need or application as a motivation.

The change is likely to come eventually, but should be approached in a less adhoc fashion.

This conincidentally avoids the minor version upgrade otherwise implied by #479.