### PR TITLE
Let the test battery honor DATALAD_TESTS_NONETWORK

### DIFF
--- a/datalad_next/archive_operations/tests/test_tarfile.py
+++ b/datalad_next/archive_operations/tests/test_tarfile.py
@@ -10,6 +10,7 @@ from typing import Generator
 import pytest
 
 from datalad_next.iter_collections.utils import FileSystemItemType
+from datalad_next.tests.marker import skipif_no_network
 
 from ..tarfile import TarArchiveOperations
 
@@ -37,6 +38,7 @@ def structured_sample_tar_xz(
     )
 
 
+@skipif_no_network
 def test_tararchive_basics(structured_sample_tar_xz: TestArchive):
     spec = structured_sample_tar_xz
     # this is intentionally a hard-coded POSIX relpath
@@ -48,6 +50,7 @@ def test_tararchive_basics(structured_sample_tar_xz: TestArchive):
             assert member.read() == spec.content
 
 
+@skipif_no_network
 def test_tararchive_contain(structured_sample_tar_xz: TestArchive):
     # this is intentionally a hard-coded POSIX relpath
     member_name = 'test-archive/onetwothree.txt'
@@ -59,6 +62,7 @@ def test_tararchive_contain(structured_sample_tar_xz: TestArchive):
     assert 'bogus' not in archive_ops
 
 
+@skipif_no_network
 def test_tararchive_iterator(structured_sample_tar_xz: TestArchive):
     spec = structured_sample_tar_xz
     with TarArchiveOperations(spec.path) as archive_ops:
@@ -68,6 +72,7 @@ def test_tararchive_iterator(structured_sample_tar_xz: TestArchive):
             assert item.name in archive_ops
 
 
+@skipif_no_network
 def test_open(structured_sample_tar_xz: TestArchive):
     spec = structured_sample_tar_xz
     file_pointer = set()

--- a/datalad_next/commands/tests/test_ls_file_collection.py
+++ b/datalad_next/commands/tests/test_ls_file_collection.py
@@ -7,6 +7,7 @@ import pytest
 from datalad.api import ls_file_collection
 
 from datalad_next.constraints.exceptions import CommandParametrizationError
+from datalad_next.tests.marker import skipif_no_network
 
 from ..ls_file_collection import LsFileCollectionParamValidator
 
@@ -30,6 +31,7 @@ def test_ls_file_collection_insufficient_args():
         ls_file_collection('bogus', 'http://example.com')
 
 
+@skipif_no_network
 def test_ls_file_collection_tarfile(sample_tar_xz):
     kwa = dict(result_renderer='disabled')
     # smoke test first
@@ -84,6 +86,7 @@ def test_ls_file_collection_validator():
         val.get_collection_iter(type='bogus', collection='any', hash=None)
 
 
+@skipif_no_network
 def test_replace_add_archive_content(sample_tar_xz, existing_dataset):
     kwa = dict(result_renderer='disabled')
 

--- a/datalad_next/iter_collections/tests/test_itertar.py
+++ b/datalad_next/iter_collections/tests/test_itertar.py
@@ -3,6 +3,8 @@ import pytest
 
 from datalad.api import download
 
+from datalad_next.tests.marker import skipif_no_network
+
 from ..tarfile import (
     TarfileItem,
     FileSystemItemType,
@@ -42,6 +44,7 @@ def sample_tar_xz(tmp_path_factory):
     tfpath.unlink()
 
 
+@skipif_no_network
 def test_iter_tar(sample_tar_xz):
     target_hash = {'SHA1': 'a8fdc205a9f19cc1c7507a60c4f01b13d11d7fd0',
                    'md5': 'ba1f2511fc30423bdbb183fe33f3dd0f'}

--- a/datalad_next/patches/tests/test_annex_progress_logging.py
+++ b/datalad_next/patches/tests/test_annex_progress_logging.py
@@ -1,4 +1,7 @@
+from datalad_next.tests.marker import skipif_no_network
 
+
+@skipif_no_network
 def test_uncurl_progress_reporting_to_annex(existing_dataset, monkeypatch):
     """Set up a repo that is used to download a key,
     check that we see progress reports

--- a/datalad_next/tests/fixtures.py
+++ b/datalad_next/tests/fixtures.py
@@ -368,6 +368,10 @@ def httpbin(httpbin_service):
     raises ``SkipTest`` whenever any of these undesired conditions is
     detected. Otherwise it just relays ``httpbin_service``.
     """
+    if os.environ.get('DATALAD_TESTS_NONETWORK'):
+        raise SkipTest(
+            'Not running httpbin-based test: NONETWORK flag set'
+        )
     if 'APPVEYOR' in os.environ and 'DEPLOY_HTTPBIN_IMAGE' not in os.environ:
         raise SkipTest(
             "Not running httpbin-based test on appveyor without "

--- a/datalad_next/tests/marker.py
+++ b/datalad_next/tests/marker.py
@@ -1,0 +1,7 @@
+import os
+import pytest
+
+skipif_no_network = pytest.mark.skipif(
+    'DATALAD_TESTS_NONETWORK' in os.environ,
+    reason='DATALAD_TESTS_NONETWORK is set'
+)

--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -1,6 +1,8 @@
 import gzip
 import pytest
 
+from datalad_next.tests.marker import skipif_no_network
+
 from ..any import AnyUrlOperations
 from ..http import (
     HttpUrlOperations,
@@ -59,6 +61,7 @@ def test_custom_http_headers_via_config(datalad_cfg):
     assert huo._headers['X-Funky'] == 'Stuff'
 
 
+@skipif_no_network
 def test_transparent_decompression(tmp_path):
     # this file is offered with transparent compression/decompression
     # by the github webserver
@@ -73,6 +76,7 @@ def test_transparent_decompression(tmp_path):
         '[build-system]\nrequires = ["setuptools >= 43.0.0", "wheel"]\n'
 
 
+@skipif_no_network
 def test_compressed_file_stay_compressed(tmp_path):
     # this file is offered with transparent compression/decompression
     # by the github webserver, but is also actually gzip'ed


### PR DESCRIPTION
This is primarily achieved via a custom pytest mark. However, there is a session-level fixture that itself depends on network access. Unlike with a function-level fixture, I cannot figure out how to make any dependent test be skipped. Instead, I need to use the mark as a skipping decorator.

With these changes I can successfully run the test suite on a system with no network access (not just a proxy-based diversion):

```
247 passed, 39 skipped, 19 warnings in 171.10s (0:02:51)
```

Ping #490