### PR TITLE
Add a mode and test for non-recursive `iter_gitworktree()`, plus fixes

### DIFF
--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -127,14 +127,18 @@ def iter_gitworktree(
       ``all`` reports on any untracked file; ``whole-dir`` yields a single
       report for a directory that is entirely untracked, and not individual
       untracked files in it; ``no-empty-dir`` skips any reports on
-      untracked empty directories. Any untracked content is yielded as
-      a ``PurePosixPath``.
+      untracked empty directories.
     link_target: bool, optional
-      If ``True``, each file-type item includes a file-like object
-      to access the file's content. This file handle will be closed
-      automatically when the next item is yielded.
+      If ``True``, information matching a
+      :class:`~datalad_next.iter_collections.utils.FileSystemItem`
+      will be included for each yielded item, and the targets of
+      any symlinks will be reported, too.
     fp: bool, optional
-      If ``True``, each file-type item includes a file-like object
+      If ``True``, information matching a
+      :class:`~datalad_next.iter_collections.utils.FileSystemItem`
+      will be included for each yielded item, but without a
+      link target detection, unless ``link_target`` is given.
+      Moreover, each file-type item includes a file-like object
       to access the file's content. This file handle will be closed
       automatically when the next item is yielded.
     recursive: {'repository', 'no'}, optional
@@ -150,7 +154,7 @@ def iter_gitworktree(
 
     Yields
     ------
-    :class:`GitWorktreeItem` or `GitWorktreeFileSystemItem`
+    :class:`GitWorktreeItem` or :class:`GitWorktreeFileSystemItem`
     """
     lsfiles_args = ['--stage', '--cached']
     if untracked:

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -156,6 +156,13 @@ def iter_gitworktree(
     ------
     :class:`GitWorktreeItem` or :class:`GitWorktreeFileSystemItem`
     """
+    # we force-convert to Path to prevent delayed crashing when reading from
+    # the file system. The docs already ask for that, but it is easy to
+    # forget/ignore and leads to non-obvious errors. Running this once is
+    # a cheap safety net
+    # https://github.com/datalad/datalad-next/issues/551
+    path = Path(path)
+
     lsfiles_args = ['--stage', '--cached']
     if untracked:
         lsfiles_args.extend(lsfiles_untracked_args[untracked])

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -5,6 +5,8 @@ from pathlib import (
 
 import pytest
 
+from datalad_next.tests.utils import rmtree
+
 from ..gitworktree import (
     GitWorktreeItem,
     GitWorktreeFileSystemItem,
@@ -91,3 +93,13 @@ def test_name_starting_with_tab(existing_dataset, no_result_rendering):
 
     iter_names = [item.name for item in iter_gitworktree(ds.pathobj)]
     assert PurePosixPath(tabbed_file_name) in iter_names
+
+
+def test_iter_gitworktree_empty(existing_dataset, no_result_rendering):
+    ds = existing_dataset
+    rmtree(ds.pathobj / '.datalad')
+    (ds.pathobj / '.gitattributes').unlink()
+    ds.save()
+    assert len(ds.status()) == 0
+    all_items = list(iter_gitworktree(ds.pathobj))
+    assert len(all_items) == 0


### PR DESCRIPTION
This adds support for a standard query that Gooey would be making. Therefore, this is a significant step towards a resolution of https://github.com/datalad/datalad-next/issues/323.

When interfaced with https://github.com/datalad/datalad-next/pull/539, it replaces `gooey-lsdir` and half of `gooey-status-light`, with a much more efficient/convenient implementation.

Also:

- Closes #463 
- Closes #468 
- Closes #551 