### PR TITLE
Use `OutputFrom` class as `iter_subproc` result, which keeps returncodes on exception

### DIFF
--- a/datalad_next/iterable_subprocess/iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/iterable_subprocess.py
@@ -1,4 +1,5 @@
 from collections import deque
+from collections.abc import Generator
 from contextlib import contextmanager
 from subprocess import PIPE, SubprocessError, Popen
 from threading import Thread
@@ -95,12 +96,19 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
                 if e.errno != 22:
                     raise
 
-    def output_from(stdout):
-        while True:
-            chunk = stdout.read(chunk_size)
+    class OutputFrom(Generator):
+        def __init__(self, stdout):
+            self.stdout = stdout
+            self.returncode = None
+
+        def send(self, _):
+            chunk = self.stdout.read(chunk_size)
             if not chunk:
-                break
-            yield chunk
+                raise StopIteration
+            return chunk
+
+        def throw(self, typ, value=None, traceback=None):
+            return super().throw(typ, value, traceback)
 
     def keep_only_most_recent(stderr, stderr_deque):
         total_length = 0
@@ -120,6 +128,7 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
 
     proc = None
     stderr_deque = deque()
+    chunk_generator = None
     exception_stdin = None
     exception_stderr = None
 
@@ -133,7 +142,8 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
             try:
                 start_t_stderr()
                 start_t_stdin()
-                yield output_from(proc.stdout)
+                chunk_generator = OutputFrom(proc.stdout)
+                yield chunk_generator
             except BaseException:
                 proc.terminate()
                 raise
@@ -146,9 +156,16 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
             raise_if_not_none(exception_stderr)
 
     except _BrokenPipeError as e:
+        if chunk_generator:
+            chunk_generator.returncode = proc.returncode
         if proc.returncode == 0:
             raise e.__context__ from None
+    except BaseException:
+        if chunk_generator:
+            chunk_generator.returncode = proc.returncode
+        raise
 
+    chunk_generator.returncode = proc.returncode
     if proc.returncode:
         raise IterableSubprocessError(proc.returncode, b''.join(stderr_deque)[-chunk_size:])
 

--- a/datalad_next/iterable_subprocess/test_iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/test_iterable_subprocess.py
@@ -127,7 +127,8 @@ def test_exception_from_not_found_process_propagated():
             b''.join(output)
 
 
-def test_exception_from_return_code():
+def test_exception_from_return_code(monkeypatch):
+    monkeypatch.setenv('LANG', 'C')
     with pytest.raises(IterableSubprocessError, match='No such file or directory') as excinfo:
         with iterable_subprocess(['ls', 'does-not-exist'], ()) as output:
             a = b''.join(output)

--- a/datalad_next/iterable_subprocess/test_iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/test_iterable_subprocess.py
@@ -312,3 +312,26 @@ def test_funzip_deflate():
 
     with iterable_subprocess(['funzip'], yield_input()) as output:
         assert b''.join(output) == contents
+
+
+def test_error_returncode_available_from_generator():
+    with pytest.raises(IterableSubprocessError):
+        with iterable_subprocess(['ls', 'does-not-exist'], ()) as ls:
+            tuple(ls)
+    assert ls.returncode != 0
+
+
+def test_error_returncode_available_from_generator_with_exception():
+    with pytest.raises(StopIteration):
+        with iterable_subprocess(['ls', 'does-not-exist'], ()) as ls:
+            while True:
+                next(ls)
+    assert ls.returncode != 0
+
+
+def test_success_returncode_available_from_generator_with_exception():
+    with pytest.raises(StopIteration):
+        with iterable_subprocess(['echo', 'a'], ()) as echo:
+            while True:
+                next(echo)
+    assert echo.returncode == 0

--- a/datalad_next/runners/iter_subproc.py
+++ b/datalad_next/runners/iter_subproc.py
@@ -49,9 +49,43 @@ def iter_subproc(
       passing chunks to the process, while the standard error thread
       fetches the error output, and while the main thread iterates over
       the process's output from client code in the context.
+
       On context exit, the main thread closes the process's standard output,
       waits for the standard input thread to exit, waits for the standard
-      error thread to exit, and wait for the process to exit.
+      error thread to exit, and wait for the process to exit. If the process
+      exited with a non-zero return code, an
+      ``IterableSubprocessError`` is raised, containing the process's return
+      code.
+
+      If the context is exited due to an exception that was raised in the
+      context, the main thread terminates the process via ``Popen.terminate()``,
+      closes the process's standard output, waits for the standard input
+      thread to exit, waits for the standard error thread to exit, waits
+      for the process to exit, and re-raises the exception.
+
+      Note, if an exception is raised in the context, this exception will bubble
+      up to the main thread. That means no ``IterableSubprocessError`` will
+      be raised if the subprocess exited with a non-zero return code.
+      To access the return code in case of an exception inside the context,
+      use the ``returncode``-attribute of the ``as``-variable.
+      This object will always contain the return code of the subprocess.
+      For example, the following code will raise a ``StopIteration``-exception
+      in the context (by repeatedly using :func:`next`). The subprocess
+      will exit with ``2`` due to the illegal option ``-@``, and no
+      ``IterableSubprocessError`` is raised. The return code is read from
+      the variable ``ls_stdout``
+
+      .. code-block:: python
+
+        >>> from datalad_next.runners import iter_subproc
+        >>> try:
+        ...     with iter_subproc(['ls', '-@']) as ls_stdout:
+        ...         while True:
+        ...             next(ls_stdout)
+        ... except Exception as e:
+        ...     print(repr(e), ls_stdout.returncode)
+        StopIteration() 2
+
     """
     return iterable_subprocess(
         args,


### PR DESCRIPTION
This PR implements a solution for the problem of not-easily available return codes that was discussed [here](https://github.com/datalad/datalad-next/pull/546#discussion_r1418976060) in PR #546.

This is an alternative (and in my view superior) approach to the discussed solution, which is implemented in PR #562.

The reason why this second approach exists is:

1. It seems much more pythonic to me
2. It is more general and does not introduce special handling of different exceptions (in this case, the handling of `StopIteration`in PR #562)
3. It makes for cleaner code when using `iter_subproc`, i.e. in `SshUrlOperations`.
