### PR TITLE
Do not compare literal with `is`

### DIFF
--- a/datalad_next/constraints/tests/test_compound.py
+++ b/datalad_next/constraints/tests/test_compound.py
@@ -248,7 +248,7 @@ def test_WithDescription(dataset):
         error_message_for_ds='dserror',
     )
     # function is maintained
-    assert c('5') is 5
+    assert c('5') == 5
     assert str(c) == '<EnsureInt with custom description>'
     assert repr(c) == \
         "WithDescription(EnsureInt(), " \


### PR DESCRIPTION
```
SyntaxWarning: "is" with a literal. Did you mean "=="?
```

Closes #526