### PR TITLE
Add `more_itertools` as a dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     annexremote
     datalad >= 0.18.4
     humanize
+    more-itertools
 packages = find_namespace:
 include_package_data = True
 


### PR DESCRIPTION
For now, we only need a single iterator from it. However, with the switch to `iter_subproc()`, more usage is to be anticipated.

For testing this is not actually a new dependency. `cheroot` already pulled it in.

Closes #556