### PR TITLE
POC: implement `iter_annexworktree` with one run-context manager and two batch-context managers

### DIFF
--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -59,6 +59,9 @@ from datalad_next.iter_collections.gitworktree import (
     GitWorktreeFileSystemItem,
     iter_gitworktree,
 )
+from datalad_next.iter_collections.annexworktree import (
+    iter_annexworktree,
+)
 
 
 lgr = getLogger('datalad.local.ls_file_collection')
@@ -72,6 +75,7 @@ _supported_collection_types = (
     'directory',
     'tarfile',
     'gitworktree',
+    'annexworktree',
 )
 
 
@@ -110,7 +114,7 @@ class LsFileCollectionParamValidator(EnsureCommandParameterization):
         hash = kwargs['hash']
         iter_fx = None
         iter_kwargs = None
-        if type in ('directory', 'tarfile', 'gitworktree'):
+        if type in ('directory', 'tarfile', 'gitworktree', 'annexworktree'):
             if not isinstance(collection, Path):
                 self.raise_for(
                     kwargs,
@@ -131,6 +135,9 @@ class LsFileCollectionParamValidator(EnsureCommandParameterization):
         elif type == 'gitworktree':
             iter_fx = iter_gitworktree
             item2res = gitworktreeitem_to_dict
+        elif type == 'annexworktree':
+            iter_fx = iter_annexworktree
+            item2res = annexworktreeitem_to_dict
         else:
             raise RuntimeError(
                 'unhandled collection-type: this is a defect, please report.')
@@ -202,6 +209,17 @@ def gitworktreeitem_to_dict(item, hash) -> Dict:
 
     if gittype is not None:
         d['gittype'] = gittype
+    return d
+
+
+def annexworktreeitem_to_dict(item, hash) -> Dict:
+    d = gitworktreeitem_to_dict(item, hash)
+    if item.annexkey:
+        d['annexkey'] = item.annexkey
+
+    if item.annexsize:
+        d['annexsize'] = item.annexsize
+
     return d
 
 

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -163,7 +163,7 @@ def iter_annexworktree(
 
         # Remaining git ls-files results are all unannexed, yield them.
         assert len(gaf_store) == 0
-        for path, glf_item in glf_store.items():
+        for glf_item in glf_store.values():
             yield AnnexWorktreeItem(
                 name=glf_item.name,
                 gitsha=glf_item.gitsha,

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -1,0 +1,174 @@
+"""Report on the content of a Git-annex repository worktree
+
+The main functionality is provided by the :func:`iter_annexworktree()`
+function.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from itertools import zip_longest
+from pathlib import (
+    Path,
+    PurePath,
+    PurePosixPath,
+)
+from typing import Generator
+
+from datalad.support.annexrepo import GeneratorAnnexJsonNoStderrProtocol
+from datalad_next.runners.batch import annexjson_batchcommand
+from datalad_next.runners.run import run
+
+from .gitworktree import (
+    GitWorktreeItem,
+    GitWorktreeFileSystemItem,
+    iter_gitworktree,
+)
+
+lgr = logging.getLogger('datalad.ext.next.iter_collections.annexworktree')
+
+
+# TODO Could be `StrEnum`, came with PY3.11
+class AnnexTreeItemType(Enum):
+    """Enumeration of item types of Git trees
+    """
+    file = 'file'
+    executablefile = 'executablefile'
+    symlink = 'symlink'
+    directory = 'directory'
+    submodule = 'submodule'
+
+
+@dataclass
+class AnnexWorktreeItem(GitWorktreeItem):
+    annexkey: str | None = None
+    annexsize: int | None = None
+    annexobjpath: PurePath | None = None
+
+
+@dataclass
+class AnnexWorktreeFileSystemItem(GitWorktreeFileSystemItem):
+    annexkey: str | None = None
+    annexsize: int | None = None
+
+
+def iter_annexworktree(
+    path: Path,
+    *,
+    untracked: str | None = 'all',
+    link_target: bool = False,
+    fp: bool = False,
+) -> Generator[AnnexWorktreeItem | AnnexWorktreeFileSystemItem, None, None]:
+    """ Iterate over the git annex worktree of a Git repository
+
+    This iterator uses ``git ls-files``, ``git annex lookupkey``, and
+    ``git annex examinekey`` to report on a git annex work tree of a Git repo.
+
+    .. note::
+      This is a POC implementation to demonstrate the concurrent use of
+      run-context-managers and two batch-context-managers. Most parameters are
+      ignored, the protocol that is used does not take care of pending results.
+
+    Parameters
+    ----------
+    path: Path
+      Path of a directory in a Git repository to report on. This directory
+      need not be the root directory of the repository, but must be part of
+      the repository's work tree.
+    untracked: {'all', 'whole-dir', 'no-empty'} or None, optional
+      If not ``None``, also reports on untracked work tree content.
+      ``all`` reports on any untracked file; ``whole-dir`` yields a single
+      report for a directory that is entirely untracked, and not individual
+      untracked files in it; ``no-empty-dir`` skips any reports on
+      untracked empty directories. Any untracked content is yielded as
+      a ``PurePosixPath``.
+    link_target: bool, optional
+      This flag behaves analog to that of ``iter_gitworktree()``. In addition,
+      enabling link target reporting will provide the location
+      of an annex object (annexed file content) via the
+      ``AnnexWorktreeItem.annexobjpath`` property. Annex object path reporting
+      is supported whether or not a particular key is locally present.
+    fp: bool, optional
+      If ``True``, each file-type item includes a file-like object
+      to access the file's content. This file handle will be closed
+      automatically when the next item is yielded.
+
+    Yields
+    ------
+    :class:`AnnexWorktreeItem` or `AnnexWorktreeFileSystemItem`
+    """
+
+    # we use git-annex-examinekey for annex object location reporting.
+    # we cannot use git-annex-contentlocation, because it only reports on
+    # present annex objects, and here we also need to report on would-be
+    # locations
+    git_annex_find_cmd = [
+        'git', 'annex', 'find', '--include=*',
+        '--json', '--json-error-messages', '.'
+    ]
+    common_args = dict(cwd=path, terminate_time=3, kill_time=1)
+
+    # We iterate over two generators, i.e. `git_ls_files` and `git_annex_find`,
+    # at the same time, and associate entries that describe the same dataset
+    # item by their "path"-property. Since we don't know the order in which
+    # entries are yielded by the iterators, we have to save output from both
+    # iterators until we get matching entries, i.e. entries with identical
+    # "path"-property (the "path"-property is `item.name` if `item` is a result
+    # of `git_ls_files`, and `item['file']`, if item is a result of
+    # `git_annex_find`).
+    gaf_store = dict()
+    glf_store = dict()
+
+    with \
+            run(git_annex_find_cmd, protocol_class=GeneratorAnnexJsonNoStderrProtocol, **common_args) as git_annex_find, \
+            annexjson_batchcommand(['git', 'annex', 'examinekey', '--json', '--batch'], **common_args) as examine_key:
+
+        git_ls_files = iter_gitworktree(path=path, untracked=untracked)
+
+        # "zip" the two iterators into 2-tuples, "shorter" iterators contribute
+        # a `None`, when they are exhausted. We assume that the set of annexed
+        # files is a subset of the files in git, i.e. the `git_annex_find`
+        # generator yields less or equal results then the `git_ls_files`
+        # generator.
+        for gaf_item, glf_item in zip_longest(git_annex_find, git_ls_files):
+            # Store both results (if they exist)
+            if gaf_item:
+                gaf_store[PurePath(PurePosixPath(gaf_item['file']))] = gaf_item
+            glf_store[glf_item.name] = glf_item
+
+            # Check the "path"-properties of all `git_ls_files`-items and
+            # check for a matching path in `git_annex_find`-items. If a
+            # matching pair exists, yield a result for an annexed file and
+            # mark the pair for deletion.
+            remove = []
+            for path, glf_item in glf_store.items():
+                gaf_item = gaf_store.get(path)
+                if gaf_item:
+                    remove.append(path)
+                    key_properties = examine_key(gaf_item['key'].encode() + b'\n')
+                    yield AnnexWorktreeItem(
+                        name=glf_item.name,
+                        gitsha=glf_item.gitsha,
+                        gittype=glf_item.gittype,
+                        annexkey=gaf_item['key'],
+                        annexsize=int(gaf_item['bytesize']),
+                        annexobjpath=PurePath(key_properties['objectpath']),
+                    )
+
+            # Delete marked pairs from both item-stores.
+            for path in remove:
+                del glf_store[path]
+                del gaf_store[path]
+
+        # Remaining git ls-files results are all unannexed, yield them.
+        assert len(gaf_store) == 0
+        for path, glf_item in glf_store.items():
+            yield AnnexWorktreeItem(
+                name=glf_item.name,
+                gitsha=glf_item.gitsha,
+                gittype=glf_item.gittype,
+                annexkey=None,
+                annexsize=None,
+                annexobjpath=None
+            )

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -1,0 +1,84 @@
+from pathlib import (
+    PurePath,
+)
+
+from datalad import cfg as dlcfg
+
+from datalad_next.datasets import Dataset
+
+from ..annexworktree import (
+    iter_annexworktree,
+)
+
+
+def _mkds(tmp_path_factory, monkeypatch, cfg_overrides):
+    with monkeypatch.context() as m:
+        for k, v in cfg_overrides.items():
+            m.setitem(dlcfg.overrides, k, v)
+        dlcfg.reload()
+        ds = Dataset(tmp_path_factory.mktemp('ds')).create(
+            result_renderer='disabled')
+    dlcfg.reload()
+    return ds
+
+
+def _dotests(ds):
+    test_file_content = 'test_file'
+    test_file = ds.pathobj / 'annexed' / 'subdir' / 'file1.txt'
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(test_file_content)
+    # we create an additional file where the content will be dropped
+    # to test behavior on unavailable annex key
+    droptest_content = 'somethingdropped'
+    droptest_file = ds.pathobj / 'annexed' / 'dropped.txt'
+    droptest_file.write_text(droptest_content)
+    ds.save(result_renderer='disabled')
+    ds.drop(droptest_file, reckless='availability',
+            result_renderer='disabled')
+
+    # get results for the annexed files
+    query_path = ds.pathobj / 'annexed'
+    res = list(iter_annexworktree(
+        query_path, untracked=None, link_target=True,
+    ))
+    assert len(res) == 2
+    #
+    # pick the present annex file to start
+    r = [r for r in res if r.name.name == 'file1.txt'][0]
+    assert r.name == PurePath('subdir', 'file1.txt')
+    # we cannot check gitsha and symlink content for identity, it will change
+    # depending on the tuning
+    # we cannot check the item type, because it will vary across repository
+    # modes (e.g., adjusted unlocked)
+    assert r.annexsize == len(test_file_content)
+    assert r.annexkey == 'MD5E-s9--37b87ee8c563af911dcc0f949826b1c9.txt'
+    # with `link_target=True` we get an objpath that is relative to the
+    # query path, and we find the actual key file there
+    assert (query_path / r.annexobjpath).read_text() == test_file_content
+    #
+    # now pick the dropped annex file
+    r = [r for r in res if r.name.name == 'dropped.txt'][0]
+    assert r.name == PurePath('dropped.txt')
+    # we get basic info regardless of availability
+    assert r.annexsize == len(droptest_content)
+    assert r.annexkey == 'MD5E-s16--770a06889bc88f8743d1ed9a1977ff7b.txt'
+    # even with an absent key file, we get its would-be location,
+    # and it is relative to the query path
+    assert r.annexobjpath.parts[:2] == ('..', '.git')
+
+
+def test_iter_annexworktree(tmp_path_factory, monkeypatch):
+    ds = _mkds(tmp_path_factory, monkeypatch, {})
+    _dotests(ds)
+
+
+def test_iter_annexworktree_tuned(tmp_path_factory, monkeypatch):
+    # same as test_file_content(), but with a "tuned" annexed that
+    # no longer matches the traditional setup.
+    # we need to be able to cope with that too
+    ds = _mkds(tmp_path_factory, monkeypatch, {
+        'annex.tune.objecthash1': 'true',
+        'annex.tune.branchhash1': 'true',
+        'annex.tune.objecthashlower': 'true',
+    })
+    _dotests(ds)

--- a/datalad_next/runners/__init__.py
+++ b/datalad_next/runners/__init__.py
@@ -50,7 +50,7 @@ also the documentation of
    :toctree: generated
 
    run
-
+   batch
 
 A standard exception type is used to communicate any process termination
 with a non-zero exit code (unless the keyword argument ``exception_on_error`` is
@@ -83,7 +83,7 @@ protocols:
 
    NoCaptureGeneratorProtocol
    StdOutCaptureGeneratorProtocol
-
+   StdOutLineCaptureGeneratorProtocol
 
 Low-level tooling
 -----------------
@@ -105,6 +105,7 @@ from datalad.runner.protocol import GeneratorMixIn
 from .protocols import (
     NoCaptureGeneratorProtocol,
     StdOutCaptureGeneratorProtocol,
+    StdOutLineCaptureGeneratorProtocol,
 )
 # exceptions
 from datalad.runner.exception import (

--- a/datalad_next/runners/batch.py
+++ b/datalad_next/runners/batch.py
@@ -1,0 +1,276 @@
+"""Helpers to execute batch commands
+
+Some of the functionality provided by this module depends on specific
+"generator" flavors of runner protocols, and additional dedicated
+low-level tooling:
+
+.. currentmodule:: datalad_next.runners.batch
+.. autosummary::
+   :toctree: generated
+
+    StdOutCaptureGeneratorProtocol
+    StdOutLineCaptureGeneratorProtocol
+    GeneratorAnnexJsonProtocol
+    _ResultGenerator
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from queue import Queue
+from typing import (
+    Any,
+    Generator,
+)
+
+from datalad.runner.nonasyncrunner import _ResultGenerator
+from datalad.support.annexrepo import GeneratorAnnexJsonProtocol
+
+from . import Protocol
+from .protocols import (
+    StdOutCaptureGeneratorProtocol,
+    StdOutLineCaptureGeneratorProtocol,
+)
+from .run import run
+
+
+class BatchProcess:
+    """Representation of a (running) batch process
+
+    An instance of this class is produced by any of the context manager variants
+    in this module. It is a convenience wrapper around an instance of a
+    :class:`_ResultGenerator` that is produced by a :meth:`ThreadedRunner.run`.
+
+    A batch process instanced is used by passing ``bytes`` input to its
+    ``__call__()`` method, and receiving the batch output as return value.
+
+    While the process is still running, it ``return_code`` property will
+    be ``None``. After the has terminated, the property will contain the
+    respective exit status.
+    """
+    def __init__(self, rgen: _ResultGenerator):
+        self._rgen = rgen
+        self._stdin_queue = rgen.runner.stdin_queue
+
+    def __call__(self, data: bytes | None) -> Any:
+        self._stdin_queue.put(data)
+        try:
+            return next(self._rgen)
+        except StopIteration:
+            return None
+
+    def close_stdin(self) -> Any:
+        return self(None)
+
+    @property
+    def return_code(self) -> None | int:
+        return self._rgen.return_code
+
+
+@contextmanager
+def batchcommand(
+        cmd: list,
+        protocol_class: type[Protocol],
+        cwd: Path | None = None,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        protocol_kwargs: dict | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """Generic context manager for batch processes
+
+    ``cmd`` is an ``argv``-list specification of a command. It is executed via
+    a :class:`~datalad_next.runners.run.run` context manager. This context
+    manager is parameterized with ``protocol_class`` (which can take any
+    implementation of a DataLad runner protocol), and optional keyword arguments
+    that are passed to the protocol class.
+
+    On leaving the context, the manager will perform a "closing_action". By
+    default, this is to close ``stdin`` of the underlying process. This will
+    typically cause the underlying process to exit. A caller can specify an
+    alternative function, i.e. ``closing_action``. If ``closing_action`` is set,
+    the function will be called with two arguments. The first argument is the
+    :class:`BatchProcess`-instance, the second argument is the stdin-queue of
+    the subprocess.
+    A custom ``closing_action`` might, for example, send some kind of exit
+    command to the subprocess, and then close stdin. This method exists because
+    the control flow might enter the exit-handler through different mechanisms.
+    One mechanism would be an un-caught exception.
+
+    If ``terminate_time`` is given, the context handler will send a
+    terminate-signal to the process, if it is still running ``terminate_time``
+    seconds after the context is left. If ``kill_time`` is given, the context
+    handler will send a kill-signal to the process, if it is still running
+    ``(terminate_time or 0) + kill_time`` seconds after the context is left.
+
+    If neither ``terminate_time`` nor ``kill_time`` are set and the process
+    is not triggered to exit, e.g. because its stdin is not closed or because
+    it requires different actions to trigger its exit, batchcommand will wait
+    forever after the context exited. Note that the context might also be
+    exited in an unexpected way by an ``Èxception``.
+
+    While this generic context manager can be used directly, it can be
+    more convenient to use any of the more specialized implementations
+    that employ a specific protocol (e.g., :func:`stdout_batchcommand`,
+    :func:`stdoutline_batchcommand`, or :func:`annexjson_batchcommand`).
+
+    Parameters
+    ----------
+    cmd : list[str]
+        A list containing the command and its arguments (argv-like).
+    cwd : Path | None
+        If not ``None``, determines a new working directory for the command.
+    terminate_time: int | None
+        The number of timeouts after which a terminate-signal will be sent to
+        the process, if it is still running. If no timeouts were provided in the
+        ``timeout``-argument, the timeout is set to ``1.0``.
+    kill_time: int | None
+        See documentation of :func:`datalad_next.runners.run.run`.
+    protocol_kwargs: dict
+        If ``terminate_time`` is given, a kill-signal will be sent to the
+        subprocess after kill-signal after ``terminate_time + kill_time``
+        timeouts. If ``terminate_time`` is not set, a kill-signal will be sent
+        after ``kill_time`` timeouts.
+        It is a good idea to set ``kill_time`` and ``terminate_time`` in order
+        to let the process exit gracefully, if it is capable to do so.
+    kwargs : dict
+        All other keyword arguments are forwarded to the
+        ``datalad_next.runners.run.run``-context manager, that is used to
+        execute the batch command.
+
+    Yields
+    -------
+    BatchProcess
+        A :class:`BatchProcess`-instance that can be used to interact with the
+        cmd
+
+    """
+    input_queue = Queue()
+    try:
+        with run(
+            cmd=cmd,
+            protocol_class=protocol_class,
+            stdin=input_queue,
+            cwd=cwd,
+            terminate_time=terminate_time,
+            kill_time=kill_time,
+            protocol_kwargs=protocol_kwargs,
+            **kwargs,
+        ) as result_generator:
+            batch_process = BatchProcess(result_generator)
+            try:
+                yield batch_process
+            finally:
+                batch_process.close_stdin()
+    finally:
+        del input_queue
+
+
+def stdout_batchcommand(
+        cmd: list,
+        cwd: Path | None = None,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """Context manager for commands that produce arbitrary output on ``stdout``
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`StdOutCaptureGeneratorProtocol` protocol implementation.  See the
+    documentation of :func:`batchcommand` for a description of the parameters.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=StdOutCaptureGeneratorProtocol,
+        cwd=cwd,
+        terminate_time=terminate_time,
+        kill_time=kill_time,
+        **kwargs,
+    )
+
+
+def stdoutline_batchcommand(
+        cmd: list,
+        cwd: Path | None = None,
+        separator: str | None = None,
+        keep_ends: bool = False,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        protocol_kwargs: dict | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """Context manager for batch commands that respond with a single line.
+
+    The context manager returns a ``BatchProcess``-instance in the
+    ``as``-Variable. It uses :class:`StdOutLineCaptureGeneratorProtocol` to
+    process data from the subprocess. This protocol will yield individual lines,
+    of decoded data.
+
+    The context manager can be used, for example, to interact with
+    git-annex commands that support ``--batch`` and return a single line in
+    response to an input.
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`StdOutLineCaptureGeneratorProtocol` protocol implementation. See the
+
+    Parameters
+    ----------
+    separator : str | None (default ``None``)
+        If ``None``, lines are separated by the built-in separators of python.
+        If not ``None``, lines are separated by the given character.
+        The``separator`` keyword argument will override a ``separator`` keyword
+        argument provided in the ``protocol_kwargs``.
+
+    keep_ends: bool (default: ``False``)
+        If ``False``, the returned lines will not contain the terminating
+        character. If ``True``, the returned lines will contain the terminating
+        character.
+        The``keep_ends`` keyword argument will override a ``keep_ends`` keyword
+        argument provided in the ``protocol_kwargs``.
+
+    See the documentation of :func:`batchcommand` for a description of the
+    remaining parameters.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=StdOutLineCaptureGeneratorProtocol,
+        cwd=cwd,
+        terminate_time=terminate_time,
+        kill_time=kill_time,
+        protocol_kwargs=dict(
+            **(protocol_kwargs or {}),
+            separator=separator,
+            keep_ends=keep_ends,
+        ),
+        **kwargs,
+    )
+
+
+def annexjson_batchcommand(
+        cmd: list,
+        cwd: Path | None = None,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        protocol_kwargs: dict | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """
+    Context manager for git-annex commands that support ``--batch --json``
+
+    The given ``cmd``-list must be complete, i.e., include
+    ``git annex ... --batch --json``, and any additional flags that may be
+    needed.
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`GeneratorAnnexJsonProtocol` protocol implementation. See the
+    documentation of :func:`batchcommand` for a description of the parameters.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=GeneratorAnnexJsonProtocol,
+        cwd=cwd,
+        terminate_time=terminate_time,
+        kill_time=kill_time,
+        protocol_kwargs=protocol_kwargs,
+        **kwargs,
+    )

--- a/datalad_next/runners/batch.py
+++ b/datalad_next/runners/batch.py
@@ -8,10 +8,9 @@ low-level tooling:
 .. autosummary::
    :toctree: generated
 
-    StdOutCaptureGeneratorProtocol
-    StdOutLineCaptureGeneratorProtocol
     GeneratorAnnexJsonProtocol
     _ResultGenerator
+
 """
 from __future__ import annotations
 
@@ -120,13 +119,13 @@ def batchcommand(
         A list containing the command and its arguments (argv-like).
     cwd : Path | None
         If not ``None``, determines a new working directory for the command.
-    terminate_time: int | None
+    terminate_time : int | None
         The number of timeouts after which a terminate-signal will be sent to
         the process, if it is still running. If no timeouts were provided in the
         ``timeout``-argument, the timeout is set to ``1.0``.
-    kill_time: int | None
+    kill_time : int | None
         See documentation of :func:`datalad_next.runners.run.run`.
-    protocol_kwargs: dict
+    protocol_kwargs : dict
         If ``terminate_time`` is given, a kill-signal will be sent to the
         subprocess after kill-signal after ``terminate_time + kill_time``
         timeouts. If ``terminate_time`` is not set, a kill-signal will be sent
@@ -211,25 +210,23 @@ def stdoutline_batchcommand(
     response to an input.
 
     Internally this calls :func:`batchcommand` with the
-    :class:`StdOutLineCaptureGeneratorProtocol` protocol implementation. See the
+    :class:`StdOutLineCaptureGeneratorProtocol` protocol implementation. See
+    the documentation of :func:`batchcommand` for a description of the
+    remaining parameters.
 
     Parameters
     ----------
     separator : str | None (default ``None``)
         If ``None``, lines are separated by the built-in separators of python.
         If not ``None``, lines are separated by the given character.
-        The``separator`` keyword argument will override a ``separator`` keyword
+        The ``separator`` keyword argument will override a ``separator`` keyword
         argument provided in the ``protocol_kwargs``.
-
-    keep_ends: bool (default: ``False``)
+    keep_ends : bool (default ``False``)
         If ``False``, the returned lines will not contain the terminating
         character. If ``True``, the returned lines will contain the terminating
-        character.
-        The``keep_ends`` keyword argument will override a ``keep_ends`` keyword
-        argument provided in the ``protocol_kwargs``.
+        character. The ``keep_ends`` keyword argument will override a
+        ``keep_ends`` keyword argument provided in the ``protocol_kwargs``.
 
-    See the documentation of :func:`batchcommand` for a description of the
-    remaining parameters.
     """
     return batchcommand(
         cmd,

--- a/datalad_next/runners/protocols.py
+++ b/datalad_next/runners/protocols.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from . import (
     GeneratorMixIn,
     NoCapture,
@@ -26,6 +28,44 @@ class StdOutCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
     def pipe_data_received(self, fd: int, data: bytes):
         assert fd == 1
         self.send_result(data)
+
+    def timeout(self, fd):
+        raise TimeoutError(f"Runner timeout {fd}")
+
+
+class StdOutLineCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
+    def __init__(self,
+                 done_future=None,
+                 encoding=None,
+                 separator: Optional[str] = None,
+                 keep_ends: bool = False
+                 ):
+        from . import LineSplitter
+
+        StdOutCapture.__init__(self, done_future, encoding)
+        GeneratorMixIn.__init__(self)
+        self.encoding = encoding or 'utf-8'
+        self.line_splitter = LineSplitter(separator, keep_ends)
+
+    def pipe_data_received(self, fd: int, data: bytes):
+        assert fd == 1
+        # This naive decode call might fail, if encodings are crossing data
+        # chunk borders. Because this protocol is part of a POC of the
+        # run-context-manager and the batch-context-manager, we leave it for
+        # now. The proper way to do that is IMHO to use the
+        # `StdOutCaptureProcessingGeneratorProtocol` from PR
+        # https://github.com/datalad/datalad-next/pull/484
+        # and the processing pipeline:
+        # `[decode_processor('utf-8'), splitlines_processor()]`
+        #
+        for line in self.line_splitter.process(data.decode()):
+            self.send_result(line)
+
+    def pipe_connection_lost(self, fd: int, exc: Optional[BaseException]) -> None:
+        if fd == 1:
+            remaining_string = self.line_splitter.finish_processing()
+            if remaining_string:
+                self.send_result(remaining_string)
 
     def timeout(self, fd):
         raise TimeoutError(f"Runner timeout {fd}")

--- a/datalad_next/runners/tests/test_batch.py
+++ b/datalad_next/runners/tests/test_batch.py
@@ -1,0 +1,244 @@
+import os
+import signal
+import sys
+
+import pytest
+
+from .. import (
+    GeneratorMixIn,
+    StdOutErrCapture,
+    StdOutCaptureGeneratorProtocol,
+)
+from ..batch import (
+    annexjson_batchcommand,
+    batchcommand,
+    stdout_batchcommand,
+    stdoutline_batchcommand,
+)
+
+
+# A batch program that takes exponentially longer to respond. This is used to
+# check for killing while waiting for `BatchProcess.__call__` to return.
+degrading_batch_prog = '''
+import sys
+import time
+
+i = 0
+while True:
+    sys.stdin.readline()
+    time.sleep(i**2 / 10)
+    print(i, flush=True)
+    i += 1
+'''
+
+
+line_echo_batch_prog = '''
+import sys
+import time
+
+end = '{end}'
+while True:
+    data = sys.stdin.readline()
+    if data == '':
+        break
+    print('read: ' + data.strip(), end=end, flush=True)
+print('closed', end=end, flush=True)
+'''
+
+
+class PythonProtocol(StdOutErrCapture, GeneratorMixIn):
+    """Parses interactive python output and enqueues complete output strings
+
+    This is an example for a protocol that processes results of an a priori
+    unknown structure and length.
+    Instances of this class interpret the stdout- and stderr-output of a
+    python interpreter. They assemble decoded stdout content until the python
+    interpreter sends ``'>>> '`` on stderr. Then the assembled output is
+    returned as result.
+
+    This requires to start the python interpreter in unbuffered mode! If not,
+    the ``stderr``-output can be processed too early, i.e. before all
+    ``stdout``-output is processed. This is due to the fact that the runner is
+    thread-based. The runner does not necessarily preserve the wall-clock-order
+    of events that arrive from different streams.
+    """
+    def __init__(self):
+        StdOutErrCapture.__init__(self)
+        GeneratorMixIn.__init__(self)
+        self.stdout = ''
+        self.stderr = b''
+        self.prompt_count = -1
+
+    def pipe_data_received(self, fd: int, data: bytes) -> None:
+        if fd == 1:
+            # We known that no multibyte encoded strings are used in the
+            # examples. Therefore, we don't have to care about encodings that
+            # are split between consecutive data chunks, and we can always
+            # successfully decode `data`.
+            self.stdout += data.decode()
+        elif fd == 2:
+            self.stderr += data
+            if len(self.stderr) >= 4 and b'>>> ' in self.stderr:
+                self.prompt_count += 1
+                self.stderr = b''
+        if self.stdout and self.prompt_count > 0:
+            self.send_result(self.stdout)
+            self.stdout = ''
+            self.prompt_count -= 1
+
+
+def test_batch_simple(existing_dataset):
+    # first with a simplistic protocol to test the basic mechanics
+    with stdout_batchcommand(
+            ['git', 'annex', 'examinekey',
+             # the \n in the format is needed to produce an output that hits
+             # the output queue after each input line
+             '--format', '${bytesize}\n',
+             '--batch'],
+            cwd=existing_dataset.pathobj,
+    ) as bp:
+        res = bp(b'MD5E-s21032--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res.rstrip(b'\r\n') == b'21032'
+        # to subprocess is still running
+        assert bp.return_code is None
+        # another batch
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res.rstrip(b'\r\n') == b'999'
+        assert bp.return_code is None
+        # we can bring the process down with stupid input, because it is
+        # inside our context handlers, it will not raise CommandError. check exit instead
+        res = bp(b'stupid\n')
+        # process exit is detectable
+        assert res is None
+        assert bp.return_code == 1
+        # continued use raises the same exception
+        # (but stacktrace is obvs different)
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res is None
+        assert bp.return_code == 1
+
+    # now with a more complex protocol (decodes JSON-lines output)
+    with annexjson_batchcommand(
+            ['git', 'annex', 'examinekey', '--json', '--batch'],
+            cwd=existing_dataset.pathobj,
+    ) as bp:
+        # output is a decoded JSON object
+        res = bp(b'MD5E-s21032--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res['backend'] == "MD5E"
+        assert res['bytesize'] == "21032"
+        assert res['key'] == "MD5E-s21032--2f4e22eb05d58c21663794876dc701aa"
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res['bytesize'] == "999"
+        res = bp(b'stupid\n')
+        assert res is None
+        assert bp.return_code == 1
+
+
+def test_batch_killing():
+    # to test killing we have to circumvent the automatic stdin-closing by
+    # BatchCommand. We do that by setting `closing_action` to an empty function.
+    with stdout_batchcommand(
+            [sys.executable, '-c',
+             'import time\nwhile True:\n    time.sleep(1)\n'],
+            terminate_time=2,
+            kill_time=2,
+    ) as bp:
+        pass
+
+    # at this point the process should have been terminated after about 3
+    # seconds, because git-annex behaves well and terminates when it receives
+    # a terminate signal
+    assert bp.return_code not in (0, None)
+    if os.name == 'posix':
+        assert bp.return_code == -signal.SIGTERM
+
+
+def test_annexjsonbatch_killing(existing_dataset):
+    # to test killing we have to circumvent the automatic stdin-closing by
+    # BatchCommand. We do that by setting `closing_action` to an empty function.
+    with annexjson_batchcommand(
+            [sys.executable, '-c',
+             'import time\nwhile True:\n    time.sleep(1)\n'],
+            cwd=existing_dataset.pathobj,
+            terminate_time=2,
+            kill_time=2,
+    ) as bp:
+        pass
+
+    # at this point the process should have been terminated after about 2
+    # seconds, because git-annex behaves well and terminates when it receives
+    # a terminate signal
+    assert bp.return_code not in (0, None)
+    if os.name == 'posix':
+        assert bp.return_code == -signal.SIGTERM
+
+
+def test_plain_batch_python_multiline():
+    # Test with a protocol that receives complex responses to a batch command.
+    # Here a set of output lines from a python-program.
+    prog = '''
+import time
+def x(count):
+    for i in range(count):
+        print(i, flush=True)
+    time.sleep(.2)
+'''
+    # We set a terminate and kill time here, because otherwise an exception
+    # that is raised in the `batchcommand`-context will get the test to hang.
+    # The reason is that the exception triggers an exit from the context,
+    # but the python process will never stop since we did neither close its
+    # stdin nor did we call the `exit()`-function.
+    with batchcommand([sys.executable, '-i', '-u', '-c', prog],
+                      protocol_class=PythonProtocol,
+                      terminate_time=3,
+                      kill_time=2,
+                      ) as python_interactive:
+
+        # Multiline output should be handled by the protocol,
+        for count in (5, 20):
+            response = python_interactive(f'x({count})\n'.encode())
+            assert len(response.splitlines()) == count
+        python_interactive.close_stdin()
+    assert python_interactive.return_code == 0
+
+    # Test with unclosed stdin, the exit-handler should close it.
+    with batchcommand([sys.executable, '-i', '-u', '-c', prog],
+                      protocol_class=PythonProtocol,
+                      terminate_time=3,
+                      kill_time=2,
+                      ) as python_interactive:
+        for count in (5, 20):
+            response = python_interactive(f'x({count})\n'.encode())
+            assert len(response.splitlines()) == count
+        # Do not close stdin here, we let BatchCommand do that.
+    assert python_interactive.return_code == 0
+
+
+def test_kill_lagging_batch():
+    # Check that a long next() on a result generator terminates the iteration
+    with batchcommand(cmd=[sys.executable, '-u', '-c', degrading_batch_prog],
+                      protocol_class=StdOutCaptureGeneratorProtocol,
+                      terminate_time=3,
+                      kill_time=2) as batch_process:
+        for i in range(10):
+            batch_process(i)
+    return_code = batch_process.return_code
+    if os.name == 'posix':
+        assert return_code == -signal.SIGTERM
+
+
+@pytest.mark.parametrize('separator,end', [(None, '\\n'), ('x', 'x')])
+def test_line_batch(separator, end):
+    # Check proper handling of separators in `stdoutline_batchcommand`.
+    prog = line_echo_batch_prog.format(end=end)
+    with stdoutline_batchcommand(
+            cmd=[sys.executable, '-u', '-c', prog],
+            separator=separator,
+    ) as batch_process:
+        r = batch_process('abc\n'.encode())
+        assert r == 'read: abc'
+        r = batch_process('def\n'.encode())
+        assert r == 'read: def'
+        r = batch_process.close_stdin()
+        assert r == 'closed'
+    assert batch_process.return_code == 0


### PR DESCRIPTION
This PR is not meant for merging. It is a POC to demonstrate how `iter_annexworktree` can be implemented with run-context-managers and batch-context-managers in the following fashion:

```python
with \
        run(['git', 'ls-files', ...], ...) as git_ls_files, \
        annexjson_batchcommand(['git', 'annex', 'examinekey', ...], ...) as examine_key, \
        annexline_batchcommand(['git', 'annex', 'lookupkey', ...], ...) as lookup_key:
    for item in git_ls_files:
        annex_key = lookup_key(item.name + '\n')
        if annex_key:
            key_properties = examine_key(annex_key)
            yield AnnexWorkTreeItem(item, key_properties)
        else:
            yield AnnexWorkTreeItem(item, None)
```

It also introduces a wrapper around the result iterators that will trigger a termination if an iteration step is longer then a given timeout.

Note: the provided git-ls-files implementation is not as complete as the "original", since this is a POC. It might not work on some corner cases. So for large scale performance comparisons at little more work is most likely to be done.