### PR TITLE
Add `bufsize`-parameter to `iter subproc` and to `iterable_subprocess.__init__`

### DIFF
--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -59,6 +59,9 @@ from datalad_next.iter_collections.gitworktree import (
     GitWorktreeFileSystemItem,
     iter_gitworktree,
 )
+from datalad_next.iter_collections.annexworktree import (
+    iter_annexworktree,
+)
 
 
 lgr = getLogger('datalad.local.ls_file_collection')
@@ -72,6 +75,7 @@ _supported_collection_types = (
     'directory',
     'tarfile',
     'gitworktree',
+    'annexworktree',
 )
 
 
@@ -110,7 +114,7 @@ class LsFileCollectionParamValidator(EnsureCommandParameterization):
         hash = kwargs['hash']
         iter_fx = None
         iter_kwargs = None
-        if type in ('directory', 'tarfile', 'gitworktree'):
+        if type in ('directory', 'tarfile', 'gitworktree', 'annexworktree'):
             if not isinstance(collection, Path):
                 self.raise_for(
                     kwargs,
@@ -131,6 +135,9 @@ class LsFileCollectionParamValidator(EnsureCommandParameterization):
         elif type == 'gitworktree':
             iter_fx = iter_gitworktree
             item2res = gitworktreeitem_to_dict
+        elif type == 'annexworktree':
+            iter_fx = iter_annexworktree
+            item2res = annexworktreeitem_to_dict
         else:
             raise RuntimeError(
                 'unhandled collection-type: this is a defect, please report.')
@@ -202,6 +209,17 @@ def gitworktreeitem_to_dict(item, hash) -> Dict:
 
     if gittype is not None:
         d['gittype'] = gittype
+    return d
+
+
+def annexworktreeitem_to_dict(item, hash) -> Dict:
+    d = gitworktreeitem_to_dict(item, hash)
+    if item.annexkey:
+        d['annexkey'] = item.annexkey
+
+    if item.annexsize:
+        d['annexsize'] = item.annexsize
+
     return d
 
 

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -1,0 +1,123 @@
+"""Report on the content of a Git-annex repository worktree
+
+The main functionality is provided by the :func:`iter_annexworktree()`
+function.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import (
+    Path,
+    PurePath,
+    PurePosixPath,
+)
+from typing import Generator
+
+from more_itertools import intersperse
+
+from .gitworktree import (
+    GitWorktreeItem,
+    GitWorktreeFileSystemItem,
+    iter_gitworktree
+)
+from datalad_next.iterable_subprocess.iterable_subprocess import iterable_subprocess
+from datalad_next.itertools import (
+    itemize,
+    join_with_list,
+    load_json,
+    route_in,
+    route_out,
+)
+
+
+lgr = logging.getLogger('datalad.ext.next.iter_collections.annexworktree')
+
+
+# TODO Could be `StrEnum`, came with PY3.11
+class AnnexTreeItemType(Enum):
+    """Enumeration of item types of Git trees
+    """
+    file = 'file'
+    executablefile = 'executablefile'
+    symlink = 'symlink'
+    directory = 'directory'
+    submodule = 'submodule'
+
+
+@dataclass
+class AnnexWorktreeItem(GitWorktreeItem):
+    annexkey: str | None = None
+    annexsize: int | None = None
+    annexobjpath: PurePath | None = None
+
+
+@dataclass
+class AnnexWorktreeFileSystemItem(GitWorktreeFileSystemItem):
+    annexkey: str | None = None
+    annexsize: int | None = None
+
+
+def iter_annexworktree(
+        path: Path,
+        *,
+        untracked: str | None = 'all',
+        link_target: bool = False,
+        fp: bool = False,
+) -> Generator[AnnexWorktreeItem | AnnexWorktreeFileSystemItem, None, None]:
+
+    glsf = iter_gitworktree(
+        path,
+        untracked=untracked,
+        link_target=link_target,
+        fp=fp
+    )
+
+    with \
+            iterable_subprocess(
+                # we get the annex key for any filename (or empty if not annexed)
+                ['git', '-C', str(path), 'annex', 'find', '--anything', '--format=\${key}\n', '--batch'],
+                # intersperse items with newlines to trigger a batch run
+                # this avoids string operations to append newlines to items
+                intersperse(
+                    b'\n',
+                    # store all output of the git ls-find in the gitfileinfo
+                    # store
+                    route_out(
+                        glsf,
+                        'git_fileinfo_store',
+                        lambda data: (str(data.name).encode(), [data])
+                    )
+                ),
+            ) as gaf, \
+            iterable_subprocess(
+                # get the key properties JSON-lines style
+                ['git', '-C', str(path), 'annex', 'examinekey', '--json', '--batch'],
+                # process all non-empty keys and store them in the key store,
+                # skip processing of empty keys and store an ignored value in
+                # the key store
+                route_out(
+                    itemize(gaf, sep=b'\n', keep_ends=True),
+                    'key_store',
+                    lambda data: (None, [None]) if data == b'\n' else (data, [data])
+                )
+            ) as gek:
+
+        for item in route_in(
+                route_in(
+                    load_json(itemize(gek, sep=b'\n')),
+                    'key_store',
+                    join_with_list,
+                ),
+                'git_fileinfo_store',
+                join_with_list,
+        ):
+            yield AnnexWorktreeItem(
+                name=item[2].name,
+                gitsha=item[2].gitsha,
+                gittype=item[2].gittype,
+                annexkey=item[1].decode().strip() if item[1] else None,
+                annexsize=int(item[0]['bytesize']) if item[0] else None,
+                annexobjpath=PurePath(PurePosixPath(str(item[0]['objectpath']))) if item[0] else None,
+            )

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -262,7 +262,7 @@ def _git_ls_files(path, *args):
         yield from decode_bytes(
             itemize(
                 r,
-                separator=b'\0',
+                sep=b'\0',
                 keep_ends=False,
             )
         )

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -1,0 +1,84 @@
+from pathlib import (
+    PurePath,
+)
+
+from datalad import cfg as dlcfg
+
+from datalad_next.datasets import Dataset
+
+from ..annexworktree import (
+    iter_annexworktree,
+)
+
+
+def _mkds(tmp_path_factory, monkeypatch, cfg_overrides):
+    with monkeypatch.context() as m:
+        for k, v in cfg_overrides.items():
+            m.setitem(dlcfg.overrides, k, v)
+        dlcfg.reload()
+        ds = Dataset(tmp_path_factory.mktemp('ds')).create(
+            result_renderer='disabled')
+    dlcfg.reload()
+    return ds
+
+
+def _dotests(ds):
+    test_file_content = 'test_file'
+    test_file = ds.pathobj / 'annexed' / 'subdir' / 'file1.txt'
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(test_file_content)
+    # we create an additional file where the content will be dropped
+    # to test behavior on unavailable annex key
+    droptest_content = 'somethingdropped'
+    droptest_file = ds.pathobj / 'annexed' / 'dropped.txt'
+    droptest_file.write_text(droptest_content)
+    ds.save(result_renderer='disabled')
+    ds.drop(droptest_file, reckless='availability',
+            result_renderer='disabled')
+
+    # get results for the annexed files
+    query_path = ds.pathobj / 'annexed'
+    res = list(iter_annexworktree(
+        query_path, untracked=None, link_target=True,
+    ))
+    assert len(res) == 2
+    #
+    # pick the present annex file to start
+    r = [r for r in res if r.name.name == 'file1.txt'][0]
+    assert r.name == PurePath('subdir', 'file1.txt')
+    # we cannot check gitsha and symlink content for identity, it will change
+    # depending on the tuning
+    # we cannot check the item type, because it will vary across repository
+    # modes (e.g., adjusted unlocked)
+    assert r.annexsize == len(test_file_content)
+    assert r.annexkey == 'MD5E-s9--37b87ee8c563af911dcc0f949826b1c9.txt'
+    # with `link_target=True` we get an objpath that is relative to the
+    # query path, and we find the actual key file there
+    assert (query_path / r.annexobjpath).read_text() == test_file_content
+    #
+    # now pick the dropped annex file
+    r = [r for r in res if r.name.name == 'dropped.txt'][0]
+    assert r.name == PurePath('dropped.txt')
+    # we get basic info regardless of availability
+    assert r.annexsize == len(droptest_content)
+    assert r.annexkey == 'MD5E-s16--770a06889bc88f8743d1ed9a1977ff7b.txt'
+    # even with an absent key file, we get its would-be location,
+    # and it is relative to the query path
+    assert r.annexobjpath.parts[:2] == ('..', '.git')
+
+
+def test_iter_annexworktree(tmp_path_factory, monkeypatch):
+    ds = _mkds(tmp_path_factory, monkeypatch, {})
+    _dotests(ds)
+
+
+def test_iter_annexworktree_tuned(tmp_path_factory, monkeypatch):
+    # same as test_file_content(), but with a "tuned" annexed that
+    # no longer matches the traditional setup.
+    # we need to be able to cope with that too
+    ds = _mkds(tmp_path_factory, monkeypatch, {
+        'annex.tune.objecthash1': 'true',
+        'annex.tune.branchhash1': 'true',
+        'annex.tune.objecthashlower': 'true',
+    })
+    _dotests(ds)

--- a/datalad_next/iterable_subprocess/iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/iterable_subprocess.py
@@ -5,7 +5,7 @@ from threading import Thread
 
 
 @contextmanager
-def iterable_subprocess(program, input_chunks, chunk_size=65536):
+def iterable_subprocess(program, input_chunks, chunk_size=65536, bufsize=-1):
     # This context starts a thread that populates the subprocess's standard input. It
     # also starts a threads that reads the process's standard error. Otherwise we risk
     # a deadlock - there is no output because the process is waiting for more input.
@@ -126,7 +126,7 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
     try:
 
         with \
-                Popen(program, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc, \
+                Popen(program, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=bufsize) as proc, \
                 thread(keep_only_most_recent, proc.stderr, stderr_deque) as (start_t_stderr, join_t_stderr), \
                 thread(input_to, proc.stdin) as (start_t_stdin, join_t_stdin):
 

--- a/datalad_next/itertools/__init__.py
+++ b/datalad_next/itertools/__init__.py
@@ -1,13 +1,129 @@
 """Various iterators, e.g., for subprocess pipelining and output processing
 
+This module provides iterators that are useful when combining
+iterable_subprocesses and for processing of subprocess output.
+
 .. currentmodule:: datalad_next.itertools
 .. autosummary::
    :toctree: generated
 
     decode_bytes
     itemize
+    load_json
+    load_json_with_flag
+    align_pattern
+    route_out
+    route_in
+    join_with_list
+
+
+Examples
+========
+
+Usage of ``route_out`` and ``route_in``
+---------------------------------------
+
+``route_out`` allows its user to:
+
+ 1. store data it receives from an iterable, and
+ 2. decide whether this data should be yielded to a consumer of ``route_out``.
+
+``route_in`` allows its user to combine data it receives from an iterable with
+data that was previously stored by ``route_out``. The user of ``route_in`` will
+receive stored data in the same order as it was stored by ``route_out``,
+including data that was not yielded by ``route_out`` but only stored.
+
+The combination of the two functions can be used to "carry" additional data
+along with data that is processed by iterators. And it can be used to route
+data around iterators that cannot process certain data.
+
+For example, a user has an iterator to divide all number in a list by 2. The
+user wants the iterator tp process all number in a list, except from zeros,
+In this case ``route_out`` and ``route_in`` can be used as follows:
+
+.. code-block:: python
+
+    from math import nan
+    from datalad_next.itertools import route_out, route_in
+
+    def splitter(data):
+        # if data == 0, return None in the first element of the result tuple
+        # to indicate that route_out should not yield anything to the consumer
+        return (None, [data]) if data == 0 else (data / 2.0, [data])
+
+    def joiner(processed_data, stored_data):
+        return nan if processed_data is None else processed_data
+
+    numbers = [0, 1, 0, 2, 0, 3, 0, 4]
+    r = route_in(
+        map(
+            lambda x: x / 2.0,
+            route_out(
+                numbers,
+                'zeros',
+                splitter
+            )
+        ),
+        'zeros',
+        joiner
+    )
+    print(list(r))
+
+The example about will print ``[nan, 0.25, nan, 0.5, nan, 0.75, nan, 1.0]``.
+
+The names that are used to share data should are used inside a ``route_in``,
+``route_out`` enclosure. For example, the following code snippet would not
+lead to a collision of names:
+
+.. code-block:: python
+
+    route_in(
+        iterator_1(route_out(input_iterable_1, 'storage', splitter),
+        'storage'
+        joiner
+    )
+    route_in(
+        iterator_2(route_out(input_iterable_2, 'storage', splitter),
+        'storage'
+        joiner
+    )
+
+In contrast to that, the following code would lead to a collision of the name
+``storage``, because it is used in nested ``route_out``- ``route_in``-calls
+
+.. code-block:: python
+
+    route_in(
+        iterator_2(
+            route_in(
+                iterator_1(
+                    route_out(
+                        route_out(input_iterable, 'storage', splitter_1),
+                        'storage',
+                        splitter_2
+                    )
+                )
+                'storage',
+                joiner_1
+            )
+        )
+        'storage',
+        joiner_2
+    )
+
 """
 
 
+from .align_pattern import align_pattern
 from .decode_bytes import decode_bytes
 from .itemize import itemize
+from .load_json import (
+    load_json,
+    load_json_with_flag,
+)
+from .decode_bytes import decode_bytes
+from .reroute import (
+    join_with_list,
+    route_in,
+    route_out,
+)

--- a/datalad_next/itertools/align_pattern.py
+++ b/datalad_next/itertools/align_pattern.py
@@ -1,0 +1,83 @@
+"""
+ Function to ensure that a pattern is completely contained in single chunks,
+ if it is present in the input chunks.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    Generator,
+    Iterable,
+)
+
+
+def align_pattern(iterable: Iterable,
+                  pattern: str | bytes
+                  ) -> Generator[str | bytes, None, None]:
+    """ Yield data chunks that contain a complete pattern, if it is present
+
+    This function ensures that a given data pattern (if it exists in the data
+    chunks) is either completely contained in a chunk or not in the chunk. That
+    means the processor ensures that all data chunks have at least the length of
+    the data pattern and that they do not end with a prefix of the data pattern.
+
+    In the context of this function, a ``pattern`` is either a string or a
+    bytestring. The ``pattern`` is compared verbatim to the content in the data
+    chunks, i.e. no parsing of the ``pattern`` is performed and no regular
+    expressions or wildcards are supported.
+
+    As a result, a simple `pattern in data_chunk` test is sufficient to
+    determine whether a pattern appears in the data stream.
+
+    ``align-pattern`` guarantees:
+
+    1. All chunks have at minimum the size of the pattern (unless the complete
+       input size is smaller than the size of the pattern).
+    2. If a complete pattern exists, it will be contained completely within a
+       single chunk, i.e. it will NOT be the case that a prefix of the pattern
+       is at the end of a chunk, and the rest of the pattern in the beginning
+       of the next chunk.
+
+    The pattern might be present multiple times in a data chunk.
+
+    Parameters
+    ----------
+    iterable: Iterable
+        An iterable that yields data chunks
+    pattern: str | bytes
+        The pattern that should be contained in the chunks
+
+    Yields
+    -------
+    str | bytes
+        data chunks that have at least the size of the pattern and do not end
+        with a prefix of the pattern. Note that a data chunk might contain the
+        pattern multiple times.
+    """
+
+    def ends_with_pattern_prefix(data: str | bytes,
+                                 pattern: str | bytes
+                                 ) -> bool:
+        """ Check whether the chunk ends with a prefix of the pattern """
+        for index in range(len(pattern) - 1, 0, -1):
+            if data[-index:] == pattern[:index]:
+                return True
+        return False
+
+    # Join data chunks until they are sufficiently long to contain the pattern,
+    # i.e. have at least size: `len(pattern)`. Continue joining, if the chunk
+    # ends with a prefix of the pattern.
+    current_chunk = None
+    for data_chunk in iterable:
+        # get the type of current_chunk from the type of this data_chunk
+        if current_chunk is None:
+            current_chunk = data_chunk
+        else:
+            current_chunk += data_chunk
+        if len(current_chunk) >= len(pattern) \
+                and not ends_with_pattern_prefix(current_chunk, pattern):
+            yield current_chunk
+            current_chunk = None
+
+    if current_chunk is not None:
+        yield current_chunk

--- a/datalad_next/itertools/decode_bytes.py
+++ b/datalad_next/itertools/decode_bytes.py
@@ -1,4 +1,4 @@
-"""Iterator that decodes bytes into strings"""
+""" Function that yields strings decoded from chunks of bytes """
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ def decode_bytes(
     Parameters
     ----------
     iterable: Iterable[bytes]
-        Iterable that yields bytes that should be decoded.
+        Iterable that yields bytes that should be decoded
     encoding: str (default: ``'utf-8'``)
         Encoding to be used for decoding.
     backslash_replace: bool (default: ``True``)

--- a/datalad_next/itertools/itemize.py
+++ b/datalad_next/itertools/itemize.py
@@ -1,4 +1,4 @@
-""" Generator the emits only complete lines """
+""" Function that yields only complete lines built from its input """
 
 from __future__ import annotations
 
@@ -13,20 +13,21 @@ __all__ = ['itemize']
 
 def itemize(
     iterable: Iterable[bytes | str],
-    separator: str | bytes | None = None,
+    sep: str | bytes | None = None,
     keep_ends: bool = False,
 ) -> Generator[bytes | str, None, None]:
-    """ Generator that emits only complete items from chunks of an iterable
+    """ Function that only yields complete items, assembled from an iterable
 
-    This generator consumes chunks from an iterable and yields items defined by
+    This function consumes chunks from an iterable and yields items defined by
     a separator. An item might span multiple input chunks.
 
-    Items are defined by a ``separator``. If ``separator`` is ``None``, the
-    line-separators built into `str.plitlines` are used.
+    Items are defined by a separator given in ``sep``. If ``separator`` is
+    ``None``, the line-separators built into `splitlines` are used, and each
+    yielded item will be a line.
 
     The generator works on string or byte chunks, depending on the type of the
     first element in ``iterable``. During its runtime, the type of the elements
-    in ``iterable`` must not change. If ``separator`` is not `None`, its type
+    in ``iterable`` must not change. If ``sep`` is not `None`, its type
     must match the type of the elements in ``iterable``.
 
     The complexity of itemization without a defined separator is higher than
@@ -44,7 +45,7 @@ def itemize(
     ----------
     iterable: Iterable[bytes | str]
         The iterable that yields the input data
-    separator: str | bytes | None
+    sep: str | bytes | None
         The separator that defines items. If ``None``, the items are
         determined by the line-separators that are built into `splitlines`.
     keep_ends: bool
@@ -56,20 +57,20 @@ def itemize(
     ------
     bytes | str
         The items determined from the input iterable. The type of the yielded
-        lines depends on the type of the first element in ``iterable``.
+        items depends on the type of the first element in ``iterable``.
     """
-    if separator is None:
+    if sep is None:
         yield from _split_lines(iterable, keep_ends=keep_ends)
     else:
-        yield from _split_lines_with_separator(
+        yield from _split_items_with_separator(
             iterable,
-            separator=separator,
+            sep=sep,
             keep_ends=keep_ends,
         )
 
 
-def _split_lines_with_separator(iterable: Iterable[bytes | str],
-                                separator: str | bytes,
+def _split_items_with_separator(iterable: Iterable[bytes | str],
+                                sep: str | bytes,
                                 keep_ends: bool = False,
                                 ) -> Generator[bytes | str, None, None]:
     assembled = None
@@ -78,20 +79,20 @@ def _split_lines_with_separator(iterable: Iterable[bytes | str],
             assembled = chunk
         else:
             assembled += chunk
-        lines = assembled.split(sep=separator)
-        if len(lines) == 1:
+        items = assembled.split(sep=sep)
+        if len(items) == 1:
             continue
 
-        if assembled.endswith(separator):
+        if assembled.endswith(sep):
             assembled = None
         else:
-            assembled = lines[-1]
-        lines.pop(-1)
+            assembled = items[-1]
+        items.pop(-1)
         if keep_ends:
-            for line in lines:
-                yield line + separator
+            for item in items:
+                yield item + sep
         else:
-            yield from lines
+            yield from items
 
     if assembled:
         yield assembled

--- a/datalad_next/itertools/load_json.py
+++ b/datalad_next/itertools/load_json.py
@@ -1,0 +1,75 @@
+""" Function that yields JSON objects converted from input chunks """
+
+from __future__ import annotations
+
+import json
+from typing import (
+    Any,
+    Generator,
+    Iterable,
+)
+
+
+__all__ = ['load_json', 'load_json_with_flag']
+
+
+def load_json(iterable: Iterable[bytes | str],
+              ) -> Generator[Any, None, None]:
+    """ Convert items yielded by ``iterable`` into JSON objects and yield them
+
+    The items should be correct JSON-strings (or bytestrings). Incorrect JSON
+    will lead to a JSONDecodeError. Generally JSON-decoding is faster if the
+    items are strings. bytestrings will work as well, but might be slower
+
+    Parameters
+    ----------
+    iterable: Iterable[bytes | str]
+        The iterable that yields the JSON-strings or -bytestrings that should be
+        parsed and converted into JSON-objects
+
+    Yields
+    ------
+    Any
+        The JSON-object that are generated from the data yielded by ``iterable``
+
+    Raises
+    ------
+    json.decoder.JSONDecodeError
+        If the data yielded by ``iterable`` is not a valid JSON-string
+    """
+    for json_string in iterable:
+        yield json.loads(json_string)
+
+
+def load_json_with_flag(
+        iterable: Iterable[bytes | str],
+) -> Generator[tuple[Any | json.decoder.JSONDecodeError, bool], None, None]:
+    """ Convert items from ``iterable`` into JSON objects and a success flag
+
+    The items should be correct JSON-strings (or bytestrings). The generator
+    returns either a tuple containing a decoded JSON-object and ``True``, if the
+    JSON string could be decoded correctly, or it will return an exception and
+    ``False``, if a JSONDecodeError occurred during JSON parsing.
+    Generally JSON-decoding is faster if the items are strings. bytestrings will
+    work as well, but might be slower.
+
+    Parameters
+    ----------
+    iterable: Iterable[bytes | str]
+        The iterable that yields the JSON-strings or -bytestrings that should be
+        parsed and converted into JSON-objects
+
+    Yields
+    ------
+    tuple[Any | json.decoder.JSONDecodeError, bool]
+        A tuple containing of a decoded JSON-object and ``True``, if the JSON
+        string could be decoded correctly. If the JSON string  could not be
+        decoded correctly, the tuple will contain the
+        ``json.decoder.JSONDecodeError`` that was raised during JSON-decoding
+        and ``False``.
+    """
+    for json_string in iterable:
+        try:
+            yield json.loads(json_string), True
+        except json.decoder.JSONDecodeError as e:
+            yield e, False

--- a/datalad_next/itertools/reroute.py
+++ b/datalad_next/itertools/reroute.py
@@ -1,0 +1,165 @@
+""" Functions that allow to route data around upstream iterator """
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Iterable,
+)
+
+
+__all__ = ['route_in', 'route_out', 'join_with_list']
+
+_active_fifos: dict[str, list] = defaultdict(list)
+
+
+def route_out(iterable: Iterable,
+              route_id: str,
+              splitter: Callable[[Any], tuple[Any | None, Any | None]],
+              ) -> Generator:
+    """ Route data around the consumer of this generator
+
+        This generator wraps another generator in order to route parts if the
+        input data around upstream consumers, while other parts of the data are
+        yielded to consumers.
+
+        Data that is routed out is stored in a FIFO-element that is identified
+        by ``route_id``.
+
+        To determine which data is to be yielded to the consumer and which data
+        is to be ignored, the ``splitter`` function is used. The ``splitter``
+        function is called with each element of the input iterable. It returns a
+        tuple of two elements. The first element is the data that is to be
+        yielded to the consumer. The second element is the data that is to be
+        stored in the FIFO-element defined by ``route_id``. If the first element
+        of the tuple is ``None``, no data is yielded to the consumer.
+
+        The counterpart to the ``splitter``-function is the ``joiner``-function
+        in ``route_in``. This module provides a standard ``joiner``-function
+        named ``join_with_list`` that works with splitters that return a list as
+        second element of the result tuple.
+
+        Parameters
+        ----------
+        iterable: Iterable
+            The iterable that yields the input data
+        route_id: str
+            The identifier of the FIFO-element that is used to store the data
+            that is routed out
+        splitter: Callable[[Any], tuple[Any | None, Any | None]]
+            The function that is used to determine which data is to be yielded
+            to the consumer and which data is to be stored in the FIFO-element
+            defined by ``route_id``. The function is called with each element of
+            the input iterable. It returns a tuple of two elements. If the
+            first element is not ``None``, it is yielded to the consumer. If the
+            first element is ``None``, nothing is yielded to the consumer. The
+            second element is stored in the FIFO-element defined by ``route_id``.
+            The cardinality of the FIFO-element will be the same as the
+            cardinality of the input iterable.
+    """
+    fifo = _active_fifos[route_id]
+    for item in iterable:
+        data_to_process, data_to_store = splitter(item)
+        if data_to_process is not None:
+            fifo.append(('process', data_to_store))
+            yield data_to_process
+        else:
+            fifo.append(('ignore', data_to_store))
+
+
+def route_in(iterable: Iterable,
+             route_id: str,
+             joiner: Callable[[Any | None, Any], Any]
+             ) -> Generator:
+    """ Insert previously rerouted data into the consumer of this generator
+
+        This generator wraps the generator ``iterable`` and inserts data that was
+        previously stored in the FIFO-element defined by ``route_id`` by the
+        ``route_out``-generator.
+
+        The cardinality of ``iterable`` must match the number of processed data
+        elements in the FIFO-element defined by ``route_id``. The output
+        cardinality of ``route_in`` will be the cardinality of the FIFO-elements,
+        and thereby the cardinality of the input iterable that was given to
+        ``route_out`` in order to create the FIFO-element. That means a
+        combination of::
+
+            route_in(
+                some_generator(
+                    route_out(input_iterable, 'id1', splitter_1)
+                ),
+                'id_1',
+                joiner_1
+            )
+
+        will yield the same number of elements as ``input_iterable``. But, the
+        number of elements processed by ``some_generator`` is determined by
+        the ``splitter``-function in ``route_out``, i.e. by the number of
+        ``splitter``-results that have a non-``None`` first element.
+
+        ``route_in``, together with ``route_out``, allows to skip processing of
+        elements like, for example, empty lines in ``some_generator``, while still
+        yielding them from ``route_in``.
+
+        ``route_in`` and ``route_out`` also allow to store additional information
+        that "tags along" with the information that is processed by the
+        generators.
+
+        Parameters
+        ----------
+        iterable: Iterable
+            The iterable that yields the input data
+        route_id: str
+            The identifier of the FIFO-element from the data should be read
+            that is to be routed in
+        joiner: Callable[[Any, Any], Any]
+            A function that determines how the data that is yielded by
+            ``iterable`` should be combined with the corresponding data that was
+            stored in the FIFO-element, in order to yield the final result.
+            The first argument to ``joiner`` is the data that is yielded by
+            ``iterable``, or ``None`` if no data was processed in the corresponding
+            step. The second argument is the data that was stored in the
+            FIFO-element in the corresponding step.
+    """
+    fifo = _active_fifos[route_id]
+    for element in iterable:
+        process_info = fifo.pop(0)
+        while process_info[0] == 'ignore':
+            yield joiner(None, process_info[1])
+            process_info = fifo.pop(0)
+        yield joiner(element, process_info[1])
+    assert len(fifo) == 0
+    del _active_fifos[route_id]
+
+
+def join_with_list(processed_data: Any | None,
+                   stored_data: list
+                   ) -> list:
+    """ A standard joiner that works with splitter that store a list
+
+        This joiner is used in combination with splitters that return a list as
+        second element of the result tuple, i.e. splitters that will store a
+        list in the FIFO-element. The joiner adds the corresponding element
+        of ``iterable`` as first element to the list. The extended list is then
+        yielded be the ``route_in``-generator.
+
+        Parameters
+        ----------
+        processed_data: Any | None
+            The data that is yielded by the ``iterable``-generator
+        stored_data: list
+            The data that was stored in the FIFO-element by the ``route_out``
+            generator
+
+        Returns
+        -------
+        list
+            A list this is equivalent to ``[processed_data] + stored_data``
+    """
+    if not isinstance(processed_data, list):
+        return [processed_data] + stored_data
+    processed_data.extend(stored_data)
+    return processed_data

--- a/datalad_next/itertools/tests/test_align_pattern.py
+++ b/datalad_next/itertools/tests/test_align_pattern.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from ..align_pattern import align_pattern
+
+
+@pytest.mark.parametrize('data_chunks,pattern,expected', [
+    (['a', 'b', 'c', 'd', 'e'], 'abc', ['abc', 'de']),
+    (['a', 'b', 'c', 'a', 'b', 'c'], 'abc', ['abc', 'abc']),
+    # Ensure that unaligned pattern prefixes are not keeping data chunks short.
+    (['a', 'b', 'c', 'dddbbb', 'a', 'b', 'x'], 'abc', ['abc', 'dddbbb', 'abx']),
+    # Expect that a trailing minimum length-chunk that ends with a pattern
+    # prefix is not returned as data, but as remainder, if it is not the final
+    # chunk.
+    (['a', 'b', 'c', 'd', 'a'], 'abc', ['abc', 'da']),
+    # Expect the last chunk to be returned as data, if final is True, although
+    # it ends with a pattern prefix. If final is false, the last chunk will be
+    # returned as a remainder, because it ends with a pattern prefix.
+    (['a', 'b', 'c', 'dddbbb', 'a'], 'abc', ['abc', 'dddbbb', 'a']),
+    (['a', 'b', 'c', '9', 'a'], 'abc', ['abc', '9a']),
+])
+def test_pattern_processor(data_chunks, pattern, expected):
+    assert expected == list(align_pattern(data_chunks, pattern=pattern))

--- a/datalad_next/itertools/tests/test_itemize.py
+++ b/datalad_next/itertools/tests/test_itemize.py
@@ -32,14 +32,14 @@ def test_assembling_and_splitting(input_chunks, separator):
     assert len(r) == 3
     assert empty.join(r) == empty.join(input_chunks)
 
-    r = tuple(itemize(input_chunks, separator=separator, keep_ends=True))
+    r = tuple(itemize(input_chunks, sep=separator, keep_ends=True))
     assert len(r) == 3
     assert empty.join(r) == empty.join(input_chunks)
 
-    r = tuple(itemize(input_chunks, separator=separator))
+    r = tuple(itemize(input_chunks, sep=separator))
     assert len(r) == 3
     assert empty.join(r) == empty.join(input_chunks).replace(separator, empty)
 
-    r = tuple(itemize(input_chunks + input_chunks[:1], separator=separator, keep_ends=True))
+    r = tuple(itemize(input_chunks + input_chunks[:1], sep=separator, keep_ends=True))
     assert len(r) == 4
     assert r[3] == input_chunks[0]

--- a/datalad_next/itertools/tests/test_load_json.py
+++ b/datalad_next/itertools/tests/test_load_json.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import timeit
+
+from ..load_json import load_json
+from ..decode_bytes import decode_bytes
+from ..itemize import itemize
+
+
+o = {
+    'list1': [
+        'a', 'bäöl', 1
+    ],
+    'dict1': {
+        'x': 123,
+        'y': 234,
+        'z': 456,
+    }
+}
+
+
+b = b'\n'.join(json.dumps(x).encode() for x in [o] * 10)
+
+c = [
+    b[i:i+10]
+    for i in range(0, len(b) + 10, 10)
+]
+
+
+def test_combi():
+    all(x == 0 for x in load_json(decode_bytes(itemize(c))))
+
+
+def test_combi_performance():
+
+    def read_all(g):
+        tuple(load_json((itemize(g))))
+
+    def read_all_decoded(g):
+        tuple(load_json(decode_bytes(itemize(g))))
+
+    repeat = 33000
+    d1 = timeit.timeit(lambda: read_all(c), number=repeat)
+    print(f'read_all x {repeat}: {d1}')
+    d2 = timeit.timeit(lambda: read_all_decoded(c), number=repeat)
+    print(f'read_all_decoded x {repeat}: {d2}')
+    print(f'read_all / read_all_decoded: {d1 / d2}')

--- a/datalad_next/itertools/tests/test_reroute.py
+++ b/datalad_next/itertools/tests/test_reroute.py
@@ -1,0 +1,34 @@
+
+from more_itertools import intersperse
+
+from ..reroute import (
+    join_with_list,
+    route_in,
+    route_out,
+)
+
+
+def test_route_around():
+    """Test routing of data around a consumer"""
+
+    # Route 0 around `lambda x: x / 2.0`.
+    r = route_in(
+        map(
+            lambda x: x / 2.0,
+            route_out(
+                intersperse(0, range(2, 20)),
+                'zeros',
+                lambda x: (None, [x]) if x == 0 else (x, [x])
+            )
+        ),
+        'zeros',
+        join_with_list
+    )
+    # The result should be a list in which every odd element consists of a list
+    # with the elements `[n / 2.0, n]` and every even element consists of a list
+    # with `[None, 0]`, because the `0`s were routed around the consumer, i.e.
+    # around `lambda x: x / 2.0`.
+    assert list(r) == list(
+        intersperse([None, 0], map(lambda x: [x / 2.0, x], range(2, 20)))
+    )
+    print(list(r))

--- a/datalad_next/runners/iter_subproc.py
+++ b/datalad_next/runners/iter_subproc.py
@@ -13,6 +13,7 @@ def iter_subproc(
     *,
     input: List[bytes] | None = None,
     chunk_size: int = COPY_BUFSIZE,
+    bufsize: int = -1,
 ):
     """Context manager to communicate with a subprocess using iterables
 
@@ -35,6 +36,9 @@ def iter_subproc(
       subprocess's ``stdin``.
     chunk_size: int, optional
       Size of chunks to read from the subprocess's stdout/stderr in bytes.
+    bufsize: int, optional
+      Buffer size to use for the subprocess's ``stdin``, ``stdout``, and
+      ``stderr``. See ``subprocess.Popen`` for details.
 
     Returns
     -------
@@ -54,4 +58,5 @@ def iter_subproc(
         args,
         tuple() if input is None else input,
         chunk_size=chunk_size,
+        buf_size=-1,
     )

--- a/datalad_next/runners/iter_subproc.py
+++ b/datalad_next/runners/iter_subproc.py
@@ -53,5 +53,5 @@ def iter_subproc(
     return iterable_subprocess(
         args,
         tuple() if input is None else input,
-        chunk_size=COPY_BUFSIZE,
+        chunk_size=chunk_size,
     )

--- a/docs/source/pyutils.rst
+++ b/docs/source/pyutils.rst
@@ -25,6 +25,7 @@ packages.
    exceptions
    itertools
    iter_collections
+   itertools
    runners
    tests.fixtures
    types


### PR DESCRIPTION
This PR adds a `bufsize`-parameter to `iter_subproc.__init__` and to `iterable_subprocess.__init__`. This is necessary to support interactive-processing, e.g. driving an interactive ssh-session.

