### PR TITLE
New test fixture to disable DataLad command renderer

### DIFF
--- a/datalad_next/commands/tests/test_credentials.py
+++ b/datalad_next/commands/tests/test_credentials.py
@@ -72,8 +72,8 @@ def test_normalize_specs():
         assert_raises(ValueError, normalize_specs, error)
 
 
-def test_errorhandling_smoketest():
-    callcfg = dict(on_failure='ignore', result_renderer='disabled')
+def test_errorhandling_smoketest(no_result_rendering):
+    callcfg = dict(on_failure='ignore')
 
     with patch('datalad_next.commands.credentials.CredentialManager',
                BrokenCredentialManager):
@@ -136,7 +136,8 @@ def test_credentials_cli(tmp_keyring):
     run_main(['credentials', 'query'], exit_code=0)
 
 
-def test_interactive_entry_get(tmp_keyring, datalad_interactive_ui):
+def test_interactive_entry_get(tmp_keyring, datalad_interactive_ui,
+                               no_result_rendering):
     ui = datalad_interactive_ui
     ui.staged_responses.extend([
         'attr1', 'attr2', 'secret'])
@@ -147,8 +148,7 @@ def test_interactive_entry_get(tmp_keyring, datalad_interactive_ui):
              name='myinteractive_get',
              # use CLI notation
              spec=[':attr1', ':attr2'],
-             prompt='dummyquestion',
-             result_renderer='disabled'),
+             prompt='dummyquestion'),
         cred_attr1='attr1',
         cred_attr2='attr2',
         cred_secret='secret',
@@ -156,7 +156,8 @@ def test_interactive_entry_get(tmp_keyring, datalad_interactive_ui):
     assert ui.operation_sequence == ['question', 'response'] * 3
 
 
-def test_interactive_entry_set(tmp_keyring, datalad_interactive_ui):
+def test_interactive_entry_set(tmp_keyring, datalad_interactive_ui,
+                               no_result_rendering):
     ui = datalad_interactive_ui
     ui.staged_responses.append('secretish')
     # should ask all properties in order and the secret last
@@ -164,8 +165,7 @@ def test_interactive_entry_set(tmp_keyring, datalad_interactive_ui):
     assert_in_results(
         cred('set',
              name='myinteractive_set',
-             prompt='dummyquestion',
-             result_renderer='disabled'),
+             prompt='dummyquestion'),
         cred_secret='secretish',
     )
     assert ui.operation_sequence == ['question', 'response']

--- a/datalad_next/commands/tests/test_ls_file_collection.py
+++ b/datalad_next/commands/tests/test_ls_file_collection.py
@@ -32,14 +32,12 @@ def test_ls_file_collection_insufficient_args():
 
 
 @skipif_no_network
-def test_ls_file_collection_tarfile(sample_tar_xz):
-    kwa = dict(result_renderer='disabled')
+def test_ls_file_collection_tarfile(sample_tar_xz, no_result_rendering):
     # smoke test first
     res = ls_file_collection(
         'tarfile',
         sample_tar_xz,
         hash='md5',
-        **kwa
     )
     assert len(res) == 6
     # test a few basic properties that should be true for any result
@@ -58,23 +56,21 @@ def test_ls_file_collection_tarfile(sample_tar_xz):
         assert r['type'] in ('file', 'directory', 'symlink', 'hardlink')
 
 
-def test_ls_file_collection_directory(tmp_path):
-    kwa = dict(result_renderer='disabled')
+def test_ls_file_collection_directory(tmp_path, no_result_rendering):
     # smoke test on an empty dir
-    res = ls_file_collection('directory', tmp_path, **kwa)
+    res = ls_file_collection('directory', tmp_path)
     assert len(res) == 0
 
 
-def test_ls_file_collection_gitworktree(existing_dataset):
-    kwa = dict(result_renderer='disabled')
+def test_ls_file_collection_gitworktree(existing_dataset, no_result_rendering):
     # smoke test on a plain dataset
-    res = ls_file_collection('gitworktree', existing_dataset.pathobj, **kwa)
+    res = ls_file_collection('gitworktree', existing_dataset.pathobj)
     assert len(res) > 1
     assert all('gitsha' in r for r in res)
 
     # and with hashing
     res_hash = ls_file_collection('gitworktree', existing_dataset.pathobj,
-                                  hash='md5', **kwa)
+                                  hash='md5')
     assert len(res) == len(res_hash)
     assert all('hash-md5' in r for r in res_hash)
 
@@ -87,16 +83,15 @@ def test_ls_file_collection_validator():
 
 
 @skipif_no_network
-def test_replace_add_archive_content(sample_tar_xz, existing_dataset):
-    kwa = dict(result_renderer='disabled')
-
+def test_replace_add_archive_content(sample_tar_xz, existing_dataset,
+                                     no_result_rendering):
     ds = existing_dataset
     archive_path = ds.pathobj / '.datalad' / 'myarchive.tar.xz'
     # get archive copy in dataset (not strictly needed, but
     # add-archive-content worked like this
-    ds.download({sample_tar_xz.as_uri(): archive_path}, **kwa)
+    ds.download({sample_tar_xz.as_uri(): archive_path})
     # properly safe to dataset (download is ignorant of datasets)
-    res = ds.save(message='add archive', **kwa)
+    res = ds.save(message='add archive')
     # the first result has the archive addition, snatch the archive key from it
     assert res[0]['path'] == str(archive_path)
     archive_key = res[0]['key']
@@ -112,7 +107,7 @@ def test_replace_add_archive_content(sample_tar_xz, existing_dataset):
     # including `ls-file-collection` executed on a different host).
     file_recs = [
         r for r in ls_file_collection(
-            'tarfile', sample_tar_xz, hash=['md5'], **kwa
+            'tarfile', sample_tar_xz, hash=['md5'],
         )
         # ignore any non-file, would not have an annex key.
         # Also ignores hardlinks (they consume no space (size=0), but could be
@@ -141,7 +136,6 @@ def test_replace_add_archive_content(sample_tar_xz, existing_dataset):
         # filenameformat
         '{item}',
         key='et:MD5-s{size}--{hash-md5}',
-        **kwa
     )
     # because we have  been adding the above URLs using a pure metadata-driven
     # approach, git-annex does not yet know that the archives remote actually
@@ -159,8 +153,8 @@ def test_replace_add_archive_content(sample_tar_xz, existing_dataset):
     # check retrieval for a test file, which is not yet around
     testfile = ds.pathobj / 'test-archive' / '123_hard.txt'
     assert ds.status(
-        testfile, annex='availability', **kwa)[0]['has_content'] is False
-    ds.get(testfile, **kwa)
+        testfile, annex='availability')[0]['has_content'] is False
+    ds.get(testfile)
     assert testfile.read_text() == '123\n'
 
 

--- a/datalad_next/conftest.py
+++ b/datalad_next/conftest.py
@@ -32,6 +32,9 @@ from datalad_next.tests.fixtures import (
     httpbin,
     # session-scope HTTPBIN instance startup and URLs
     httpbin_service,
+    # function-scope, disabled datalad command result rendering for all
+    # command calls
+    no_result_rendering,
     # session-scope redirection of log messages
     reduce_logging,
     # session-scope, standard webdav credential (full dict)

--- a/datalad_next/constraints/tests/test_cmdarg_validation.py
+++ b/datalad_next/constraints/tests/test_cmdarg_validation.py
@@ -197,7 +197,7 @@ def test_invalid_multi_validation():
         val(valid_input)
 
 
-def test_cmd_with_validation():
+def test_cmd_with_validation(no_result_rendering):
     target_urls = ['http://example.com', 'file:///dev/null']
     target_url_path_maps = [
         {'http://example.com': Path('some/dir/file')},
@@ -227,7 +227,7 @@ def test_cmd_with_validation():
     ):
         res = CmdWithValidation.__call__(
             input,
-            return_type='item-or-list', result_renderer='disabled',
+            return_type='item-or-list',
         )
         assert 'spec' in res
         assert res['spec'] == target
@@ -241,14 +241,14 @@ def test_cmd_with_validation():
             f.seek(0)
             res = CmdWithValidation.__call__(
                 f.name,
-                return_type='item-or-list', result_renderer='disabled',
+                return_type='item-or-list',
             )
             assert res['spec'] == target_url_path_maps
 
     with patch("sys.stdin", StringIO(json_lines)):
         res = CmdWithValidation.__call__(
             '-',
-            return_type='item-or-list', result_renderer='disabled',
+            return_type='item-or-list',
         )
         assert res['spec'] == target_url_path_maps
 
@@ -259,7 +259,7 @@ def test_cmd_with_validation():
     with pytest.raises(ValueError):
         CmdWithValidation.__call__(
             'unsupported',
-            return_type='item-or-list', result_renderer='disabled',
+            return_type='item-or-list',
         )
 
     # no call with a required argument missing

--- a/datalad_next/constraints/tests/test_tutorial.py
+++ b/datalad_next/constraints/tests/test_tutorial.py
@@ -54,10 +54,10 @@ class DoBatch(ValidatedInterface):
             )
 
 
-def test_dobatch(monkeypatch):
+def test_dobatch(monkeypatch, no_result_rendering):
     data_in = '{"this":[1,2,3],"noise":"some"}\n{"this":true}'
     monkeypatch.setattr('sys.stdin', StringIO(data_in))
-    res = DoBatch.__call__('-', result_renderer='disabled')
+    res = DoBatch.__call__('-')
     assert len(res) == 2
     assert res[0]['selected'] == [1, 2, 3]
     assert res[1]['selected'] is True
@@ -65,7 +65,7 @@ def test_dobatch(monkeypatch):
     # now we have an intermediate error
     monkeypatch.setattr('sys.stdin', StringIO('bug\n' + data_in))
     res = DoBatch.__call__(
-        '-', on_failure='ignore', result_renderer='disabled')
+        '-', on_failure='ignore')
     assert len(res) == 3
     assert res[0]['status'] == 'error'
     assert 'Expecting value' in res[0]['error_message']

--- a/datalad_next/gitremotes/tests/test_datalad_annex.py
+++ b/datalad_next/gitremotes/tests/test_datalad_annex.py
@@ -304,8 +304,8 @@ def _check_typeweb(pushtmpl, clonetmpl, ds, server, clonepath):
         dsclone.repo.get_hexsha(DEFAULT_BRANCH))
 
 
-def test_submodule_url(tmp_path, existing_noannex_dataset, http_server):
-    ckwa = dict(result_renderer='disabled')
+def test_submodule_url(tmp_path, existing_noannex_dataset, http_server,
+                       no_result_rendering):
     servepath = http_server.path
     url = http_server.url
     # a future subdataset that we want to register under a complex URL
@@ -320,7 +320,7 @@ def test_submodule_url(tmp_path, existing_noannex_dataset, http_server):
     ])
     tobesubds.repo.call_git(['push', '-u', 'dla', DEFAULT_BRANCH])
     # create a superdataset to register the subds to
-    super = Dataset(tmp_path / 'super').create(**ckwa)
+    super = Dataset(tmp_path / 'super').create()
     with patch.dict(
             "os.environ", {
                 "GIT_CONFIG_COUNT": "1",
@@ -332,11 +332,11 @@ def test_submodule_url(tmp_path, existing_noannex_dataset, http_server):
         super.clone(
             f'datalad-annex::{url}?type=web&url={{noquery}}&exporttree=yes',
             'subds',
-            **ckwa)
+        )
     # no clone the entire super
-    superclone = clone(super.path, tmp_path / 'superclone', **ckwa)
+    superclone = clone(super.path, tmp_path / 'superclone')
     # and auto-fetch the sub via the datalad-annex remote helper
-    superclone.get('subds', get_data=False, recursive=True, **ckwa)
+    superclone.get('subds', get_data=False, recursive=True)
     # we got the original subds
     subdsclone = Dataset(superclone.pathobj / 'subds')
     eq_(tobesubds.id, subdsclone.id)

--- a/datalad_next/patches/tests/test_configuration.py
+++ b/datalad_next/patches/tests/test_configuration.py
@@ -9,16 +9,13 @@ from datalad_next.exceptions import IncompleteResultsError
 # run all -core tests
 from datalad.local.tests.test_configuration import *
 
-ckwa = dict(
-    result_renderer='disabled',
-)
 
-
-def test_config_get_global(existing_dataset, tmp_path):
+def test_config_get_global(existing_dataset, tmp_path,
+                           no_result_rendering):
     """Make sure `get` does not require a dataset to be present"""
     # enter a tempdir to be confident that there is no dataset around
     with chpwd(str(tmp_path)):
-        res = configuration('get', 'user.name', result_renderer='disabled')
+        res = configuration('get', 'user.name')
         assert_in_results(
             res,
             name='user.name',
@@ -29,25 +26,25 @@ def test_config_get_global(existing_dataset, tmp_path):
         in existing_dataset.configuration.__doc__
 
 
-def test_getset_None(tmp_path):
+def test_getset_None(tmp_path, no_result_rendering):
     # enter a tempdir to be confident that there is no dataset around
     with chpwd(str(tmp_path)):
         # set an empty string, this is not the same as `None`
-        configuration('set', 'some.item=', scope='global', **ckwa)
+        configuration('set', 'some.item=', scope='global')
         assert_in_results(
-            configuration('get', 'some.item', **ckwa),
+            configuration('get', 'some.item'),
             value='',
         )
         # an unset config item is equivalent to `None`
-        configuration('unset', 'some.item', scope='global', **ckwa),
+        configuration('unset', 'some.item', scope='global'),
         # retrieving an unset item triggers an exception ...
         assert_raises(
             IncompleteResultsError,
-            configuration, 'get', 'some.item', **ckwa)
+            configuration, 'get', 'some.item')
         # ... because the status of the respective result is "impossible"
         assert_in_results(
             configuration('get', 'some.item',
-                          on_failure='ignore', **ckwa),
+                          on_failure='ignore'),
             value=None,
             status='impossible',
         )

--- a/datalad_next/patches/tests/test_create_sibling_ghlike.py
+++ b/datalad_next/patches/tests/test_create_sibling_ghlike.py
@@ -16,7 +16,7 @@ from datalad.distributed.tests.test_create_sibling_gogs import *
 
 # we overwrite this one from core, because it assumed the old credential
 # system to be used
-def test_invalid_call(dataset, existing_dataset):
+def test_invalid_call(dataset, existing_dataset, no_result_rendering):
     # no dataset
     assert_raises(ValueError, dataset.create_sibling_gin, 'bogus')
     ds = existing_dataset
@@ -26,8 +26,7 @@ def test_invalid_call(dataset, existing_dataset):
         ds.create_sibling_gin, 'bo  gus', credential='some')
 
     # conflicting sibling name
-    ds.siblings('add', name='gin', url='http://example.com',
-                result_renderer='disabled')
+    ds.siblings('add', name='gin', url='http://example.com')
     res = ds.create_sibling_gin(
         'bogus', name='gin', credential='some', on_failure='ignore',
         dry_run=True)

--- a/datalad_next/patches/tests/test_run.py
+++ b/datalad_next/patches/tests/test_run.py
@@ -7,7 +7,7 @@ from datalad_next.tests.utils import (
 )
 
 
-def test_substitution_config_default(existing_dataset):
+def test_substitution_config_default(existing_dataset, no_result_rendering):
     ds = existing_dataset
 
     if ds.config.get('datalad.run.substitutions.python') is not None:
@@ -17,9 +17,9 @@ def test_substitution_config_default(existing_dataset):
 
     # the {python} placeholder is not explicitly defined, but it has
     # a default, which run() should discover and use
-    res = ds.run('{python} -c "True"', result_renderer='disabled')
+    res = ds.run('{python} -c "True"')
     assert_result_count(res, 1, action='run', status='ok')
 
     # make sure we could actually detect breakage with the check above
     with pytest.raises(IncompleteResultsError):
-        ds.run('{python} -c "breakage"', result_renderer='disabled')
+        ds.run('{python} -c "breakage"')


### PR DESCRIPTION
The fixture is function-scope.

Edit: Test logs say this works. I should now extend it to the entire codebase.