### PR TITLE
Disable test DAV server logging by default

### DIFF
--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -89,6 +89,9 @@ class WebDAVPath(object):
             "port": 43612,
             "provider_mapping": {"/": str(self.path)},
             "simple_dc": {"user_mapping": {'*': auth}},
+            # disable DAV server logging to avoid clustering the test output
+            # unless logger runs at least on debug log level
+            "logging": {"enable": lgr.isEnabledFor(10)},
         }
         app = WsgiDAVApp(config)
         self.server = wsgi.Server(


### PR DESCRIPTION
DAV server logs produce many lines of output during test runs that obscure more relevant messages.

This change makes the server logging conditional on a datalad log level of debug or more verbose.

Ping #503