### PR TITLE
Add batch command-context manager on top of run-context manager

### DIFF
--- a/datalad_next/runners/batch.py
+++ b/datalad_next/runners/batch.py
@@ -1,0 +1,276 @@
+"""Helpers to execute batch commands
+
+Some of the functionality provided by this module depends on specific
+"generator" flavors of runner protocols, and additional dedicated
+low-level tooling:
+
+.. currentmodule:: datalad_next.runners.batch
+.. autosummary::
+   :toctree: generated
+
+    StdOutCaptureGeneratorProtocol
+    StdOutLineCaptureGeneratorProtocol
+    GeneratorAnnexJsonProtocol
+    _ResultGenerator
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from queue import Queue
+from typing import (
+    Any,
+    Generator,
+)
+
+from datalad.runner.nonasyncrunner import _ResultGenerator
+from datalad.support.annexrepo import GeneratorAnnexJsonProtocol
+
+from . import Protocol
+from .protocols import (
+    StdOutCaptureGeneratorProtocol,
+    StdOutLineCaptureGeneratorProtocol,
+)
+from .run import run
+
+
+class BatchProcess:
+    """Representation of a (running) batch process
+
+    An instance of this class is produced by any of the context manager variants
+    in this module. It is a convenience wrapper around an instance of a
+    :class:`_ResultGenerator` that is produced by a :meth:`ThreadedRunner.run`.
+
+    A batch process instanced is used by passing ``bytes`` input to its
+    ``__call__()`` method, and receiving the batch output as return value.
+
+    While the process is still running, it ``return_code`` property will
+    be ``None``. After the has terminated, the property will contain the
+    respective exit status.
+    """
+    def __init__(self, rgen: _ResultGenerator):
+        self._rgen = rgen
+        self._stdin_queue = rgen.runner.stdin_queue
+
+    def __call__(self, data: bytes | None) -> Any:
+        self._stdin_queue.put(data)
+        try:
+            return next(self._rgen)
+        except StopIteration:
+            return None
+
+    def close_stdin(self) -> Any:
+        return self(None)
+
+    @property
+    def return_code(self) -> None | int:
+        return self._rgen.return_code
+
+
+@contextmanager
+def batchcommand(
+        cmd: list,
+        protocol_class: type[Protocol],
+        cwd: Path | None = None,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        protocol_kwargs: dict | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """Generic context manager for batch processes
+
+    ``cmd`` is an ``argv``-list specification of a command. It is executed via
+    a :class:`~datalad_next.runners.run.run` context manager. This context
+    manager is parameterized with ``protocol_class`` (which can take any
+    implementation of a DataLad runner protocol), and optional keyword arguments
+    that are passed to the protocol class.
+
+    On leaving the context, the manager will perform a "closing_action". By
+    default, this is to close ``stdin`` of the underlying process. This will
+    typically cause the underlying process to exit. A caller can specify an
+    alternative function, i.e. ``closing_action``. If ``closing_action`` is set,
+    the function will be called with two arguments. The first argument is the
+    :class:`BatchProcess`-instance, the second argument is the stdin-queue of
+    the subprocess.
+    A custom ``closing_action`` might, for example, send some kind of exit
+    command to the subprocess, and then close stdin. This method exists because
+    the control flow might enter the exit-handler through different mechanisms.
+    One mechanism would be an un-caught exception.
+
+    If ``terminate_time`` is given, the context handler will send a
+    terminate-signal to the process, if it is still running ``terminate_time``
+    seconds after the context is left. If ``kill_time`` is given, the context
+    handler will send a kill-signal to the process, if it is still running
+    ``(terminate_time or 0) + kill_time`` seconds after the context is left.
+
+    If neither ``terminate_time`` nor ``kill_time`` are set and the process
+    is not triggered to exit, e.g. because its stdin is not closed or because
+    it requires different actions to trigger its exit, batchcommand will wait
+    forever after the context exited. Note that the context might also be
+    exited in an unexpected way by an ``Èxception``.
+
+    While this generic context manager can be used directly, it can be
+    more convenient to use any of the more specialized implementations
+    that employ a specific protocol (e.g., :func:`stdout_batchcommand`,
+    :func:`stdoutline_batchcommand`, or :func:`annexjson_batchcommand`).
+
+    Parameters
+    ----------
+    cmd : list[str]
+        A list containing the command and its arguments (argv-like).
+    cwd : Path | None
+        If not ``None``, determines a new working directory for the command.
+    terminate_time: int | None
+        The number of timeouts after which a terminate-signal will be sent to
+        the process, if it is still running. If no timeouts were provided in the
+        ``timeout``-argument, the timeout is set to ``1.0``.
+    kill_time: int | None
+        See documentation of :func:`datalad_next.runners.run.run`.
+    protocol_kwargs: dict
+        If ``terminate_time`` is given, a kill-signal will be sent to the
+        subprocess after kill-signal after ``terminate_time + kill_time``
+        timeouts. If ``terminate_time`` is not set, a kill-signal will be sent
+        after ``kill_time`` timeouts.
+        It is a good idea to set ``kill_time`` and ``terminate_time`` in order
+        to let the process exit gracefully, if it is capable to do so.
+    kwargs : dict
+        All other keyword arguments are forwarded to the
+        ``datalad_next.runners.run.run``-context manager, that is used to
+        execute the batch command.
+
+    Yields
+    -------
+    BatchProcess
+        A :class:`BatchProcess`-instance that can be used to interact with the
+        cmd
+
+    """
+    input_queue = Queue()
+    try:
+        with run(
+            cmd=cmd,
+            protocol_class=protocol_class,
+            stdin=input_queue,
+            cwd=cwd,
+            terminate_time=terminate_time,
+            kill_time=kill_time,
+            protocol_kwargs=protocol_kwargs,
+            **kwargs,
+        ) as result_generator:
+            batch_process = BatchProcess(result_generator)
+            try:
+                yield batch_process
+            finally:
+                batch_process.close_stdin()
+    finally:
+        del input_queue
+
+
+def stdout_batchcommand(
+        cmd: list,
+        cwd: Path | None = None,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """Context manager for commands that produce arbitrary output on ``stdout``
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`StdOutCaptureGeneratorProtocol` protocol implementation.  See the
+    documentation of :func:`batchcommand` for a description of the parameters.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=StdOutCaptureGeneratorProtocol,
+        cwd=cwd,
+        terminate_time=terminate_time,
+        kill_time=kill_time,
+        **kwargs,
+    )
+
+
+def stdoutline_batchcommand(
+        cmd: list,
+        cwd: Path | None = None,
+        separator: str | None = None,
+        keep_ends: bool = False,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        protocol_kwargs: dict | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """Context manager for batch commands that respond with a single line.
+
+    The context manager returns a ``BatchProcess``-instance in the
+    ``as``-Variable. It uses :class:`StdOutLineCaptureGeneratorProtocol` to
+    process data from the subprocess. This protocol will yield individual lines,
+    of decoded data.
+
+    The context manager can be used, for example, to interact with
+    git-annex commands that support ``--batch`` and return a single line in
+    response to an input.
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`StdOutLineCaptureGeneratorProtocol` protocol implementation. See the
+
+    Parameters
+    ----------
+    separator : str | None (default ``None``)
+        If ``None``, lines are separated by the built-in separators of python.
+        If not ``None``, lines are separated by the given character.
+        The``separator`` keyword argument will override a ``separator`` keyword
+        argument provided in the ``protocol_kwargs``.
+
+    keep_ends: bool (default: ``False``)
+        If ``False``, the returned lines will not contain the terminating
+        character. If ``True``, the returned lines will contain the terminating
+        character.
+        The``keep_ends`` keyword argument will override a ``keep_ends`` keyword
+        argument provided in the ``protocol_kwargs``.
+
+    See the documentation of :func:`batchcommand` for a description of the
+    remaining parameters.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=StdOutLineCaptureGeneratorProtocol,
+        cwd=cwd,
+        terminate_time=terminate_time,
+        kill_time=kill_time,
+        protocol_kwargs=dict(
+            **(protocol_kwargs or {}),
+            separator=separator,
+            keep_ends=keep_ends,
+        ),
+        **kwargs,
+    )
+
+
+def annexjson_batchcommand(
+        cmd: list,
+        cwd: Path | None = None,
+        terminate_time: int | None = None,
+        kill_time: int | None = None,
+        protocol_kwargs: dict | None = None,
+        **kwargs,
+) -> Generator[BatchProcess, None, None]:
+    """
+    Context manager for git-annex commands that support ``--batch --json``
+
+    The given ``cmd``-list must be complete, i.e., include
+    ``git annex ... --batch --json``, and any additional flags that may be
+    needed.
+
+    Internally this calls :func:`batchcommand` with the
+    :class:`GeneratorAnnexJsonProtocol` protocol implementation. See the
+    documentation of :func:`batchcommand` for a description of the parameters.
+    """
+    return batchcommand(
+        cmd,
+        protocol_class=GeneratorAnnexJsonProtocol,
+        cwd=cwd,
+        terminate_time=terminate_time,
+        kill_time=kill_time,
+        protocol_kwargs=protocol_kwargs,
+        **kwargs,
+    )

--- a/datalad_next/runners/protocols.py
+++ b/datalad_next/runners/protocols.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from . import (
     GeneratorMixIn,
     NoCapture,
@@ -26,6 +28,44 @@ class StdOutCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
     def pipe_data_received(self, fd: int, data: bytes):
         assert fd == 1
         self.send_result(data)
+
+    def timeout(self, fd):
+        raise TimeoutError(f"Runner timeout {fd}")
+
+
+class StdOutLineCaptureGeneratorProtocol(StdOutCapture, GeneratorMixIn):
+    def __init__(self,
+                 done_future=None,
+                 encoding=None,
+                 separator: Optional[str] = None,
+                 keep_ends: bool = False
+                 ):
+        from . import LineSplitter
+
+        StdOutCapture.__init__(self, done_future, encoding)
+        GeneratorMixIn.__init__(self)
+        self.encoding = encoding or 'utf-8'
+        self.line_splitter = LineSplitter(separator, keep_ends)
+
+    def pipe_data_received(self, fd: int, data: bytes):
+        assert fd == 1
+        # This naive decode call might fail, if encodings are crossing data
+        # chunk borders. Because this protocol is part of a POC of the
+        # run-context-manager and the batch-context-manager, we leave it for
+        # now. The proper way to do that is IMHO to use the
+        # `StdOutCaptureProcessingGeneratorProtocol` from PR
+        # https://github.com/datalad/datalad-next/pull/484
+        # and the processing pipeline:
+        # `[decode_processor('utf-8'), splitlines_processor()]`
+        #
+        for line in self.line_splitter.process(data.decode()):
+            self.send_result(line)
+
+    def pipe_connection_lost(self, fd: int, exc: Optional[BaseException]) -> None:
+        if fd == 1:
+            remaining_string = self.line_splitter.finish_processing()
+            if remaining_string:
+                self.send_result(remaining_string)
 
     def timeout(self, fd):
         raise TimeoutError(f"Runner timeout {fd}")

--- a/datalad_next/runners/tests/test_batch.py
+++ b/datalad_next/runners/tests/test_batch.py
@@ -1,0 +1,244 @@
+import os
+import signal
+import sys
+
+import pytest
+
+from .. import (
+    GeneratorMixIn,
+    StdOutErrCapture,
+    StdOutCaptureGeneratorProtocol,
+)
+from ..batch import (
+    annexjson_batchcommand,
+    batchcommand,
+    stdout_batchcommand,
+    stdoutline_batchcommand,
+)
+
+
+# A batch program that takes exponentially longer to respond. This is used to
+# check for killing while waiting for `BatchProcess.__call__` to return.
+degrading_batch_prog = '''
+import sys
+import time
+
+i = 0
+while True:
+    sys.stdin.readline()
+    time.sleep(i**2 / 10)
+    print(i, flush=True)
+    i += 1
+'''
+
+
+line_echo_batch_prog = '''
+import sys
+import time
+
+end = '{end}'
+while True:
+    data = sys.stdin.readline()
+    if data == '':
+        break
+    print('read: ' + data.strip(), end=end, flush=True)
+print('closed', end=end, flush=True)
+'''
+
+
+class PythonProtocol(StdOutErrCapture, GeneratorMixIn):
+    """Parses interactive python output and enqueues complete output strings
+
+    This is an example for a protocol that processes results of an a priori
+    unknown structure and length.
+    Instances of this class interpret the stdout- and stderr-output of a
+    python interpreter. They assemble decoded stdout content until the python
+    interpreter sends ``'>>> '`` on stderr. Then the assembled output is
+    returned as result.
+
+    This requires to start the python interpreter in unbuffered mode! If not,
+    the ``stderr``-output can be processed too early, i.e. before all
+    ``stdout``-output is processed. This is due to the fact that the runner is
+    thread-based. The runner does not necessarily preserve the wall-clock-order
+    of events that arrive from different streams.
+    """
+    def __init__(self):
+        StdOutErrCapture.__init__(self)
+        GeneratorMixIn.__init__(self)
+        self.stdout = ''
+        self.stderr = b''
+        self.prompt_count = -1
+
+    def pipe_data_received(self, fd: int, data: bytes) -> None:
+        if fd == 1:
+            # We known that no multibyte encoded strings are used in the
+            # examples. Therefore, we don't have to care about encodings that
+            # are split between consecutive data chunks, and we can always
+            # successfully decode `data`.
+            self.stdout += data.decode()
+        elif fd == 2:
+            self.stderr += data
+            if len(self.stderr) >= 4 and b'>>> ' in self.stderr:
+                self.prompt_count += 1
+                self.stderr = b''
+        if self.stdout and self.prompt_count > 0:
+            self.send_result(self.stdout)
+            self.stdout = ''
+            self.prompt_count -= 1
+
+
+def test_batch_simple(existing_dataset):
+    # first with a simplistic protocol to test the basic mechanics
+    with stdout_batchcommand(
+            ['git', 'annex', 'examinekey',
+             # the \n in the format is needed to produce an output that hits
+             # the output queue after each input line
+             '--format', '${bytesize}\n',
+             '--batch'],
+            cwd=existing_dataset.pathobj,
+    ) as bp:
+        res = bp(b'MD5E-s21032--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res.rstrip(b'\r\n') == b'21032'
+        # to subprocess is still running
+        assert bp.return_code is None
+        # another batch
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res.rstrip(b'\r\n') == b'999'
+        assert bp.return_code is None
+        # we can bring the process down with stupid input, because it is
+        # inside our context handlers, it will not raise CommandError. check exit instead
+        res = bp(b'stupid\n')
+        # process exit is detectable
+        assert res is None
+        assert bp.return_code == 1
+        # continued use raises the same exception
+        # (but stacktrace is obvs different)
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res is None
+        assert bp.return_code == 1
+
+    # now with a more complex protocol (decodes JSON-lines output)
+    with annexjson_batchcommand(
+            ['git', 'annex', 'examinekey', '--json', '--batch'],
+            cwd=existing_dataset.pathobj,
+    ) as bp:
+        # output is a decoded JSON object
+        res = bp(b'MD5E-s21032--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res['backend'] == "MD5E"
+        assert res['bytesize'] == "21032"
+        assert res['key'] == "MD5E-s21032--2f4e22eb05d58c21663794876dc701aa"
+        res = bp(b'MD5E-s999--2f4e22eb05d58c21663794876dc701aa\n')
+        assert res['bytesize'] == "999"
+        res = bp(b'stupid\n')
+        assert res is None
+        assert bp.return_code == 1
+
+
+def test_batch_killing():
+    # to test killing we have to circumvent the automatic stdin-closing by
+    # BatchCommand. We do that by setting `closing_action` to an empty function.
+    with stdout_batchcommand(
+            [sys.executable, '-c',
+             'import time\nwhile True:\n    time.sleep(1)\n'],
+            terminate_time=2,
+            kill_time=2,
+    ) as bp:
+        pass
+
+    # at this point the process should have been terminated after about 3
+    # seconds, because git-annex behaves well and terminates when it receives
+    # a terminate signal
+    assert bp.return_code not in (0, None)
+    if os.name == 'posix':
+        assert bp.return_code == -signal.SIGTERM
+
+
+def test_annexjsonbatch_killing(existing_dataset):
+    # to test killing we have to circumvent the automatic stdin-closing by
+    # BatchCommand. We do that by setting `closing_action` to an empty function.
+    with annexjson_batchcommand(
+            [sys.executable, '-c',
+             'import time\nwhile True:\n    time.sleep(1)\n'],
+            cwd=existing_dataset.pathobj,
+            terminate_time=2,
+            kill_time=2,
+    ) as bp:
+        pass
+
+    # at this point the process should have been terminated after about 2
+    # seconds, because git-annex behaves well and terminates when it receives
+    # a terminate signal
+    assert bp.return_code not in (0, None)
+    if os.name == 'posix':
+        assert bp.return_code == -signal.SIGTERM
+
+
+def test_plain_batch_python_multiline():
+    # Test with a protocol that receives complex responses to a batch command.
+    # Here a set of output lines from a python-program.
+    prog = '''
+import time
+def x(count):
+    for i in range(count):
+        print(i, flush=True)
+    time.sleep(.2)
+'''
+    # We set a terminate and kill time here, because otherwise an exception
+    # that is raised in the `batchcommand`-context will get the test to hang.
+    # The reason is that the exception triggers an exit from the context,
+    # but the python process will never stop since we did neither close its
+    # stdin nor did we call the `exit()`-function.
+    with batchcommand([sys.executable, '-i', '-u', '-c', prog],
+                      protocol_class=PythonProtocol,
+                      terminate_time=3,
+                      kill_time=2,
+                      ) as python_interactive:
+
+        # Multiline output should be handled by the protocol,
+        for count in (5, 20):
+            response = python_interactive(f'x({count})\n'.encode())
+            assert len(response.splitlines()) == count
+        python_interactive.close_stdin()
+    assert python_interactive.return_code == 0
+
+    # Test with unclosed stdin, the exit-handler should close it.
+    with batchcommand([sys.executable, '-i', '-u', '-c', prog],
+                      protocol_class=PythonProtocol,
+                      terminate_time=3,
+                      kill_time=2,
+                      ) as python_interactive:
+        for count in (5, 20):
+            response = python_interactive(f'x({count})\n'.encode())
+            assert len(response.splitlines()) == count
+        # Do not close stdin here, we let BatchCommand do that.
+    assert python_interactive.return_code == 0
+
+
+def test_kill_lagging_batch():
+    # Check that a long next() on a result generator terminates the iteration
+    with batchcommand(cmd=[sys.executable, '-u', '-c', degrading_batch_prog],
+                      protocol_class=StdOutCaptureGeneratorProtocol,
+                      terminate_time=3,
+                      kill_time=2) as batch_process:
+        for i in range(10):
+            batch_process(i)
+    return_code = batch_process.return_code
+    if os.name == 'posix':
+        assert return_code == -signal.SIGTERM
+
+
+@pytest.mark.parametrize('separator,end', [(None, '\\n'), ('x', 'x')])
+def test_line_batch(separator, end):
+    # Check proper handling of separators in `stdoutline_batchcommand`.
+    prog = line_echo_batch_prog.format(end=end)
+    with stdoutline_batchcommand(
+            cmd=[sys.executable, '-u', '-c', prog],
+            separator=separator,
+    ) as batch_process:
+        r = batch_process('abc\n'.encode())
+        assert r == 'read: abc'
+        r = batch_process('def\n'.encode())
+        assert r == 'read: def'
+        r = batch_process.close_stdin()
+        assert r == 'closed'
+    assert batch_process.return_code == 0


### PR DESCRIPTION
This PR is a Draft-PR because it is against another PR. 

This PR adds a `batchcommand`-context manager. A `batchcommand`-context manager starts a subprocess and supports batch-style communication with it. That means, the user can send a request to the subprocess and receive the response from the subprocess.

How bytes that are read from the subprocess are assembled into a response is determined by the protocol that is used when the `batchcommand`-context manager is created. Typical responses would be single lines of text or JSON-encoded data.

The PR contains three convenience functions that provide context-manager for common interaction patterns (common in `datalad` and `datalad_next` anyways):

1. `stdout_batchcommand`: this context-manager writes to `stdin` of the subprocess and returns the next, yet unread, chunk of bytes that was written to `stdout` of the subprocess.
2. `stdoutline_batchcommand`: this context-manager writes to `stdin` of the subprocess and returns the next, yet unread, line that was written to `stdout` of the subprocess. Line-separators and whether they are included in the output can be chosen when creating the context-manager.
3. `annexjson_batchcommand`: this context-mananger writes to `stdin` of the subprocess and returns a JSON-object, that is created from the next, yet unread, line that is written to `stdout` of the subprocess. This context-mananger is geared towards git-annex batch commands with JSON-result output, i.e. git-annex invocations with the parameters `--batch`, `--json`, or `--json-error-messages`.
    
The tests contain an example for a protocol, `PythonProtocol` that handles output from an interactive python interpreter, which varies in size.
