### PR TITLE
Tune type checker workflow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install mypy
-        run: pip install mypy  # you can pin your preferred version
+        run: python -m pip install mypy  # you can pin your preferred version
       - name: Get Python changed files
         id: changed-py-files
         uses: tj-actions/changed-files@v23
@@ -28,4 +28,12 @@ jobs:
             **/*.py
       - name: Type check changed files
         if: steps.changed-py-files.outputs.any_changed == 'true'
-        run: mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --ignore-missing-imports
+        run: |
+          # get any type stubs that mypy thinks it needs
+          mypy --install-types --non-interactive
+          # run mypy on the modified files only, and do not even follow imports.
+          # this results is a fairly superficial test, but given the overall
+          # state of annotations, we strive to become more correct incrementally
+          # with focused error reports, rather than barfing a huge complaint
+          # that is unrelated to the changeset someone has been working on
+          mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --follow-imports skip --ignore-missing-imports --pretty --show-error-context


### PR DESCRIPTION
Make the report narrowly focused on the changeset of a PR. See comments inside for rational.