### PR TITLE
Remove default separator from `itemize()`

### DIFF
--- a/datalad_next/itertools/itemize.py
+++ b/datalad_next/itertools/itemize.py
@@ -13,7 +13,8 @@ __all__ = ['itemize']
 
 def itemize(
     iterable: Iterable[bytes | str],
-    separator: str | bytes | None = None,
+    separator: str | bytes | None,
+    *,
     keep_ends: bool = False,
 ) -> Generator[bytes | str, None, None]:
     """ Generator that emits only complete items from chunks of an iterable

--- a/datalad_next/itertools/tests/test_itemize.py
+++ b/datalad_next/itertools/tests/test_itemize.py
@@ -28,7 +28,7 @@ byte_chunks_other = [chunk.encode() for chunk in text_chunks_other]
 def test_assembling_and_splitting(input_chunks, separator):
     empty = input_chunks[0][:0]
 
-    r = tuple(itemize(input_chunks, keep_ends=True))
+    r = tuple(itemize(input_chunks, None, keep_ends=True))
     assert len(r) == 3
     assert empty.join(r) == empty.join(input_chunks)
 


### PR DESCRIPTION
This addresses an issues brought up in
https://github.com/datalad/datalad-next/pull/539#discussion_r1403427421

This changeset removes the default argument to avoid the impression that "line-processing" is the main target. The code does not imply that, and the existing usage also not.

The possibility to do line-splitting is not touched (or removed). The documentation needs no adjustment.
