### PR TITLE
`iterable_subprocess` based `annexworktree()`

### DIFF
--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -59,6 +59,9 @@ from datalad_next.iter_collections.gitworktree import (
     GitWorktreeFileSystemItem,
     iter_gitworktree,
 )
+from datalad_next.iter_collections.annexworktree import (
+    iter_annexworktree,
+)
 
 
 lgr = getLogger('datalad.local.ls_file_collection')
@@ -72,6 +75,7 @@ _supported_collection_types = (
     'directory',
     'tarfile',
     'gitworktree',
+    'annexworktree',
 )
 
 
@@ -110,7 +114,7 @@ class LsFileCollectionParamValidator(EnsureCommandParameterization):
         hash = kwargs['hash']
         iter_fx = None
         iter_kwargs = None
-        if type in ('directory', 'tarfile', 'gitworktree'):
+        if type in ('directory', 'tarfile', 'gitworktree', 'annexworktree'):
             if not isinstance(collection, Path):
                 self.raise_for(
                     kwargs,
@@ -131,6 +135,9 @@ class LsFileCollectionParamValidator(EnsureCommandParameterization):
         elif type == 'gitworktree':
             iter_fx = iter_gitworktree
             item2res = gitworktreeitem_to_dict
+        elif type == 'annexworktree':
+            iter_fx = iter_annexworktree
+            item2res = annexworktreeitem_to_dict
         else:
             raise RuntimeError(
                 'unhandled collection-type: this is a defect, please report.')
@@ -202,6 +209,17 @@ def gitworktreeitem_to_dict(item, hash) -> Dict:
 
     if gittype is not None:
         d['gittype'] = gittype
+    return d
+
+
+def annexworktreeitem_to_dict(item, hash) -> Dict:
+    d = gitworktreeitem_to_dict(item, hash)
+    if item.annexkey:
+        d['type'] = 'annexed file'
+        d['annexkey'] = item.annexkey
+        d['annexsize'] = item.annexsize
+        d['annexobjpath'] = item.annexobjpath
+
     return d
 
 

--- a/datalad_next/commands/tests/test_ls_file_collection.py
+++ b/datalad_next/commands/tests/test_ls_file_collection.py
@@ -165,3 +165,35 @@ def test_ls_renderer():
         Path(__file__).parent,
         result_renderer='tailored',
     )
+
+
+def test_ls_annexworktree_empty_dataset(existing_dataset):
+    res = ls_file_collection(
+        'annexworktree',
+        existing_dataset.pathobj,
+        result_renderer='disabled'
+    )
+    assert len(res) == 3
+    annexed_files = [annex_info for annex_info in res if 'annexkey' in annex_info]
+    assert len(annexed_files) == 0
+
+
+def test_ls_annexworktree_simple_dataset(existing_dataset):
+
+    (existing_dataset.pathobj / 'sample.bin').write_bytes(b'\x00' * 1024)
+    existing_dataset.save(message='add sample file')
+
+    res = ls_file_collection(
+        'annexworktree',
+        existing_dataset.pathobj,
+        result_renderer='disabled'
+    )
+    assert len(res) == 4
+    annexed_files = [annex_info for annex_info in res if 'annexkey' in annex_info]
+    assert len(annexed_files) == 1
+    assert annexed_files[0]['type'] == 'annexed file'
+    assert {
+        'annexkey',
+        'annexsize',
+        'annexobjpath'
+    }.issubset(set(annexed_files[0].keys()))

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -20,6 +20,7 @@ collections.
    annexworktree
    directory
    gitworktree
+   annexworktree
    tarfile
    zipfile
    utils

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -20,7 +20,6 @@ collections.
    annexworktree
    directory
    gitworktree
-   annexworktree
    tarfile
    zipfile
    utils

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -17,6 +17,7 @@ collections.
 .. autosummary::
    :toctree: generated
 
+   annexworktree
    directory
    gitworktree
    tarfile

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -67,11 +67,12 @@ class AnnexWorktreeFileSystemItem(GitWorktreeFileSystemItem):
 # iter_gitworktree() we should provide the same filtering for that one
 # too!
 def iter_annexworktree(
-        path: Path,
-        *,
-        untracked: str | None = 'all',
-        link_target: bool = False,
-        fp: bool = False,
+    path: Path,
+    *,
+    untracked: str | None = 'all',
+    link_target: bool = False,
+    fp: bool = False,
+    recursive: str = 'repository',
 ) -> Generator[AnnexWorktreeItem | AnnexWorktreeFileSystemItem, None, None]:
     """Companion to ``iter_gitworktree()`` for git-annex repositories
 
@@ -124,6 +125,10 @@ def iter_annexworktree(
       Moreover, each file-type item includes a file-like object
       to access the file's content. This file handle will be closed
       automatically when the next item is yielded.
+    recursive: {'repository', 'no'}, optional
+      Pass on to
+      :func:`~datalad_next.iter_collections.gitworktree.iter_gitworktree`,
+      thereby determining which items this iterator will yield.
 
     Yields
     ------
@@ -135,6 +140,7 @@ def iter_annexworktree(
         untracked=untracked,
         link_target=False,
         fp=False,
+        recursive=recursive,
     )
 
     git_fileinfo_store: list[Any] = list()

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -27,7 +27,7 @@ from datalad_next.itertools import (
     load_json,
     route_in,
     route_out,
-    dont_process,
+    StoreOnly,
 )
 from datalad_next.runners import iter_subproc
 
@@ -67,7 +67,7 @@ def get_annex_item(data):
 def join_annex_info(processed_data,
                     stored_data: AnnexWorktreeItem | AnnexWorktreeFileSystemItem
                     ):
-    if processed_data is dont_process:
+    if processed_data is StoreOnly:
         return stored_data
     else:
         if processed_data:
@@ -131,7 +131,7 @@ def iter_annexworktree(
                     # do not process empty key lines. Non-empty key lines
                     # are processed, but nothing needs to be stored because the
                     # processing result includes the key itself.
-                    lambda key: (dont_process, None)
+                    lambda key: (StoreOnly, None)
                                  if key == linesep_bytes
                                  else (key, None)
                 )
@@ -139,14 +139,14 @@ def iter_annexworktree(
 
         yield from route_in(
             # the following `route_in` yields processed keys for annexed
-            # files and `dont_process` for non-annexed files. Its
+            # files and `StoreOnly` for non-annexed files. Its
             # cardinality is the same as the cardinality of
             # `iter_gitworktree`, i.e. it produces data for each element
             # yielded by `iter_gitworktree`.
             route_in(
                 load_json(itemize(gek, sep=linesep_bytes)),
                 key_store,
-                # `processed` data is either `dont_process` or detailed
+                # `processed` data is either `StoreOnly` or detailed
                 # annex key information. we just return `process_data` as
                 # result, because `join_annex_info` knows how to incorporate
                 # it into an `AnnexWorktree*`-object.

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -115,33 +115,30 @@ def iter_annexworktree(
                 ['git', '-C', str(path),
                  'annex', 'examinekey', '--json', '--batch'],
                 # use only non-empty keys as input to `git annex examinekey`.
-                input=route_out(
-                    itemize(
-                        gaf,
-                        # git-annex changed its line-ending behavior, but we
-                        # should be safe, because we declare a specific format
-                        # for git-annex-find above
-                        # TODO this should be the following line only, not need
-                        # to put ends back
-                        # but MIH cannot get this adjusted
-                        #sep=b'\n',
-                        sep=None,
-                        keep_ends=True,
-                    ),
-                    # we need this route-out solely for the purpose
-                    # of maintaining a 1:1 relation ship of items reported
-                    # by git-ls-files and git-annex-find (merged again
-                    # in the route-in that gives `results` below`. The
-                    # "store" here does not actually store anything other than
-                    # `None`s
-                    _annex_git_align,
-                    # do not process empty key lines. Non-empty key lines
-                    # are processed, but nothing needs to be stored because the
-                    # processing result includes the key itself.
-                    # TODO when `keep_ends=True` is removed above, the strip()
-                    # should not be necessary anymore, but MIH cannot get
-                    # this adjusted
-                    lambda key: (key if key.strip() else StoreOnly, None)
+                input=intersperse(
+                    # Add line ending to submit the key to batch processing in
+                    # `git annex examinekey`.
+                    b'\n',
+                    route_out(
+                        itemize(
+                            gaf,
+                            # git-annex changed its line-ending behavior, but we
+                            # should be safe, because we declare a specific format
+                            # for git-annex-find above
+                            sep=b'\n',
+                        ),
+                        # we need this route-out solely for the purpose
+                        # of maintaining a 1:1 relation ship of items reported
+                        # by git-ls-files and git-annex-find (merged again
+                        # in the route-in that gives `results` below`. The
+                        # "store" here does not actually store anything other than
+                        # `None`s
+                        _annex_git_align,
+                        # do not process empty key lines. Non-empty key lines
+                        # are processed, but nothing needs to be stored because the
+                        # processing result includes the key itself.
+                        lambda key: (key if key else StoreOnly, None)
+                    )
                 )
             ) as gek:
 

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -8,7 +8,6 @@ from more_itertools import intersperse
 from pathlib import (
     Path,
     PurePath,
-    PurePosixPath,
 )
 from typing import (
     Any,

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -1,6 +1,7 @@
 """Report on the content of a Git-annex repository worktree
 
-The main functionality is provided by the :func:`iter_annexworktree()` function.
+The main functionality is provided by the :func:`iter_annexworktree()`
+function.
 """
 from __future__ import annotations
 
@@ -145,7 +146,8 @@ def iter_annexworktree(
                 # we get the annex key for any filename
                 # (or empty if not annexed)
                 ['git', '-C', str(path),
-                 'annex', 'find', '--anything', '--format=${key}\n', '--batch'],
+                 'annex', 'find', '--anything', '--format=${key}\n',
+                 '--batch'],
                 # intersperse items with newlines to trigger a batch run
                 # this avoids string operations to append newlines to items
                 input=intersperse(
@@ -178,9 +180,9 @@ def iter_annexworktree(
                     route_out(
                         itemize(
                             gaf,
-                            # git-annex changed its line-ending behavior, but we
-                            # should be safe, because we declare a specific format
-                            # for git-annex-find above
+                            # git-annex changed its line-ending behavior, but
+                            # we should be safe, because we declare a specific
+                            # format for git-annex-find above
                             sep=b'\n',
                         ),
                         # we need this route-out solely for the purpose
@@ -193,8 +195,8 @@ def iter_annexworktree(
                         # output of `git annex examinekey`).
                         _annex_git_align,
                         # do not process empty key lines. Non-empty key lines
-                        # are processed, but nothing needs to be stored because the
-                        # processing result includes the key itself.
+                        # are processed, but nothing needs to be stored because
+                        # the processing result includes the key itself.
                         lambda key: (key if key else StoreOnly, None)
                     )
                 )

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -82,9 +82,10 @@ def iter_annexworktree(
     item in bytes, and the path where the content of an annexed item will be
     available, if it is present.
 
-    This iterator is based on :func:`iter_gitworktree` and like this, any
-    yielded item reflects the last committed or staged content, not the state
-    of an unstaged modification in the work tree.
+    This iterator is based on
+    :func:`datalad_next.iter_collections.gitworktree.iter_gitworktree` and like
+    this, any yielded item reflects the last committed or staged content, not
+    the state of an unstaged modification in the work tree.
 
     When no reporting of link targets or file-objects are requested, items of
     type :class:`AnnexWorktreeItem` are yielded, otherwise
@@ -108,9 +109,13 @@ def iter_annexworktree(
     ----------
     path: Path
       Path of a directory in a Git repository to report on.
-      Please see :func:`iter_gitworktree` for details.
+      Please see
+      :func:`datalad_next.iter_collections.gitworktree.iter_gitworktree` for
+      details.
     untracked: {'all', 'whole-dir', 'no-empty'} or `None`, optional
-      Please see :func:`iter_gitworktree` for details.
+      Please see
+      :func:`datalad_next.iter_collections.gitworktree.iter_gitworktree` for
+      details.
     link_target: bool, optional
       If ``True`` and the item represents a symlink, the target of the symlink
       is stored in the ``link_target`` attribute of the item.

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -49,7 +49,7 @@ class AnnexWorktreeFileSystemItem(GitWorktreeFileSystemItem):
     annexobjpath: PurePath | None = None
 
 
-def content_path(item: AnnexWorktreeItem | AnnexWorktreeFileSystemItem,
+def content_path(item: AnnexWorktreeFileSystemItem,
                  base_path: Path,
                  link_target: bool,
                  ) -> PurePath | None:

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -81,7 +81,9 @@ def iter_annexworktree(
     )
 
     git_fileinfo_store: list[Any] = list()
-    key_store: list[Any] = list()
+    # this is a technical helper that will just store a bunch of `None`s
+    # for aligning item-results between git-ls-files and git-annex-find
+    _annex_git_align: list[Any] = list()
 
     with \
             iter_subproc(
@@ -116,7 +118,13 @@ def iter_annexworktree(
                 # use only non-empty keys as input to `git annex examinekey`.
                 input=route_out(
                     itemize(gaf, sep=None, keep_ends=True),
-                    key_store,
+                    # we need this route-out solely for the purpose
+                    # of maintaining a 1:1 relation ship of items reported
+                    # by git-ls-files and git-annex-find (merged again
+                    # in the route-in that gives `results` below`. The
+                    # "store" here does not actually store anything other than
+                    # `None`s
+                    _annex_git_align,
                     # do not process empty key lines. Non-empty key lines
                     # are processed, but nothing needs to be stored because the
                     # processing result includes the key itself.
@@ -132,7 +140,7 @@ def iter_annexworktree(
             # yielded by `iter_gitworktree`.
             route_in(
                 load_json(itemize(gek, sep=None)),
-                key_store,
+                _annex_git_align,
                 # `processed` data is either `StoreOnly` or detailed
                 # annex key information. we just return `process_data` as
                 # result, because `join_annex_info` knows how to incorporate

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -153,7 +153,7 @@ def iter_annexworktree(
                 # we get the annex key for any filename
                 # (or empty if not annexed)
                 ['git', '-C', str(path),
-                 'annex', 'find', '--anything', '--format=${key}\n',
+                 'annex', 'find', '--anything', '--format=${key}\\n',
                  '--batch'],
                 # intersperse items with newlines to trigger a batch run
                 # this avoids string operations to append newlines to items

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from more_itertools import intersperse
 from pathlib import (
     Path,
     PurePath,
@@ -14,14 +15,6 @@ from typing import (
     Generator,
 )
 
-from more_itertools import intersperse
-
-from .gitworktree import (
-    GitWorktreeItem,
-    GitWorktreeFileSystemItem,
-    FileSystemItemType,
-    iter_gitworktree
-)
 from datalad_next.itertools import (
     itemize,
     load_json,
@@ -30,6 +23,12 @@ from datalad_next.itertools import (
     StoreOnly,
 )
 from datalad_next.runners import iter_subproc
+
+from .gitworktree import (
+    GitWorktreeItem,
+    GitWorktreeFileSystemItem,
+    iter_gitworktree
+)
 
 
 lgr = logging.getLogger('datalad.ext.next.iter_collections.annexworktree')

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -1,0 +1,123 @@
+"""Report on the content of a Git-annex repository worktree
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from os import linesep
+from pathlib import (
+    Path,
+    PurePath,
+    PurePosixPath,
+)
+from typing import (
+    Any,
+    Generator,
+)
+
+from more_itertools import intersperse
+
+from .gitworktree import (
+    GitWorktreeItem,
+    GitWorktreeFileSystemItem,
+    iter_gitworktree
+)
+from datalad_next.itertools import (
+    itemize,
+    join_with_list,
+    load_json,
+    route_in,
+    route_out,
+    dont_process,
+)
+from datalad_next.runners import iter_subproc
+
+
+lgr = logging.getLogger('datalad.ext.next.iter_collections.annexworktree')
+
+
+linesep_bytes = linesep.encode()
+
+
+@dataclass
+class AnnexWorktreeItem(GitWorktreeItem):
+    annexkey: str | None = None
+    annexsize: int | None = None
+    annexobjpath: PurePath | None = None
+
+
+@dataclass
+class AnnexWorktreeFileSystemItem(GitWorktreeFileSystemItem):
+    annexkey: str | None = None
+    annexsize: int | None = None
+
+
+def iter_annexworktree(
+        path: Path,
+        *,
+        untracked: str | None = 'all',
+        link_target: bool = False,
+        fp: bool = False,
+) -> Generator[AnnexWorktreeItem | AnnexWorktreeFileSystemItem, None, None]:
+
+    glsf = iter_gitworktree(
+        path,
+        untracked=untracked,
+        link_target=link_target,
+        fp=fp
+    )
+
+    git_fileinfo_store: list[Any] = list()
+    key_store: list[Any] = list()
+
+    with \
+            iter_subproc(
+                # we get the annex key for any filename (or empty if not annexed)
+                ['git', '-C', str(path), 'annex', 'find', '--anything', '--format=\${key}\n', '--batch'],
+                # intersperse items with newlines to trigger a batch run
+                # this avoids string operations to append newlines to items
+                input=intersperse(
+                    b'\n',
+                    # store all output of the git ls-find in the gitfileinfo
+                    # store
+                    route_out(
+                        glsf,
+                        git_fileinfo_store,
+                        lambda data: (str(data.name).encode(), [data])
+                    )
+                ),
+            ) as gaf, \
+            iter_subproc(
+                # get the key properties JSON-lines style
+                ['git', '-C', str(path), 'annex', 'examinekey', '--json', '--batch'],
+                # process all non-empty keys and store them in the key store,
+                # skip processing of empty keys and store an ignored value in
+                # the key store
+                input=route_out(
+                    itemize(gaf, sep=linesep_bytes, keep_ends=True),
+                    key_store,
+                    lambda data: (dont_process, [None])
+                                 if data == linesep_bytes
+                                 else (data, [data])
+                )
+            ) as gek:
+
+        for item in route_in(
+                route_in(
+                    load_json(itemize(gek, sep=linesep_bytes)),
+                    key_store,
+                    join_with_list,
+                ),
+                git_fileinfo_store,
+                join_with_list,
+        ):
+            yield AnnexWorktreeItem(
+                name=item[2].name,
+                gitsha=item[2].gitsha,
+                gittype=item[2].gittype,
+                annexkey=item[1].decode().strip() if item[1] else None,
+                annexsize=int(item[0]['bytesize']) if item[0] else None,
+                annexobjpath=PurePath(PurePosixPath(str(item[0]['objectpath'])))
+                             if item[0]
+                             else None,
+            )

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -128,11 +128,13 @@ def iter_annexworktree(
                             sep=b'\n',
                         ),
                         # we need this route-out solely for the purpose
-                        # of maintaining a 1:1 relation ship of items reported
+                        # of maintaining a 1:1 relationship of items reported
                         # by git-ls-files and git-annex-find (merged again
-                        # in the route-in that gives `results` below`. The
-                        # "store" here does not actually store anything other than
-                        # `None`s
+                        # in the `route-in` that gives `results` below). The
+                        # "store" here does not actually store anything other
+                        # than`None`s (because the `key` --which is consumed by
+                        # `git annex examinekey`-- is also present in the
+                        # output of `git annex examinekey`).
                         _annex_git_align,
                         # do not process empty key lines. Non-empty key lines
                         # are processed, but nothing needs to be stored because the

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -242,6 +242,6 @@ def _join_annex_info(
         joined.update(
             annexkey=processed_data['key'],
             annexsize=int(processed_data['bytesize']),
-            annexobjpath=PurePosixPath(str(processed_data['objectpath'])),
+            annexobjpath=PurePath(str(processed_data['objectpath'])),
         )
         return joined

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -89,7 +89,7 @@ def iter_annexworktree(
                 # we get the annex key for any filename
                 # (or empty if not annexed)
                 ['git', '-C', str(path),
-                 'annex', 'find', '--anything', '--format=\${key}\n', '--batch'],
+                 'annex', 'find', '--anything', '--format=${key}\n', '--batch'],
                 # intersperse items with newlines to trigger a batch run
                 # this avoids string operations to append newlines to items
                 input=intersperse(

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -117,7 +117,18 @@ def iter_annexworktree(
                  'annex', 'examinekey', '--json', '--batch'],
                 # use only non-empty keys as input to `git annex examinekey`.
                 input=route_out(
-                    itemize(gaf, sep=None, keep_ends=True),
+                    itemize(
+                        gaf,
+                        # git-annex changed its line-ending behavior, but we
+                        # should be safe, because we declare a specific format
+                        # for git-annex-find above
+                        # TODO this should be the following line only, not need
+                        # to put ends back
+                        # but MIH cannot get this adjusted
+                        #sep=b'\n',
+                        sep=None,
+                        keep_ends=True,
+                    ),
                     # we need this route-out solely for the purpose
                     # of maintaining a 1:1 relation ship of items reported
                     # by git-ls-files and git-annex-find (merged again
@@ -128,6 +139,9 @@ def iter_annexworktree(
                     # do not process empty key lines. Non-empty key lines
                     # are processed, but nothing needs to be stored because the
                     # processing result includes the key itself.
+                    # TODO when `keep_ends=True` is removed above, the strip()
+                    # should not be necessary anymore, but MIH cannot get
+                    # this adjusted
                     lambda key: (key if key.strip() else StoreOnly, None)
                 )
             ) as gek:

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -69,9 +69,62 @@ def iter_annexworktree(
         link_target: bool = False,
         fp: bool = False,
 ) -> Generator[AnnexWorktreeItem | AnnexWorktreeFileSystemItem, None, None]:
-    """TODO
-    """
+    """Report work tree item of an annexed Git repository
 
+    This iterator can be used to report on all tracked, and untracked
+    non-annexed content and on the annexed content of the work tree of an
+    annexed Git repository. This includes files that have been removed
+    from the work tree (deleted), unless their removal has already been staged.
+
+    For any tracked content, yielded items include type information, gitsha
+    as last known to Git, and annex information, if the file is annexed. Annex
+    information includes the key of the annexed item, the size of the annexed
+    item in bytes, and the path where the content of an annexed item will be
+    available, if it is present.
+
+    This iterator is based on :func:`iter_gitworktree` and like this, any
+    yielded item reflects the last committed or staged content, not the state
+    of an unstaged modification in the work tree.
+
+    When no reporting of link targets or file-objects are requested, items of
+    type :class:`AnnexWorktreeItem` are yielded, otherwise
+    :class:`AnnexWorktreeFileSystemItem` instances are yielded. In both cases,
+    ``gitsha``, ``gittype``, ``annexkey``, ``annexsize``, and ``annnexobjpath``
+    properties are provided. Either of ``gitsha`` and ``gittyoe`` being ``None``
+    indicates untracked work tree content. Either of ``annexkey``, ``annexsize``,
+    ``annexobjpath`` being ``None`` indicates non-annexed work tree content.
+
+    .. note::
+      The ``gitsha`` is not equivalent to a SHA1 hash of a file's content,
+      but is the SHA-type blob identifier as reported and used by Git.
+
+    .. note::
+      Although ``annexobjpath`` is always set for annexed content, that does not
+      imply that an object at this path actually exists. The latter will only
+      be the case if the annexed content is present in the work tree, typically
+      as a result of a `datalad get`- or `git annex get`-call.
+
+    Parameters
+    ----------
+    path: Path
+      Path of a directory in a Git repository to report on.
+      Please see :func:`iter_gitworktree` for details.
+    untracked: {'all', 'whole-dir', 'no-empty'} or `None`, optional
+      Please see :func:`iter_gitworktree` for details.
+    link_target: bool, optional
+      If ``True`` and the item represents a symlink, the target of the symlink
+      is stored in the ``link_target`` attribute of the item.
+    fp: bool, optional
+      If ``True``, each file-type item includes a file-like object
+      to access the file's content, if the file is either: non-annexed, or if
+      the files is annexed and the content is locally available.
+      This file handle will be closed automatically when the next item is
+      yielded.
+
+    Yields
+    ------
+    :class:`AnnexWorktreeItem` or `AnnexWorktreeFileSystemItem`
+    """
     glsf = iter_gitworktree(
         path,
         untracked=untracked,

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from os import linesep
 from pathlib import (
     Path,
     PurePath,
@@ -33,9 +32,6 @@ from datalad_next.runners import iter_subproc
 
 
 lgr = logging.getLogger('datalad.ext.next.iter_collections.annexworktree')
-
-
-linesep_bytes = linesep.encode()
 
 
 @dataclass
@@ -126,13 +122,13 @@ def iter_annexworktree(
                 ['git', '-C', str(path), 'annex', 'examinekey', '--json', '--batch'],
                 # use only non-empty keys as input to `git annex examinekey`.
                 input=route_out(
-                    itemize(gaf, sep=linesep_bytes, keep_ends=True),
+                    itemize(gaf, sep=None, keep_ends=True),
                     key_store,
                     # do not process empty key lines. Non-empty key lines
                     # are processed, but nothing needs to be stored because the
                     # processing result includes the key itself.
                     lambda key: (StoreOnly, None)
-                                 if key == linesep_bytes
+                                 if key.strip() == b''
                                  else (key, None)
                 )
             ) as gek:
@@ -144,7 +140,7 @@ def iter_annexworktree(
             # `iter_gitworktree`, i.e. it produces data for each element
             # yielded by `iter_gitworktree`.
             route_in(
-                load_json(itemize(gek, sep=linesep_bytes)),
+                load_json(itemize(gek, sep=None)),
                 key_store,
                 # `processed` data is either `StoreOnly` or detailed
                 # annex key information. we just return `process_data` as

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -1,0 +1,84 @@
+from pathlib import (
+    PurePath,
+)
+
+from datalad import cfg as dlcfg
+
+from datalad_next.datasets import Dataset
+
+from ..annexworktree import (
+    iter_annexworktree,
+)
+
+
+def _mkds(tmp_path_factory, monkeypatch, cfg_overrides):
+    with monkeypatch.context() as m:
+        for k, v in cfg_overrides.items():
+            m.setitem(dlcfg.overrides, k, v)
+        dlcfg.reload()
+        ds = Dataset(tmp_path_factory.mktemp('ds')).create(
+            result_renderer='disabled')
+    dlcfg.reload()
+    return ds
+
+
+def _dotests(ds):
+    test_file_content = 'test_file'
+    test_file = ds.pathobj / 'annexed' / 'subdir' / 'file1.txt'
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(test_file_content)
+    # we create an additional file where the content will be dropped
+    # to test behavior on unavailable annex key
+    droptest_content = 'somethingdropped'
+    droptest_file = ds.pathobj / 'annexed' / 'dropped.txt'
+    droptest_file.write_text(droptest_content)
+    ds.save(result_renderer='disabled')
+    ds.drop(droptest_file, reckless='availability',
+            result_renderer='disabled')
+
+    # get results for the annexed files
+    query_path = ds.pathobj / 'annexed'
+    res = list(iter_annexworktree(
+        query_path, untracked=None, link_target=True,
+    ))
+    assert len(res) == 2
+    #
+    # pick the present annex file to start
+    r = [r for r in res if r.name.name == 'file1.txt'][0]
+    assert r.name == PurePath('subdir', 'file1.txt')
+    # we cannot check gitsha and symlink content for identity, it will change
+    # depending on the tuning
+    # we cannot check the item type, because it will vary across repository
+    # modes (e.g., adjusted unlocked)
+    assert r.annexsize == len(test_file_content)
+    assert r.annexkey == 'MD5E-s9--37b87ee8c563af911dcc0f949826b1c9.txt'
+    # with `link_target=True` we get an objpath that is relative to the
+    # query path, and we find the actual key file there
+    assert (query_path / r.annexobjpath).read_text() == test_file_content
+    #
+    # now pick the dropped annex file
+    r = [r for r in res if r.name.name == 'dropped.txt'][0]
+    assert r.name == PurePath('dropped.txt')
+    # we get basic info regardless of availability
+    assert r.annexsize == len(droptest_content)
+    assert r.annexkey == 'MD5E-s16--770a06889bc88f8743d1ed9a1977ff7b.txt'
+    # even with an absent key file, we get its would-be location,
+    # and it is relative to the query path
+    assert r.annexobjpath.parts[:2] == ('..', '.git')
+
+
+def test_iter_annexworktree(tmp_path_factory, monkeypatch):
+    ds = _mkds(tmp_path_factory, monkeypatch, {})
+    _dotests(ds)
+
+
+def test_iter_annexworktree_tuned(tmp_path_factory, monkeypatch):
+    # same as test_file_content(), but with a "tuned" annexed that
+    # no longer matches the traditional setup.
+    # we need to be able to cope with that too
+    ds = _mkds(tmp_path_factory, monkeypatch, {
+        'annex.tune.objecthash1': 'true',
+        'annex.tune.branchhash1': 'true',
+        'annex.tune.objecthashlower': 'true',
+    })
+    _dotests(ds)

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -86,15 +86,19 @@ def test_iter_annexworktree_tuned(tmp_path_factory, monkeypatch):
 
 def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
     ds = existing_dataset
+    content_tmpl = 'content: #ö file_{}\n'
     for i in range(3):
-        (ds.pathobj / f'file_{i}').write_text(f'content: #ö file_{i}\n')
+        (ds.pathobj / f'file_{i}').write_text(content_tmpl.format(i))
     ds.save()
     ds.drop(
         ds.pathobj / 'file_1',
         reckless='availability',
     )
-    for ai in filter(lambda i: str(i.name).startswith('file_'), iter_annexworktree(ds.pathobj, fp=True)):
+    for ai in filter(
+        lambda i: str(i.name).startswith('file_'),
+        iter_annexworktree(ds.pathobj, fp=True)
+    ):
         if ai.fp:
-            assert f'content: #ö {str(ai.name)}\n' == ai.fp.read().decode()
+            assert content_tmpl.format(ai.name) == ai.fp.read().decode()
         else:
             assert (ds.pathobj / ai.annexobjpath).exists() is False

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -92,9 +92,12 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
     # we count them up on creation, and then down on test
     fcount = 0
 
-    content_tmpl = 'content: #ö file_{}\n'
+    content_tmpl = 'content: #ö file_{}'
     for i in range(3):
-        (ds.pathobj / f'file_{i}').write_text(content_tmpl.format(i))
+        (ds.pathobj / f'file_{i}').write_text(
+            content_tmpl.format(i),
+            encoding='utf-8'
+        )
         fcount += 1
     ds.save()
     ds.drop(
@@ -103,7 +106,10 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
     )
     # and also add a file to git directly and a have one untracked too
     for i in ('untracked', 'ingit'):
-        (ds.pathobj / f'file_{i}').write_text(content_tmpl.format(i))
+        (ds.pathobj / f'file_{i}').write_text(
+            content_tmpl.format(i),
+            encoding='utf-8'
+        )
         fcount += 1
     ds.save('file_ingit', to_git=True)
     # and add symlinks (untracked and in git)
@@ -113,7 +119,7 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
         for i in ('symlinkuntracked', 'symlinkingit'):
             tpath = ds.pathobj / f'target_{i}'
             lpath = ds.pathobj / f'file_{i}'
-            tpath.write_text(content_tmpl.format(i))
+            tpath.write_text(content_tmpl.format(i), encoding='utf-8')
             lpath.symlink_to(tpath)
             fcount += 1
     ds.save('file_symlinkingit', to_git=True)

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -94,11 +94,21 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
         ds.pathobj / 'file_1',
         reckless='availability',
     )
+    # and also add a file to git directly and a have one untracked too
+    for i in ('untracked', 'ingit'):
+        (ds.pathobj / f'file_{i}').write_text(content_tmpl.format(i))
+    ds.save('file_ingit', to_git=True)
+
+    # we expect to process an exact number of files below
+    fcount = 5
     for ai in filter(
-        lambda i: str(i.name).startswith('file_'),
+        lambda i: str(i.name.name).startswith('file_'),
         iter_annexworktree(ds.pathobj, fp=True)
     ):
+        fcount -= 1
         if ai.fp:
-            assert content_tmpl.format(ai.name) == ai.fp.read().decode()
+            assert content_tmpl.format(
+                ai.name.name[5:]) == ai.fp.read().decode()
         else:
             assert (ds.pathobj / ai.annexobjpath).exists() is False
+    assert not fcount

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -82,3 +82,20 @@ def test_iter_annexworktree_tuned(tmp_path_factory, monkeypatch):
         'annex.tune.objecthashlower': 'true',
     })
     _dotests(ds)
+
+
+def test_iter_annexworktree_basic_fp(tmp_path_factory, monkeypatch):
+    ds = _mkds(tmp_path_factory, monkeypatch, {})
+    for i in range(3):
+        (ds.pathobj / f'file_{i}').write_text(f'content: #ö file_{i}\n')
+    ds.save(result_renderer='disabled')
+    ds.drop(
+        ds.pathobj / 'file_1',
+        reckless='availability',
+        result_renderer='disabled'
+    )
+    for ai in filter(lambda i: str(i.name).startswith('file_'), iter_annexworktree(ds.pathobj, fp=True)):
+        if ai.fp:
+            assert f'content: #ö {str(ai.name)}\n' == ai.fp.read().decode()
+        else:
+            assert (ds.pathobj / ai.annexobjpath).exists() is False

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -5,6 +5,7 @@ from pathlib import (
 from datalad import cfg as dlcfg
 
 from datalad_next.datasets import Dataset
+from datalad_next.utils import check_symlink_capability
 
 from ..annexworktree import (
     iter_annexworktree,
@@ -86,9 +87,16 @@ def test_iter_annexworktree_tuned(tmp_path_factory, monkeypatch):
 
 def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
     ds = existing_dataset
+    # we expect to process an exact number of files below
+    # 3 annexed files, 1 untracked, 1 in git,
+    # and possibly 1 symlink in git, 1 symlink untracked
+    # we count them up on creation, and then down on test
+    fcount = 0
+
     content_tmpl = 'content: #ö file_{}\n'
     for i in range(3):
         (ds.pathobj / f'file_{i}').write_text(content_tmpl.format(i))
+        fcount += 1
     ds.save()
     ds.drop(
         ds.pathobj / 'file_1',
@@ -97,10 +105,20 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
     # and also add a file to git directly and a have one untracked too
     for i in ('untracked', 'ingit'):
         (ds.pathobj / f'file_{i}').write_text(content_tmpl.format(i))
+        fcount += 1
     ds.save('file_ingit', to_git=True)
+    # and add symlinks (untracked and in git)
+    if check_symlink_capability(
+        ds.pathobj / '_dummy', ds.pathobj / '_dummy_target'
+    ):
+        for i in ('symlinkuntracked', 'symlinkingit'):
+            tpath = ds.pathobj / f'target_{i}'
+            lpath = ds.pathobj / f'file_{i}'
+            tpath.write_text(content_tmpl.format(i))
+            lpath.symlink_to(tpath)
+            fcount += 1
+    ds.save('file_symlinkingit', to_git=True)
 
-    # we expect to process an exact number of files below
-    fcount = 5
     for ai in filter(
         lambda i: str(i.name.name).startswith('file_'),
         iter_annexworktree(ds.pathobj, fp=True)
@@ -110,5 +128,7 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
             assert content_tmpl.format(
                 ai.name.name[5:]) == ai.fp.read().decode()
         else:
-            assert (ds.pathobj / ai.annexobjpath).exists() is False
+            assert (ai.annexobjpath and (
+                ds.pathobj / ai.annexobjpath).exists() is False) or (
+                    ai.name.exists() is False)
     assert not fcount

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -84,15 +84,14 @@ def test_iter_annexworktree_tuned(tmp_path_factory, monkeypatch):
     _dotests(ds)
 
 
-def test_iter_annexworktree_basic_fp(tmp_path_factory, monkeypatch):
-    ds = _mkds(tmp_path_factory, monkeypatch, {})
+def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
+    ds = existing_dataset
     for i in range(3):
         (ds.pathobj / f'file_{i}').write_text(f'content: #ö file_{i}\n')
-    ds.save(result_renderer='disabled')
+    ds.save()
     ds.drop(
         ds.pathobj / 'file_1',
         reckless='availability',
-        result_renderer='disabled'
     )
     for ai in filter(lambda i: str(i.name).startswith('file_'), iter_annexworktree(ds.pathobj, fp=True)):
         if ai.fp:

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -45,7 +45,7 @@ def _dotests(ds):
     #
     # pick the present annex file to start
     r = [r for r in res if r.name.name == 'file1.txt'][0]
-    assert r.name == PurePath('subdir', 'file1.txt')
+    assert r.name == query_path / 'subdir' / 'file1.txt'
     # we cannot check gitsha and symlink content for identity, it will change
     # depending on the tuning
     # we cannot check the item type, because it will vary across repository
@@ -58,7 +58,7 @@ def _dotests(ds):
     #
     # now pick the dropped annex file
     r = [r for r in res if r.name.name == 'dropped.txt'][0]
-    assert r.name == PurePath('dropped.txt')
+    assert r.name == query_path / 'dropped.txt'
     # we get basic info regardless of availability
     assert r.annexsize == len(droptest_content)
     assert r.annexkey == 'MD5E-s16--770a06889bc88f8743d1ed9a1977ff7b.txt'

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -7,9 +7,8 @@ from datalad import cfg as dlcfg
 from datalad_next.datasets import Dataset
 from datalad_next.utils import check_symlink_capability
 
-from ..annexworktree import (
-    iter_annexworktree,
-)
+from ..gitworktree import GitTreeItemType
+from ..annexworktree import iter_annexworktree
 
 
 def _mkds(tmp_path_factory, monkeypatch, cfg_overrides):
@@ -132,3 +131,17 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
                 ds.pathobj / ai.annexobjpath).exists() is False) or (
                     ai.name.exists() is False)
     assert not fcount
+
+
+def test_iter_annexworktree_nonrecursive(existing_dataset):
+    # just a smoke test
+    # given that iter_annexworktree() only wraps iter_gitworktree()
+    # there is nothing to test here, any item not yielded by
+    # iter_gitworktree() will also not be amended
+    all_items = list(iter_annexworktree(
+        existing_dataset.pathobj, recursive='no'))
+    # we get a .datalad directory-tyoe item, rather than the file item from
+    # inside the dir
+    dirs = [i for i in all_items if i.gittype == GitTreeItemType.directory]
+    assert len(dirs) == 1
+    dirs[0].name == PurePath('.datalad')

--- a/datalad_next/itertools/__init__.py
+++ b/datalad_next/itertools/__init__.py
@@ -6,8 +6,14 @@
 
     decode_bytes
     itemize
+    load_json
+    load_json_with_flag
 """
 
 
 from .decode_bytes import decode_bytes
 from .itemize import itemize
+from .load_json import (
+    load_json,
+    load_json_with_flag,
+)

--- a/datalad_next/itertools/__init__.py
+++ b/datalad_next/itertools/__init__.py
@@ -10,7 +10,6 @@
     load_json_with_flag
     route_out
     route_in
-    join_with_list
 """
 
 
@@ -21,7 +20,6 @@ from .load_json import (
     load_json_with_flag,
 )
 from .reroute import (
-    join_with_list,
     route_in,
     route_out,
     dont_process,

--- a/datalad_next/itertools/__init__.py
+++ b/datalad_next/itertools/__init__.py
@@ -22,5 +22,5 @@ from .load_json import (
 from .reroute import (
     route_in,
     route_out,
-    dont_process,
+    StoreOnly,
 )

--- a/datalad_next/itertools/__init__.py
+++ b/datalad_next/itertools/__init__.py
@@ -8,6 +8,9 @@
     itemize
     load_json
     load_json_with_flag
+    route_out
+    route_in
+    join_with_list
 """
 
 
@@ -16,4 +19,10 @@ from .itemize import itemize
 from .load_json import (
     load_json,
     load_json_with_flag,
+)
+from .reroute import (
+    join_with_list,
+    route_in,
+    route_out,
+    dont_process,
 )

--- a/datalad_next/itertools/load_json.py
+++ b/datalad_next/itertools/load_json.py
@@ -1,0 +1,112 @@
+""" Functions that yield JSON objects converted from input items """
+
+from __future__ import annotations
+
+import json
+from typing import (
+    Any,
+    Generator,
+    Iterable,
+)
+
+
+__all__ = ['load_json', 'load_json_with_flag']
+
+
+def load_json(iterable: Iterable[bytes | str],
+              ) -> Generator[Any, None, None]:
+    """ Convert items yielded by ``iterable`` into JSON objects and yield them
+
+    ``load_json`` fetches items from the underlying
+    iterable. The items are expected to be ``bytes``, ``str``, or ``bytearry``,
+    and contain one JSON-encoded object. ``load_json``
+    will convert each item into a JSON-object, by feeding it into
+    ``json.loads``.
+
+    On successful conversion to a JSON-object, ``load_json`` will yield the
+    resulting JSON-object. If the conversion to a JSON-object fails,
+    ``load_json`` will raise a ``json.decoder.JSONDecodeError``:
+
+    .. code-block:: python
+
+        >>> from datalad_next.itertools import load_json, load_json_with_flag
+        >>> tuple(load_json(['{"a": 1}']))
+        ({'a': 1},)
+        >>> tuple(load_json(['{"c": 3']))   # Faulty JSON-encoding, doctest: +SKIP
+        Traceback (most recent call last):
+            ...
+        json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 8 (char 7)
+
+    Using ``load_json`` together with ``itemize`` allows the processing of
+    JSON-lines data. ``itemize`` will yield a single item for each line and
+    ``load_json`` will convert it into a JSON-object.
+
+    Note: JSON-decoding is slightly faster if the items of type ``str``. Items
+    of type ``bytes`` or ``bytearray`` will work as well, but processing might
+    be slower.
+
+    Parameters
+    ----------
+    iterable: Iterable[bytes | str]
+        The iterable that yields the JSON-strings or -bytestrings that should be
+        parsed and converted into JSON-objects
+
+    Yields
+    ------
+    Any
+        The JSON-object that are generated from the data yielded by ``iterable``
+
+    Raises
+    ------
+    json.decoder.JSONDecodeError
+        If the data yielded by ``iterable`` is not a valid JSON-string
+    """
+    for json_string in iterable:
+        yield json.loads(json_string)
+
+
+def load_json_with_flag(
+        iterable: Iterable[bytes | str],
+) -> Generator[tuple[Any | json.decoder.JSONDecodeError, bool], None, None]:
+    """ Convert items from ``iterable`` into JSON objects and a success flag
+
+    ``load_json_with_flag`` works analogous to ``load_json``, but reports
+    success and failure differently.
+
+    On successful conversion to a JSON-object, ``load_json_with_flag`` will
+    yield a tuple of two elements. The first element contains the JSON-object,
+    the second element is ``True``.
+
+    If the conversion to a JSON-object fails, ``load_json_with_flag`` will
+    yield a tuple of two elements, where the first element contains the
+    ``json.decoder.JSONDecodeError`` that was raised during conversion, and the
+    second element is ``False``:
+
+    .. code-block:: python
+
+        >>> from datalad_next.itertools import load_json, load_json_with_flag
+        >>> tuple(load_json_with_flag(['{"b": 2}']))
+        (({'b': 2}, True),)
+        >>> tuple(load_json_with_flag(['{"d": 4']))   # Faulty JSON-encoding
+        ((JSONDecodeError("Expecting ',' delimiter: line 1 column 8 (char 7)"), False),)
+
+    Parameters
+    ----------
+    iterable: Iterable[bytes | str]
+        The iterable that yields the JSON-strings or -bytestrings that should be
+        parsed and converted into JSON-objects
+
+    Yields
+    ------
+    tuple[Any | json.decoder.JSONDecodeError, bool]
+        A tuple containing of a decoded JSON-object and ``True``, if the JSON
+        string could be decoded correctly. If the JSON string  could not be
+        decoded correctly, the tuple will contain the
+        ``json.decoder.JSONDecodeError`` that was raised during JSON-decoding
+        and ``False``.
+    """
+    for json_string in iterable:
+        try:
+            yield json.loads(json_string), True
+        except json.decoder.JSONDecodeError as e:
+            yield e, False

--- a/datalad_next/itertools/load_json.py
+++ b/datalad_next/itertools/load_json.py
@@ -17,10 +17,10 @@ def load_json(iterable: Iterable[bytes | str],
               ) -> Generator[Any, None, None]:
     """ Convert items yielded by ``iterable`` into JSON objects and yield them
 
-    ``load_json`` fetches items from the underlying
+    This function fetches items from the underlying
     iterable. The items are expected to be ``bytes``, ``str``, or ``bytearry``,
-    and contain one JSON-encoded object. ``load_json``
-    will convert each item into a JSON-object, by feeding it into
+    and contain one JSON-encoded object. Items
+    are converted into a JSON-object, by feeding them into
     ``json.loads``.
 
     On successful conversion to a JSON-object, ``load_json`` will yield the

--- a/datalad_next/itertools/reroute.py
+++ b/datalad_next/itertools/reroute.py
@@ -18,7 +18,7 @@ dont_process = object()
 
 def route_out(iterable: Iterable,
               data_store: list,
-              splitter: Callable[[Any], tuple[Any, Any | None]],
+              splitter: Callable[[Any], tuple[Any, Any]],
               ) -> Generator:
     """ Route data around the consumer of this iterable
 

--- a/datalad_next/itertools/reroute.py
+++ b/datalad_next/itertools/reroute.py
@@ -10,7 +10,7 @@ from typing import (
 )
 
 
-__all__ = ['dont_process', 'join_with_list', 'route_in', 'route_out']
+__all__ = ['dont_process', 'route_in', 'route_out']
 
 
 dont_process = object()
@@ -191,42 +191,3 @@ def route_in(iterable: Iterable,
         assert process_info[0] is False
         yield joiner(dont_process, process_info[1])
     del data_store[:]
-
-
-def join_with_list(processed_data: Any,
-                   stored_data: list
-                   ) -> list:
-    """ A standard joiner that works with splitter-functions that store a list
-
-        This joiner is used in combination with splitters that return a list as
-        second element of the result tuple, i.e. splitters that will store a
-        list in their data store.
-
-        :func:`join_with_list` adds ``processed_data`` as first element to the
-        list ``stored_data``. The extended list is then yielded by
-        :func:`route_in`.
-
-        Parameters
-        ----------
-        processed_data: Any
-            The data that was yielded by the underlying iterable of the
-            :func:`route_in`-call, if data was processed. If no data was
-            processed: ``datalad_next.itertools.dont_process``.
-        stored_data: list
-            The data that was stored in the data store provided at the
-            :func:`route_in`-call.
-
-        Returns
-        -------
-        list
-            If ``processed_data is datalad_next.itertools.dont_process``, the
-            result will be ``[None] + stored_data``. If ``processed_data`` is
-            any other object, the result will be equivalent to
-            ``[processed_data] + stored_data``.
-    """
-    if processed_data is dont_process:
-        return [None] + stored_data
-    if not isinstance(processed_data, list):
-        return [processed_data] + stored_data
-    processed_data.extend(stored_data)
-    return processed_data

--- a/datalad_next/itertools/reroute.py
+++ b/datalad_next/itertools/reroute.py
@@ -1,0 +1,232 @@
+""" Functions that allow to route data around upstream iterator """
+
+from __future__ import annotations
+
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Iterable,
+)
+
+
+__all__ = ['dont_process', 'join_with_list', 'route_in', 'route_out']
+
+
+dont_process = object()
+
+
+def route_out(iterable: Iterable,
+              data_store: list,
+              splitter: Callable[[Any], tuple[Any, Any | None]],
+              ) -> Generator:
+    """ Route data around the consumer of this iterable
+
+    :func:`route_out` allows its user to:
+
+     1. store data that is received from an iterable,
+     2. determine whether this data should be yielded to a consumer of
+        ``route_out``, by calling :func:`splitter`.
+
+    To determine which data is to be yielded to the consumer and which data
+    should only be stored but not yielded, :func:`route_out` calls
+    :func:`splitter`. :func:`splitter` is called for each element of the input
+    iterable, with the element as sole argument. The function should return a
+    tuple of two elements. The first element is the data that is to be
+    yielded to the consumer. The second element is the data that is to be
+    stored in the list ``data_store``. If the first element of the tuple is
+    ``datalad_next.itertools.dont_process``, no data is yielded to the
+    consumer.
+
+    :func:`route_in` can be used to combine data that was previously
+    stored by :func:`route_out` with the data that is yielded by
+    :func:`route_out` and with the data the was not processed, i.e. not yielded
+    by :func:`route_out`.
+
+    The elements yielded by :func:`route_in` will be in the same
+    order in which they were passed into :func:`route_out`, including the
+    elements that were not yielded by :func:`route_out` because :func:`splitter`
+    returned ``dont_process`` in the first element of the result-tuple.
+
+    The combination of the two functions :func:`route_out` and :func:`route_in`
+    can be used to "carry" additional data along with data that is processed by
+    iterators. And it can be used to route data around iterators that cannot
+    process certain data.
+
+    For example, a user has an iterator to divide all number in a list by the
+    number ``2``. The user wants the iterator to process all numbers in a list,
+    except from zeros, In this case :func:`route_out` and :func:`route_in` can
+    be used as follows:
+
+    .. code-block:: python
+
+        from math import nan
+        from datalad_next.itertools import route_out, route_in, dont_process
+
+        def splitter(data):
+            # if data == 0, return `dont_process` in the first element of the
+            # result tuple to indicate that route_out should not yield this
+            # element to its consumer
+            return (dont_process, [data]) if data == 0 else (data, [data])
+
+        def joiner(processed_data, stored_data):
+            #
+            return nan if processed_data is dont_process else processed_data
+
+        numbers = [0, 1, 0, 2, 0, 3, 0, 4]
+        store = list()
+        r = route_in(
+            map(
+                lambda x: x / 2.0,
+                route_out(
+                    numbers,
+                    store,
+                    splitter
+                )
+            ),
+            store,
+            joiner
+        )
+        print(list(r))
+
+    The example about will print ``[nan, 0.5, nan, 1.0, nan, 1.5, nan, 2.0]``.
+
+    Parameters
+    ----------
+    iterable: Iterable
+        The iterable that yields the input data
+    data_store: list
+        The list that is used to store the data that is routed out
+    splitter: Callable[[Any], tuple[Any, Any | None]]
+        The function that is used to determine which part of the input data,
+        if any, is to be yielded to the consumer and which data is to
+        be stored in the list ``data_store``. The function is called with each
+        The function is called for each element of
+        the input iterable with the element as sole argument. It should return a
+        tuple of two elements. If the first element is not
+        ``datalad_next.itertools.dont_process``, it is yielded to the consumer.
+        If the first element is ``datalad_next.itertools.dont_process``,
+        nothing is yielded to the consumer. The second element is stored in the
+        list ``data_store``.
+        The cardinality of ``data_store`` will be the same as the cardinality of
+        the input iterable.
+    """
+    for item in iterable:
+        data_to_process, data_to_store = splitter(item)
+        if data_to_process is dont_process:
+            data_store.append((False, data_to_store))
+        else:
+            data_store.append((True, data_to_store))
+            yield data_to_process
+
+def route_in(iterable: Iterable,
+             data_store: list,
+             joiner: Callable[[Any, Any], Any]
+             ) -> Generator:
+    """ Yield previously rerouted data to the consumer
+
+    This function is the counter-part to :func:`route_out`. It takes the iterable
+    ``iterable`` and a data store given in ``data_store`` and yields elements
+    in the same order in which :func:`route_out` received them from its
+    underlying iterable (using the same data store). This includes elements that
+    were not yielded by :func:`route_out`, but only stored.
+
+    :func:`route_in` uses  :func:`joiner`-function to determine how stored and
+    optionally processed data should be joined into a single element, which is
+    then yielded by :func:`route_in`.
+    :func:`route_in` calls :func:`joiner` with a 2-tuple. The first
+    element of the tuple is either ``dont_process`` or the next item from the
+    underlying iterator. The second element is the data
+    that was stored in the data store. :func:`joiner` should return a single
+    element, which will be yielded by :func:`route_in`.
+
+    This module provides a standard joiner-function: :func:`join_with_list`
+    that works with splitter-functions that return a list as second element of
+    the result tuple.
+
+    The cardinality of ``iterable`` must match the number of processed data
+    elements in the data store. The output cardinality of :func:`route_in` will
+    be the cardinality of the input iterable of the corresponding
+    :func:`route_out`-call. Given the following code:
+
+    .. code-block:: python
+
+        store_1 = list()
+        route_in(
+            some_generator(
+                route_out(input_iterable, store_1, splitter_1)
+            ),
+            store_1,
+            joiner_1
+        )
+
+    :func:`route_in` will yield the same number of elements as ``input_iterable``.
+    But, the number of elements processed by ``some_generator`` is determined by
+    the :func:`splitter_1` in :func:`route_out`, i.e. by the number of
+    :func:`splitter_1`-results that have don't have
+    ``datalad_next.itertools.don_process`` as first element.
+
+    Parameters
+    ----------
+    iterable: Iterable
+        The iterable that yields the input data.
+    data_store: list
+        The list from which the data that be routed is read.
+    joiner: Callable[[Any, Any], Any]
+        A function that determines how the data that is yielded by
+        ``iterable`` should be combined with the corresponding data from
+        ``data_store``, in order to yield the final result.
+        The first argument to ``joiner`` is the data that is yielded by
+        ``iterable``, or ``datalad_next.itertools.dont_process`` if no data
+        was processed in the corresponding step. The second argument is the
+        data that was stored in ``data_store`` in the corresponding step.
+    """
+    for element in iterable:
+        process_info = data_store.pop(0)
+        while not process_info[0]:
+            yield joiner(dont_process, process_info[1])
+            process_info = data_store.pop(0)
+        yield joiner(element, process_info[1])
+    for process_info in data_store:
+        assert process_info[0] is False
+        yield joiner(dont_process, process_info[1])
+    del data_store[:]
+
+
+def join_with_list(processed_data: Any,
+                   stored_data: list
+                   ) -> list:
+    """ A standard joiner that works with splitter-functions that store a list
+
+        This joiner is used in combination with splitters that return a list as
+        second element of the result tuple, i.e. splitters that will store a
+        list in their data store.
+
+        :func:`join_with_list` adds ``processed_data`` as first element to the
+        list ``stored_data``. The extended list is then yielded by
+        :func:`route_in`.
+
+        Parameters
+        ----------
+        processed_data: Any
+            The data that was yielded by the underlying iterable of the
+            :func:`route_in`-call, if data was processed. If no data was
+            processed: ``datalad_next.itertools.dont_process``.
+        stored_data: list
+            The data that was stored in the data store provided at the
+            :func:`route_in`-call.
+
+        Returns
+        -------
+        list
+            If ``processed_data is datalad_next.itertools.dont_process``, the
+            result will be ``[None] + stored_data``. If ``processed_data`` is
+            any other object, the result will be equivalent to
+            ``[processed_data] + stored_data``.
+    """
+    if processed_data is dont_process:
+        return [None] + stored_data
+    if not isinstance(processed_data, list):
+        return [processed_data] + stored_data
+    processed_data.extend(stored_data)
+    return processed_data

--- a/datalad_next/itertools/reroute.py
+++ b/datalad_next/itertools/reroute.py
@@ -184,11 +184,20 @@ def route_in(iterable: Iterable,
     """
     for element in iterable:
         process_info = data_store.pop(0)
+        # route_out() translated StoreOnly to False, now we translate it back
+        # and yield until we find an item that was processed
         while not process_info[0]:
             yield joiner(StoreOnly, process_info[1])
             process_info = data_store.pop(0)
         yield joiner(element, process_info[1])
+    # we reached the end of the incoming iterable.
+    # this means that we must not find any remaining items in `data_store`
+    # that indicate that they would have a corresponding item in the
+    # iterable (process_info[0] == True)
     for process_info in data_store:
-        assert process_info[0] is False
+        assert process_info[0] is False, \
+            "iterable did not yield matching item for route-in item, cardinality mismatch?"
         yield joiner(StoreOnly, process_info[1])
+    # rather than pop() in the last loop, wejust yielded from the list
+    # now this information is no longer needed
     del data_store[:]

--- a/datalad_next/itertools/reroute.py
+++ b/datalad_next/itertools/reroute.py
@@ -30,8 +30,8 @@ def route_out(iterable: Iterable,
 
     To determine which data is to be yielded to the consumer and which data
     should only be stored but not yielded, :func:`route_out` calls
-    :func:`splitter`. :func:`splitter` is called for each element of the input
-    iterable, with the element as sole argument. The function should return a
+    :func:`splitter`. :func:`splitter` is called for each item of the input
+    iterable, with the item as sole argument. The function should return a
     tuple of two elements. The first element is the data that is to be
     yielded to the consumer. The second element is the data that is to be
     stored in the list ``data_store``. If the first element of the tuple is
@@ -43,9 +43,9 @@ def route_out(iterable: Iterable,
     :func:`route_out` and with the data the was not processed, i.e. not yielded
     by :func:`route_out`.
 
-    The elements yielded by :func:`route_in` will be in the same
+    The items yielded by :func:`route_in` will be in the same
     order in which they were passed into :func:`route_out`, including the
-    elements that were not yielded by :func:`route_out` because :func:`splitter`
+    items that were not yielded by :func:`route_out` because :func:`splitter`
     returned ``dont_process`` in the first element of the result-tuple.
 
     The combination of the two functions :func:`route_out` and :func:`route_in`
@@ -53,33 +53,33 @@ def route_out(iterable: Iterable,
     iterators. And it can be used to route data around iterators that cannot
     process certain data.
 
-    For example, a user has an iterator to divide all number in a list by the
-    number ``2``. The user wants the iterator to process all numbers in a list,
-    except from zeros, In this case :func:`route_out` and :func:`route_in` can
-    be used as follows:
+    For example, a user has an iterator to divide the number ``2`` by all
+    numbers in a list. The user wants the iterator to process all numbers in a
+    divisor list, except from zeros, In this case :func:`route_out` and
+    :func:`route_in` can be used as follows:
 
     .. code-block:: python
 
         from math import nan
         from datalad_next.itertools import route_out, route_in, dont_process
 
-        def splitter(data):
-            # if data == 0, return `dont_process` in the first element of the
+        def splitter(divisor):
+            # if divisor == 0, return `dont_process` in the first element of the
             # result tuple to indicate that route_out should not yield this
             # element to its consumer
-            return (dont_process, data) if data == 0 else (data, data)
+            return (dont_process, divisor) if divisor == 0 else (divisor, divisor)
 
         def joiner(processed_data, stored_data):
             #
             return nan if processed_data is dont_process else processed_data
 
-        numbers = [0, 1, 0, 2, 0, 3, 0, 4]
+        divisors = [0, 1, 0, 2, 0, 3, 0, 4]
         store = list()
         r = route_in(
             map(
                 lambda x: 2.0 / x,
                 route_out(
-                    numbers,
+                    divisors,
                     store,
                     splitter
                 )
@@ -100,9 +100,9 @@ def route_out(iterable: Iterable,
     splitter: Callable[[Any], tuple[Any, Any | None]]
         The function that is used to determine which part of the input data,
         if any, is to be yielded to the consumer and which data is to
-        be stored in the list ``data_store``. The function is called with each
-        The function is called for each element of
-        the input iterable with the element as sole argument. It should return a
+        be stored in the list ``data_store``.
+        The function is called for each item of
+        the input iterable with the item as sole argument. It should return a
         tuple of two elements. If the first element is not
         ``datalad_next.itertools.dont_process``, it is yielded to the consumer.
         If the first element is ``datalad_next.itertools.dont_process``,
@@ -126,19 +126,19 @@ def route_in(iterable: Iterable,
     """ Yield previously rerouted data to the consumer
 
     This function is the counter-part to :func:`route_out`. It takes the iterable
-    ``iterable`` and a data store given in ``data_store`` and yields elements
+    ``iterable`` and a data store given in ``data_store`` and yields items
     in the same order in which :func:`route_out` received them from its
-    underlying iterable (using the same data store). This includes elements that
+    underlying iterable (using the same data store). This includes items that
     were not yielded by :func:`route_out`, but only stored.
 
-    :func:`route_in` uses  :func:`joiner`-function to determine how stored and
-    optionally processed data should be joined into a single element, which is
+    :func:`route_in` uses :func:`joiner`-function to determine how stored and
+    optionally processed data should be joined into a single item, which is
     then yielded by :func:`route_in`.
     :func:`route_in` calls :func:`joiner` with a 2-tuple. The first
     element of the tuple is either ``dont_process`` or the next item from the
     underlying iterator. The second element is the data
-    that was stored in the data store. :func:`joiner` should return a single
-    element, which will be yielded by :func:`route_in`.
+    that was stored in the data store. The result of :func:`joiner` which will
+    be yielded by :func:`route_in`.
 
     This module provides a standard joiner-function: :func:`join_with_list`
     that works with splitter-functions that return a list as second element of
@@ -171,12 +171,12 @@ def route_in(iterable: Iterable,
     iterable: Iterable
         The iterable that yields the input data.
     data_store: list
-        The list from which the data that be routed is read.
+        The list from which the data that is to be "routed in" is read.
     joiner: Callable[[Any, Any], Any]
-        A function that determines how the data that is yielded by
+        A function that determines how the items that are yielded by
         ``iterable`` should be combined with the corresponding data from
         ``data_store``, in order to yield the final result.
-        The first argument to ``joiner`` is the data that is yielded by
+        The first argument to ``joiner`` is the item that is yielded by
         ``iterable``, or ``datalad_next.itertools.dont_process`` if no data
         was processed in the corresponding step. The second argument is the
         data that was stored in ``data_store`` in the corresponding step.

--- a/datalad_next/itertools/reroute.py
+++ b/datalad_next/itertools/reroute.py
@@ -67,7 +67,7 @@ def route_out(iterable: Iterable,
             # if data == 0, return `dont_process` in the first element of the
             # result tuple to indicate that route_out should not yield this
             # element to its consumer
-            return (dont_process, [data]) if data == 0 else (data, [data])
+            return (dont_process, data) if data == 0 else (data, data)
 
         def joiner(processed_data, stored_data):
             #
@@ -77,7 +77,7 @@ def route_out(iterable: Iterable,
         store = list()
         r = route_in(
             map(
-                lambda x: x / 2.0,
+                lambda x: 2.0 / x,
                 route_out(
                     numbers,
                     store,
@@ -89,7 +89,7 @@ def route_out(iterable: Iterable,
         )
         print(list(r))
 
-    The example about will print ``[nan, 0.5, nan, 1.0, nan, 1.5, nan, 2.0]``.
+    The example about will print ``[nan, 2.0, nan, 1.0, nan, 0.6666666666666666, nan, 0.5]``.
 
     Parameters
     ----------

--- a/datalad_next/itertools/tests/test_decode_bytes.py
+++ b/datalad_next/itertools/tests/test_decode_bytes.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import sys
-import timeit
-
 import pytest
 
 from ..decode_bytes import decode_bytes
@@ -26,23 +23,12 @@ def test_unfixable_error_decoding():
     assert ''.join(r) == 'abc\\xc3deföghi'
 
 
-def test_undecodable_byte():
+def test_single_undecodable_byte():
     # check that a single undecodable byte is handled properly
     r = tuple(decode_bytes([b'\xc3']))
     assert ''.join(r) == '\\xc3'
     with pytest.raises(UnicodeDecodeError):
         tuple(decode_bytes([b'\xc3'], backslash_replace=False))
-
-
-def test_performance():
-    encoded = 'ö'.encode('utf-8')
-    part_1, part_2 = encoded[:1], encoded[1:]
-
-    # check that incomplete encodings are caught
-    iterable = [b'abc' + part_1 + b'def' + part_1, part_2 + b'ghi']
-
-    d1 = timeit.timeit(lambda: tuple(decode_bytes(iterable)), number=1000000)
-    print(d1, file=sys.stderr)
 
 
 def test_no_empty_strings():

--- a/datalad_next/itertools/tests/test_load_json.py
+++ b/datalad_next/itertools/tests/test_load_json.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from json.decoder import JSONDecodeError
+
+import pytest
+
+from ..load_json import (
+    load_json,
+    load_json_with_flag,
+)
+from ..decode_bytes import decode_bytes
+from ..itemize import itemize
+
+
+json_object = {
+    'list1': [
+        'a', 'bäöl', 1
+    ],
+    'dict1': {
+        'x': 123,
+        'y': 234,
+        'z': 456,
+    }
+}
+
+
+correct_json = b'\n'.join(
+    json.dumps(x).encode()
+    for x in [json_object] * 10
+) + b'\n'
+
+correct_chunks = [
+    correct_json[i:i + 10]
+    for i in range(0, len(correct_json) + 10, 10)
+]
+
+faulty_json = correct_json.replace(b'}\n', b'\n')
+faulty_chunks = [
+    faulty_json[i:i + 10]
+    for i in range(0, len(correct_json) + 10, 10)
+]
+
+
+def test_load_json_on_decoded_bytes():
+    assert all(x == json_object for x in load_json(
+        decode_bytes(itemize(correct_chunks, b'\n'))))
+    with pytest.raises(JSONDecodeError):
+        list(load_json(decode_bytes(itemize(faulty_chunks, b'\n'))))
+
+
+def test_load_json_with_flag():
+    assert all(
+        obj == json_object and success is True
+        for (obj, success)
+        in load_json_with_flag(decode_bytes(itemize(correct_chunks, b'\n')))
+    )
+    assert all(
+        isinstance(exc, JSONDecodeError) and success is False
+        for (exc, success)
+        in load_json_with_flag(decode_bytes(itemize(faulty_chunks, b'\n')))
+    )

--- a/datalad_next/itertools/tests/test_reroute.py
+++ b/datalad_next/itertools/tests/test_reroute.py
@@ -4,7 +4,7 @@ from more_itertools import intersperse
 from ..reroute import (
     route_in,
     route_out,
-    dont_process
+    StoreOnly
 )
 
 
@@ -19,14 +19,14 @@ def test_route_around():
             route_out(
                 intersperse(0, range(2, 20)),
                 store,
-                lambda divisor: (dont_process, [divisor])
+                lambda divisor: (StoreOnly, [divisor])
                                 if divisor == 0
                                 else (divisor, None)
             )
         ),
         store,
         lambda processed_data, stored_data: processed_data
-                                            if processed_data is not dont_process
+                                            if processed_data is not StoreOnly
                                             else 'divisor is 0'
     )
     # The result should be a list in which every odd element consists of a list
@@ -48,7 +48,7 @@ def test_route_no_processing():
             route_out(
                 range(10),
                 store,
-                lambda x: (dont_process, x)
+                lambda x: (StoreOnly, x)
             )
         ),
         store,

--- a/datalad_next/itertools/tests/test_reroute.py
+++ b/datalad_next/itertools/tests/test_reroute.py
@@ -1,0 +1,54 @@
+
+from more_itertools import intersperse
+
+from ..reroute import (
+    join_with_list,
+    route_in,
+    route_out,
+    dont_process
+)
+
+
+def test_route_around():
+    """Test routing of data around a consumer"""
+
+    # Route 0 around `lambda x: x / 2.0`.
+    store = list()
+    r = route_in(
+        map(
+            lambda x: x / 2.0,
+            route_out(
+                intersperse(0, range(2, 20)),
+                store,
+                lambda x: (dont_process, [x]) if x == 0 else (x, [x])
+            )
+        ),
+        store,
+        join_with_list
+    )
+    # The result should be a list in which every odd element consists of a list
+    # with the elements `[n / 2.0, n]` and every even element consists of a list
+    # with `[dont_process, 0]`, because the `0`s were routed around the
+    # consumer, i.e. around `lambda x: x / 2.0`.
+    assert list(r) == list(
+        intersperse([None, 0], map(lambda x: [x / 2.0, x], range(2, 20)))
+    )
+
+
+def test_route_no_processing():
+    """Test routing of data without processing"""
+
+    store = list()
+    r = route_in(
+        map(
+            lambda x: x,
+            route_out(
+                range(10),
+                store,
+                lambda x: (dont_process, x)
+            )
+        ),
+        store,
+        lambda x, y: y
+    )
+    assert list(r) == list(range(10))

--- a/datalad_next/itertools/tests/test_reroute.py
+++ b/datalad_next/itertools/tests/test_reroute.py
@@ -2,7 +2,6 @@
 from more_itertools import intersperse
 
 from ..reroute import (
-    join_with_list,
     route_in,
     route_out,
     dont_process
@@ -12,26 +11,30 @@ from ..reroute import (
 def test_route_around():
     """Test routing of data around a consumer"""
 
-    # Route 0 around `lambda x: x / 2.0`.
+    # Route 0 around `lambda x: 2.0 / x.
     store = list()
     r = route_in(
         map(
-            lambda x: x / 2.0,
+            lambda divisor: 2.0 / divisor,
             route_out(
                 intersperse(0, range(2, 20)),
                 store,
-                lambda x: (dont_process, [x]) if x == 0 else (x, [x])
+                lambda divisor: (dont_process, [divisor])
+                                if divisor == 0
+                                else (divisor, None)
             )
         ),
         store,
-        join_with_list
+        lambda processed_data, stored_data: processed_data
+                                            if processed_data is not dont_process
+                                            else 'divisor is 0'
     )
     # The result should be a list in which every odd element consists of a list
     # with the elements `[n / 2.0, n]` and every even element consists of a list
     # with `[dont_process, 0]`, because the `0`s were routed around the
     # consumer, i.e. around `lambda x: x / 2.0`.
     assert list(r) == list(
-        intersperse([None, 0], map(lambda x: [x / 2.0, x], range(2, 20)))
+        intersperse('divisor is 0', map(lambda x: 2.0 / x, range(2, 20)))
     )
 
 


### PR DESCRIPTION
This is moving PR https://github.com/mih/datalad-next/pull/3 here, to get it tested properly. Below is the original description by @christian-monch 

It includes (sits on top of) https://github.com/datalad/datalad-next/pull/538 (merged now)

TODO

- [x] Rebase on #552
- [x] Add documentation
- [x] Make `keep_ends=True str.strip()` combo obsolete (and ease debugging why @mih cannot do it, ideally)
- [x] `fp=True` currently only does meaningful things for annexed files, but it should also act properly for any other file. This aspect of the functionality is still undertested.

----

This PR adds an implementation of `iter_annexworktree` that is based on `iterable_subprocesses` and the ideas laid out in issue https://github.com/datalad/datalad-next/issues/537.

This PR included a collection of data processors that are basically generator-wrapper.

The PR also modifies `iter_gitworktree` to use `iterable_subprocesses` instead of the datalad-core runner.

The current implementation of `iter_annexworktree` iterates over a dataset with 33k annex files in less than 5 seconds on my machine.
