### PR TITLE
fix issue #559, a Windows line endings-related bug

### DIFF
--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -187,10 +187,13 @@ def iter_annexworktree(
                     route_out(
                         itemize(
                             gaf,
-                            # git-annex changed its line-ending behavior, but
-                            # we should be safe, because we declare a specific
-                            # format for git-annex-find above
-                            sep=b'\n',
+                            # although we declare a specific key output format
+                            # for the git-annex find call, some versions of
+                            # git-annex on Windows will terminate the key output
+                            # with '\r\n' instead of '\n'. We therefore use
+                            # `None` as separator, which enables `itemize()`
+                            # to use either separator, i.e. '\r\n' or '\n'.
+                            sep=None,
                         ),
                         # we need this route-out solely for the purpose
                         # of maintaining a 1:1 relationship of items reported

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -17,6 +17,7 @@ from typing import (
     Generator,
 )
 
+from datalad_next.consts import on_windows
 from datalad_next.itertools import (
     itemize,
     load_json,
@@ -188,12 +189,12 @@ def iter_annexworktree(
                         itemize(
                             gaf,
                             # although we declare a specific key output format
-                            # for the git-annex find call, some versions of
-                            # git-annex on Windows will terminate the key output
-                            # with '\r\n' instead of '\n'. We therefore use
+                            # for the git-annex find call, versions of
+                            # git-annex <10.20231129 on Windows will terminate
+                            # lines with '\r\n' instead of '\n'. We therefore use
                             # `None` as separator, which enables `itemize()`
                             # to use either separator, i.e. '\r\n' or '\n'.
-                            sep=None,
+                            sep=None if on_windows else b'\n',
                         ),
                         # we need this route-out solely for the purpose
                         # of maintaining a 1:1 relationship of items reported


### PR DESCRIPTION
This commit fixes issue #559.

It allows `itemize` to any of multiple line-separators to separate the output of `git annex find`. This takes care of the fact that some git-annex versions will output an unrequested `'\r'` in addition to a requested `'\n'`.