### PR TITLE
Throw away INFO log messages in test runs

### DIFF
--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -32,6 +32,8 @@ from datalad_next.tests.fixtures import (
     httpbin,
     # session-scope HTTPBIN instance startup and URLs
     httpbin_service,
+    # session-scope redirection of log messages
+    reduce_logging,
     # session-scope, standard webdav credential (full dict)
     webdav_credential,
     # function-scope, serve a local temp-path via WebDAV


### PR DESCRIPTION
This is an attempt to denoise the test output.

~~There seems to be something special about git-fetch/push logging from datalad-core, but overall this is much better.~~

It removes about 1k lines from the CI run output, about ~25%.

Ping #503