### PR TITLE
Use `iter_subproc` in `datalad_next.url_operations.ssh` instead of datalad-core runner code

### DIFF
--- a/datalad_next/iterable_subprocess/test_iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/test_iterable_subprocess.py
@@ -128,13 +128,12 @@ def test_exception_from_not_found_process_propagated():
 
 
 def test_exception_from_return_code():
-    with pytest.raises(IterableSubprocessError) as excinfo:
+    with pytest.raises(IterableSubprocessError, match='No such file or directory') as excinfo:
         with iterable_subprocess(['ls', 'does-not-exist'], ()) as output:
             a = b''.join(output)
 
     assert excinfo.value.returncode > 0
-    assert (b'No such file or directory' in excinfo.value.stderr) \
-           or (b'Datei oder Verzeichnis nicht gefunden' in excinfo.value.stderr)
+    assert b'No such file or directory' in excinfo.value.stderr
 
 
 def test_exception_from_context_even_though_return_code_with_long_standard_error():

--- a/datalad_next/iterable_subprocess/test_iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/test_iterable_subprocess.py
@@ -128,12 +128,13 @@ def test_exception_from_not_found_process_propagated():
 
 
 def test_exception_from_return_code():
-    with pytest.raises(IterableSubprocessError, match='No such file or directory') as excinfo:
+    with pytest.raises(IterableSubprocessError) as excinfo:
         with iterable_subprocess(['ls', 'does-not-exist'], ()) as output:
             a = b''.join(output)
 
     assert excinfo.value.returncode > 0
-    assert b'No such file or directory' in excinfo.value.stderr
+    assert (b'No such file or directory' in excinfo.value.stderr) \
+           or (b'Datei oder Verzeichnis nicht gefunden' in excinfo.value.stderr)
 
 
 def test_exception_from_context_even_though_return_code_with_long_standard_error():

--- a/datalad_next/itertools/__init__.py
+++ b/datalad_next/itertools/__init__.py
@@ -4,6 +4,7 @@
 .. autosummary::
    :toctree: generated
 
+    align_pattern
     decode_bytes
     itemize
     load_json
@@ -13,6 +14,7 @@
 """
 
 
+from .align_pattern import align_pattern
 from .decode_bytes import decode_bytes
 from .itemize import itemize
 from .load_json import (

--- a/datalad_next/itertools/align_pattern.py
+++ b/datalad_next/itertools/align_pattern.py
@@ -1,0 +1,94 @@
+""" Function to ensure that a pattern is completely contained in single chunks
+"""
+
+from __future__ import annotations
+
+from typing import (
+    Generator,
+    Iterable,
+)
+
+
+def align_pattern(iterable: Iterable[str | bytes | bytearray],
+                  pattern: str | bytes | bytearray
+                  ) -> Generator[str | bytes | bytearray, None, None]:
+    """ Yield data chunks that contain a complete pattern, if it is present
+
+    ``align_pattern`` makes it easy to find a pattern (``str``, ``bytes``,
+    or ``bytearray``) in data chunks. It joins data-chunks in such a way,
+    that a simple containment-check (e.g. ``pattern in chunk``) on the chunks
+    that ``align_pattern`` yields will suffice to determine whether the pattern
+    is present in the stream yielded by the underlying iterable or not.
+
+    To achieve this, ``align_pattern`` will join consecutive chunks to ensures
+    that the following two assertions hold:
+
+    1. Each chunk that is yielded by ``align_pattern`` has at least the length
+       of the pattern (unless the underlying iterable is exhausted before the
+       length of the pattern is reached).
+
+    2. The pattern is not split between two chunks, i.e. no chunk that is
+       yielded by ``align_pattern`` ends with a prefix of the pattern (unless
+       it is the last chunk that the underlying iterable yield).
+
+    The pattern might be present multiple times in a yielded data chunk.
+
+    Note: the ``pattern`` is compared verbatim to the content in the data
+    chunks, i.e. no parsing of the ``pattern`` is performed and no regular
+    expressions or wildcards are supported.
+
+    .. code-block:: python
+
+        >>> from datalad_next.itertools import align_pattern
+        >>> tuple(align_pattern([b'abcd', b'e', b'fghi'], pattern=b'def'))
+        (b'abcdefghi',)
+        >>> # The pattern can be present multiple times in a yielded chunk
+        >>> tuple(align_pattern([b'abcd', b'e', b'fdefghi'], pattern=b'def'))
+        (b'abcdefdefghi',)
+
+    Use this function if you want to locate a pattern in an input stream. It
+    allows to use a simple ``in``-check to determine whether the pattern is
+    present in the yielded result chunks.
+
+    Parameters
+    ----------
+    iterable: Iterable
+        An iterable that yields data chunks.
+    pattern: str | bytes | bytearray
+        The pattern that should be contained in the chunks. Its type must be
+        compatible to the type of the elements in ``iterable``.
+
+    Yields
+    -------
+    str | bytes | bytearray
+        data chunks that have at least the size of the pattern and do not end
+        with a prefix of the pattern. Note that a data chunk might contain the
+        pattern multiple times.
+    """
+
+    def ends_with_pattern_prefix(data: str | bytes | bytearray,
+                                 pattern: str | bytes | bytearray,
+                                 ) -> bool:
+        """ Check whether the chunk ends with a prefix of the pattern """
+        for index in range(len(pattern) - 1, 0, -1):
+            if data[-index:] == pattern[:index]:
+                return True
+        return False
+
+    # Join data chunks until they are sufficiently long to contain the pattern,
+    # i.e. have at least size: `len(pattern)`. Continue joining, if the chunk
+    # ends with a prefix of the pattern.
+    current_chunk = None
+    for data_chunk in iterable:
+        # get the type of current_chunk from the type of this data_chunk
+        if current_chunk is None:
+            current_chunk = data_chunk
+        else:
+            current_chunk += data_chunk
+        if len(current_chunk) >= len(pattern) \
+                and not ends_with_pattern_prefix(current_chunk, pattern):
+            yield current_chunk
+            current_chunk = None
+
+    if current_chunk is not None:
+        yield current_chunk

--- a/datalad_next/itertools/align_pattern.py
+++ b/datalad_next/itertools/align_pattern.py
@@ -50,6 +50,14 @@ def align_pattern(iterable: Iterable[str | bytes | bytearray],
     allows to use a simple ``in``-check to determine whether the pattern is
     present in the yielded result chunks.
 
+    The function always yields everything it has fetched from the underlying
+    iterable. So after a yield it does not cache any data from the underlying
+    iterable. That means, if the functionality of
+    ``align_pattern`` is no longer required, the underlying iterator can be
+    used, when ``align_pattern`` has yielded a data chunk.
+    This allows more efficient  processing of the data that remains in the
+    underlying iterable.
+
     Parameters
     ----------
     iterable: Iterable

--- a/datalad_next/itertools/tests/test_align_pattern.py
+++ b/datalad_next/itertools/tests/test_align_pattern.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from ..align_pattern import align_pattern
+
+
+@pytest.mark.parametrize('data_chunks,pattern,expected', [
+    (['a', 'b', 'c', 'd', 'e'], 'abc', ['abc', 'de']),
+    (['a', 'b', 'c', 'a', 'b', 'c'], 'abc', ['abc', 'abc']),
+    # Ensure that unaligned pattern prefixes are not keeping data chunks short.
+    (['a', 'b', 'c', 'dddbbb', 'a', 'b', 'x'], 'abc', ['abc', 'dddbbb', 'abx']),
+    # Expect that a trailing minimum length-chunk that ends with a pattern
+    # prefix is not returned as data, but as remainder, if it is not the final
+    # chunk.
+    (['a', 'b', 'c', 'd', 'a'], 'abc', ['abc', 'da']),
+    # Expect the last chunk to be returned as data, if final is True, although
+    # it ends with a pattern prefix. If final is false, the last chunk will be
+    # returned as a remainder, because it ends with a pattern prefix.
+    (['a', 'b', 'c', 'dddbbb', 'a'], 'abc', ['abc', 'dddbbb', 'a']),
+    (['a', 'b', 'c', '9', 'a'], 'abc', ['abc', '9a']),
+])
+def test_pattern_processor(data_chunks, pattern, expected):
+    assert expected == list(align_pattern(data_chunks, pattern=pattern))

--- a/datalad_next/runners/__init__.py
+++ b/datalad_next/runners/__init__.py
@@ -42,7 +42,10 @@ inspired by ``asyncio.SubprocessProtocol``.
    StdOutErrCapture
 """
 
-from .iter_subproc import iter_subproc
+from .iter_subproc import (
+    iter_subproc,
+    IterableSubprocessError,
+)
 
 # runners
 from datalad.runner import (

--- a/datalad_next/runners/iter_subproc.py
+++ b/datalad_next/runners/iter_subproc.py
@@ -4,8 +4,12 @@ from typing import (
     List,
 )
 
-from datalad_next.iterable_subprocess.iterable_subprocess \
-    import iterable_subprocess
+from datalad_next.iterable_subprocess.iterable_subprocess import (
+    iterable_subprocess,
+    # not needed here, but we want to provide all critical pieces from
+    # the same place. This is the key exception type
+    IterableSubprocessError,
+)
 from datalad_next.consts import COPY_BUFSIZE
 
 __all__ = ['iter_subproc']

--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -342,16 +342,16 @@ class UrlOperations:
     def _get_hasher(self, hash: list[str] | None) -> NoOpHash | MultiHash:
         return MultiHash(hash) if hash is not None else NoOpHash()
 
-    def _reporting(self,
-                   stream: Iterable[Any],
-                   *,
-                   progress_id: str,
-                   label: str,
-                   expected_size: int | None,
-                   start_log_msg: tuple,
-                   end_log_msg: tuple,
-                   update_log_msg: tuple
-                   ) -> Generator[Any, None, None]:
+    def _with_progress(self,
+                       stream: Iterable[Any],
+                       *,
+                       progress_id: str,
+                       label: str,
+                       expected_size: int | None,
+                       start_log_msg: tuple,
+                       end_log_msg: tuple,
+                       update_log_msg: tuple
+                       ) -> Generator[Any, None, None]:
         yield from side_effect(
             lambda chunk: self._progress_report_update(
                 progress_id,

--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -347,7 +347,7 @@ class UrlOperations:
                    *,
                    progress_id: str,
                    label: str,
-                   expected_size: int,
+                   expected_size: int | None,
                    start_log_msg: tuple,
                    end_log_msg: tuple,
                    update_log_msg: tuple

--- a/datalad_next/url_operations/__init__.py
+++ b/datalad_next/url_operations/__init__.py
@@ -15,10 +15,14 @@ Available handlers:
 from __future__ import annotations
 
 import logging
+from functools import partial
+from more_itertools import side_effect
 from pathlib import Path
 from typing import (
     Any,
     Dict,
+    Generator,
+    Iterable,
 )
 
 import datalad
@@ -337,6 +341,37 @@ class UrlOperations:
 
     def _get_hasher(self, hash: list[str] | None) -> NoOpHash | MultiHash:
         return MultiHash(hash) if hash is not None else NoOpHash()
+
+    def _reporting(self,
+                   stream: Iterable[Any],
+                   *,
+                   progress_id: str,
+                   label: str,
+                   expected_size: int,
+                   start_log_msg: tuple,
+                   end_log_msg: tuple,
+                   update_log_msg: tuple
+                   ) -> Generator[Any, None, None]:
+        yield from side_effect(
+            lambda chunk: self._progress_report_update(
+                progress_id,
+                update_log_msg,
+                len(chunk)
+            ),
+            stream,
+            before=partial(
+                self._progress_report_start,
+                progress_id,
+                start_log_msg,
+                label,
+                expected_size
+            ),
+            after=partial(
+                self._progress_report_stop,
+                progress_id,
+                end_log_msg
+            )
+        )
 
 
 #

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -294,7 +294,7 @@ class SshUrlOperations(UrlOperations):
         try:
             with iter_subproc(
                     cmd,
-                    input=self._reporting(
+                    input=self._with_progress(
                         iter(upload_queue.get, None),
                         progress_id=progress_id,
                         label='uploading',

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -94,14 +94,17 @@ class SshUrlOperations(UrlOperations):
         cmd = ssh_cat.get_cmd(SshUrlOperations._stat_cmd)
         try:
             with iter_subproc(cmd) as stream:
-                props = self._get_props(url, stream)
+                # any exception that is raised in this context and not caught
+                # will prevent the creation of `IterableSubprocessError`. But
+                # we rely on the return code of the ssh-process to signal
+                # specific errors. Therefore, we catch the expected
+                # `StopIteration` here.
+                try:
+                    props = self._get_props(url, stream)
+                except StopIteration:
+                    pass
         except IterableSubprocessError as e:
             self._check_return_code(e.returncode, url)
-        except StopIteration:
-            # The stream was empty, this happens, if the ssh-shell does not
-            # return any output. Usually that indicates that the resource
-            # identified by `url` is not available.
-            raise UrlOperationsResourceUnknown(url)
         return {k: v for k, v in props.items() if not k.startswith('_')}
 
     def _get_props(self, url, stream: Generator) -> dict:
@@ -174,39 +177,44 @@ class SshUrlOperations(UrlOperations):
         cmd = ssh_cat.get_cmd(f'{SshUrlOperations._stat_cmd}; {SshUrlOperations._cat_cmd}')
         try:
             with iter_subproc(cmd) as stream:
-                props = self._get_props(from_url, stream)
-                expected_size = props['content-length']
-                # The stream might have changed due to not yet processed, but
-                # fetched data, that is now chained in front of it. Therefore we
-                # get the updated stream from the props
-                download_stream = props.pop('_stream')
+                # any exception that is raised in this context and not caught
+                # will prevent the creation of `IterableSubprocessError`. But
+                # we rely on the return code of the ssh-process to signal
+                # specific errors. Therefore, we catch the expected
+                # `StopIteration` here.
+                try:
+                    props = self._get_props(from_url, stream)
+                    expected_size = props['content-length']
+                    # The stream might have changed due to not yet processed, but
+                    # fetched data, that is now chained in front of it. Therefore we
+                    # get the updated stream from the props
+                    download_stream = props.pop('_stream')
 
-                dst_fp = sys.stdout.buffer \
-                    if to_path is None \
-                    else open(to_path, 'wb')
+                    dst_fp = sys.stdout.buffer \
+                        if to_path is None \
+                        else open(to_path, 'wb')
 
-                # Localize variable access to minimize overhead
-                dst_fp_write = dst_fp.write
+                    # Localize variable access to minimize overhead
+                    dst_fp_write = dst_fp.write
 
-                # download can start
-                for chunk in self._reporting(
-                        download_stream,
-                        progress_id=progress_id,
-                        label='downloading',
-                        expected_size=expected_size,
-                        start_log_msg=('Download %s to %s', from_url, to_path),
-                        end_log_msg=('Finished download',),
-                        update_log_msg=('Downloaded chunk',)
-                ):
-                    # write data
-                    dst_fp_write(chunk)
-                    # compute hash simultaneously
-                    hasher.update(chunk)
-
+                    # download can start
+                    for chunk in self._reporting(
+                            download_stream,
+                            progress_id=progress_id,
+                            label='downloading',
+                            expected_size=expected_size,
+                            start_log_msg=('Download %s to %s', from_url, to_path),
+                            end_log_msg=('Finished download',),
+                            update_log_msg=('Downloaded chunk',)
+                    ):
+                        # write data
+                        dst_fp_write(chunk)
+                        # compute hash simultaneously
+                        hasher.update(chunk)
+                except StopIteration:
+                    pass
         except IterableSubprocessError as e:
             self._check_return_code(e.returncode, from_url)
-        except StopIteration:
-            raise UrlOperationsResourceUnknown(from_url)
         finally:
             if dst_fp and to_path is not None:
                 dst_fp.close()

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -164,6 +164,8 @@ class SshUrlOperations(UrlOperations):
         hasher = self._get_hasher(hash)
         progress_id = self._get_progress_id(from_url, str(to_path))
 
+        dst_fp = None
+
         ssh_cat = _SshCommandBuilder(from_url)
         cmd = ssh_cat.get_cmd(f'{SshUrlOperations._stat_cmd}; {SshUrlOperations._cat_cmd}')
         try:
@@ -208,6 +210,8 @@ class SshUrlOperations(UrlOperations):
         except StopIteration:
             raise UrlOperationsResourceUnknown(from_url)
         finally:
+            if dst_fp and to_path is not None:
+                dst_fp.close()
             self._progress_report_stop(progress_id, ('Finished download',))
 
         return {

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -198,7 +198,12 @@ class SshUrlOperations(UrlOperations):
                             ('Download %s to %s', from_url, to_path),
                             'downloading',
                             expected_size
-                        )
+                        ),
+                        after=partial(
+                            self._progress_report_stop,
+                            progress_id,
+                            ('Finished download',)
+                       )
                 ):
                     # write data
                     dst_fp_write(chunk)
@@ -212,7 +217,6 @@ class SshUrlOperations(UrlOperations):
         finally:
             if dst_fp and to_path is not None:
                 dst_fp.close()
-            self._progress_report_stop(progress_id, ('Finished download',))
 
         return {
             **props,
@@ -300,6 +304,11 @@ class SshUrlOperations(UrlOperations):
                             ('Upload %s to %s', source_name, to_url),
                             'uploading',
                             expected_size
+                        ),
+                        after=partial(
+                            self._progress_report_stop,
+                            progress_id,
+                            ('Finished upload',)
                         )
                     )
             ):
@@ -324,8 +333,6 @@ class SshUrlOperations(UrlOperations):
             if chunk != b'':
                 # we had a timeout while uploading
                 raise TimeoutError
-        finally:
-            self._progress_report_stop(progress_id, ('Finished upload',))
 
         return {
             **hasher.get_hexdigest(),

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -41,11 +41,7 @@ from . import (
 lgr = logging.getLogger('datalad.ext.next.ssh_url_operations')
 
 
-__all__ = [
-    'SshUrlOperations',
-    'UrlOperationsRemoteError',
-    'UrlOperationsResourceUnknown'
-]
+__all__ = ['SshUrlOperations']
 
 
 class SshUrlOperations(UrlOperations):

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -25,8 +25,10 @@ from urllib.parse import urlparse
 from more_itertools import side_effect
 
 from datalad_next.consts import COPY_BUFSIZE
-from datalad_next.runners.iter_subproc import iter_subproc
-from datalad_next.iterable_subprocess.iterable_subprocess import IterableSubprocessError
+from datalad_next.runners import (
+    iter_subproc,
+    IterableSubprocessError,
+)
 from datalad_next.itertools import align_pattern
 
 

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -198,7 +198,7 @@ class SshUrlOperations(UrlOperations):
                     dst_fp_write = dst_fp.write
 
                     # download can start
-                    for chunk in self._reporting(
+                    for chunk in self._with_progress(
                             download_stream,
                             progress_id=progress_id,
                             label='downloading',

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -185,25 +185,14 @@ class SshUrlOperations(UrlOperations):
                 dst_fp_write = dst_fp.write
 
                 # download can start
-                for chunk in side_effect(
-                        lambda chunk: self._progress_report_update(
-                            progress_id,
-                            ('Downloaded chunk',),
-                            len(chunk)
-                        ),
+                for chunk in self._reporting(
                         download_stream,
-                        before=partial(
-                            self._progress_report_start,
-                            progress_id,
-                            ('Download %s to %s', from_url, to_path),
-                            'downloading',
-                            expected_size
-                        ),
-                        after=partial(
-                            self._progress_report_stop,
-                            progress_id,
-                            ('Finished download',)
-                       )
+                        progress_id=progress_id,
+                        label='downloading',
+                        expected_size=expected_size,
+                        start_log_msg=('Download %s to %s', from_url, to_path),
+                        end_log_msg=('Finished download',),
+                        update_log_msg=('Downloaded chunk',)
                 ):
                     # write data
                     dst_fp_write(chunk)
@@ -293,23 +282,14 @@ class SshUrlOperations(UrlOperations):
         try:
             with iter_subproc(
                     cmd,
-                    input=side_effect(
-                        lambda chunk: self._progress_report_update(
-                            progress_id, ('Uploaded chunk',), len(chunk)
-                        ),
+                    input=self._reporting(
                         iter(upload_queue.get, None),
-                        before=partial(
-                            self._progress_report_start,
-                            progress_id,
-                            ('Upload %s to %s', source_name, to_url),
-                            'uploading',
-                            expected_size
-                        ),
-                        after=partial(
-                            self._progress_report_stop,
-                            progress_id,
-                            ('Finished upload',)
-                        )
+                        progress_id=progress_id,
+                        label='uploading',
+                        expected_size=expected_size,
+                        start_log_msg=('Upload %s to %s', source_name, to_url),
+                        end_log_msg=('Finished upload',),
+                        update_log_msg=('Uploaded chunk',)
                     )
             ):
                 upload_size = 0

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -207,6 +207,9 @@ class SshUrlOperations(UrlOperations):
             self._check_return_code(e.returncode, from_url)
         except StopIteration:
             raise UrlOperationsResourceUnknown(from_url)
+        finally:
+            self._progress_report_stop(progress_id, ('Finished download',))
+
         return {
             **props,
             **hasher.get_hexdigest(),
@@ -317,6 +320,8 @@ class SshUrlOperations(UrlOperations):
             if chunk != b'':
                 # we had a timeout while uploading
                 raise TimeoutError
+        finally:
+            self._progress_report_stop(progress_id, ('Finished upload',))
 
         return {
             **hasher.get_hexdigest(),

--- a/datalad_next/url_operations/ssh.py
+++ b/datalad_next/url_operations/ssh.py
@@ -135,10 +135,9 @@ class SshUrlOperations(UrlOperations):
         chunk = chunk[marker_index + 1:]
         props = {
             'content-length': expected_size,
-            '_stream':
-                chain([chunk], aligned_stream)
-                if chunk
-                else aligned_stream
+            # go back to the original iterator, no need to keep looking for
+            # a pattern
+            '_stream': chain([chunk], stream) if chunk else stream
         }
         return props
 


### PR DESCRIPTION
This PR uses `iter_subproc` instead of the datalad-core based `run` context-manager to implement `SshUrlOperations`.


The code changes are based on `iter-annexworktree-subproc`-branch (PR #539) and contain only one commit beyond the branch `iter-annexworktree-subproc`: 64e82d761e38f27d4aad73757c359570d45c2b19. This branch should be rebased on `main` once PR #539 is merged.


TODO:

- [x] Run a benchmark