### PR TITLE
Support archive type detection for `.tgz` annex keys

### DIFF
--- a/changelog.d/20231026_185357_michael.hanke_archivist_tgz.md
+++ b/changelog.d/20231026_185357_michael.hanke_archivist_tgz.md
@@ -1,0 +1,6 @@
+### 💫 Enhancements and new features
+
+- The `archivist` remote now supports archive type detection
+  from `*E`-type annex keys for `.tgz` archives too.
+  Fixes https://github.com/datalad/datalad-next/issues/517 via
+  https://github.com/datalad/datalad-next/pull/518 (by @mih)

--- a/datalad_next/types/archivist.py
+++ b/datalad_next/types/archivist.py
@@ -134,6 +134,8 @@ class ArchivistLocator:
                 atype = ArchiveType.zip
             elif '.tar' in suf:
                 atype = ArchiveType.tar
+            elif '.tgz' in suf:
+                atype = ArchiveType.tar
 
         return cls(
             akey=akey,

--- a/datalad_next/types/archivist.py
+++ b/datalad_next/types/archivist.py
@@ -74,7 +74,7 @@ class ArchivistLocator:
     """
     akey: AnnexKey
     member: PurePosixPath
-    size: int
+    size: int | None = None
     # datalad-archives did not have the type info, we want to be
     # able to handle those too, make optional
     atype: ArchiveType | None = None
@@ -91,21 +91,21 @@ class ArchivistLocator:
     @classmethod
     def from_str(cls, url: str):
         """Return ``ArchivistLocator`` from ``str`` form"""
-        url_matched = _recognized_urls.match(url)
-        if not url_matched:
+        url_match = _recognized_urls.match(url)
+        if not url_match:
             raise ValueError('Unrecognized dl+archives locator syntax')
-        url_matched = url_matched.groupdict()
+        url_matched = url_match.groupdict()
         # convert to desired type
         akey = AnnexKey.from_str(url_matched['key'])
 
         # archive member properties
-        props_matched = _archive_member_props.match(url_matched['props'])
-        if not props_matched:
+        props_match = _archive_member_props.match(url_matched['props'])
+        if not props_match:
             # without at least a 'path' there is nothing we can do here
             raise ValueError(
                 'dl+archives locator contains invalid archive member '
                 f'specification: {url_matched["props"]!r}')
-        props_matched = props_matched.groupdict()
+        props_matched = props_match.groupdict()
         amember_path = PurePosixPath(props_matched['path'])
         if amember_path.is_absolute():
             raise ValueError(
@@ -116,6 +116,8 @@ class ArchivistLocator:
 
         # size is optional, regex ensure that it is an int
         size = props_matched.get('size')
+        if size is not None:
+            size = int(size)
 
         # archive type, could be None
         atype = props_matched.get('atype')

--- a/datalad_next/types/tests/test_archivist.py
+++ b/datalad_next/types/tests/test_archivist.py
@@ -24,6 +24,12 @@ def test_archivistlocator():
         'dl+archive:MD5E-s1--e9f624eb778e6f945771c543b6e9c7b2.tar#path=f.txt'
     ).atype == ArchiveType.tar
     assert ArchivistLocator.from_str(
+        'dl+archive:MD5E-s1--e9f624eb778e6f945771c543b6e9c7b2.tgz#path=f.txt'
+    ).atype == ArchiveType.tar
+    assert ArchivistLocator.from_str(
+        'dl+archive:MD5E-s1--e9f624eb778e6f945771c543b6e9c7b2.tar.gz#path=f.txt'
+    ).atype == ArchiveType.tar
+    assert ArchivistLocator.from_str(
         'dl+archive:MD5E-s1--e9f624eb778e6f945771c543b6e9c7b2.zip#path=f.txt'
     ).atype == ArchiveType.zip
 


### PR DESCRIPTION
This seems to be at least as sensible as `.tar`.

Closes #517
