### PR TITLE
Type annotation check simplified and only scanning changes

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -7,7 +7,7 @@ on:
       - '!**/tests/**.py'
 
 jobs:
-  mypy:
+  static-type-check:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
@@ -17,15 +17,15 @@ jobs:
           architecture: x64
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements-devel.txt
       - name: Install mypy
-        run: pip install mypy
-      - name: Run mypy
-        uses: sasanquaneuf/mypy-github-action@releases/v1
+        run: pip install mypy  # you can pin your preferred version
+      - name: Get Python changed files
+        id: changed-py-files
+        uses: tj-actions/changed-files@v23
         with:
-          checkName: 'mypy'   # NOTE: this needs to be the same as the job name
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            *.py
+            **/*.py
+      - name: Type check changed files
+        if: steps.changed-py-files.outputs.any_changed == 'true'
+        run: mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --ignore-missing-imports


### PR DESCRIPTION
The previous setup tried everything and produces an overwhelming report that nobody would pay attention to. This new approach would selectively report on content that is near that touch be a specific PR.

Closes #501