### PR TITLE
Enhance `iter_subproc` with a `cwd` parameter

### DIFF
--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -153,7 +153,7 @@ def iter_annexworktree(
             iter_subproc(
                 # we get the annex key for any filename
                 # (or empty if not annexed)
-                ['git', '-C', str(path),
+                ['git',
                  'annex', 'find', '--anything', '--format=${key}\\n',
                  '--batch'],
                 # intersperse items with newlines to trigger a batch run
@@ -174,11 +174,12 @@ def iter_annexworktree(
                             git_worktree_item
                         )
                     )
-                )
+                ),
+                cwd=path,
             ) as gaf, \
             iter_subproc(
                 # get the key properties JSON-lines style
-                ['git', '-C', str(path),
+                ['git',
                  'annex', 'examinekey', '--json', '--batch'],
                 # use only non-empty keys as input to `git annex examinekey`.
                 input=intersperse(
@@ -210,7 +211,8 @@ def iter_annexworktree(
                         # the processing result includes the key itself.
                         lambda key: (key if key else StoreOnly, None)
                     )
-                )
+                ),
+                cwd=path,
             ) as gek:
 
         results = route_in(

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -315,13 +315,14 @@ def _lsfiles_line2props(
 def _git_ls_files(path, *args):
     with iter_subproc(
             [
-                'git', '-C', str(path),
+                'git',
                 'ls-files',
                 # we rely on zero-byte splitting below
                 '-z',
                 # otherwise take whatever is coming in
                 *args,
             ],
+            cwd=path,
     ) as r:
         yield from decode_bytes(
             itemize(

--- a/datalad_next/iterable_subprocess/iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/iterable_subprocess.py
@@ -50,6 +50,7 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
     @contextmanager
     def thread(target, *args):
         exception = None
+
         def wrapper():
             nonlocal exception
             try:
@@ -135,9 +136,21 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
     try:
 
         with \
-                Popen(program, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc, \
-                thread(keep_only_most_recent, proc.stderr, stderr_deque) as (start_t_stderr, join_t_stderr), \
-                thread(input_to, proc.stdin) as (start_t_stdin, join_t_stdin):
+                Popen(
+                    program,
+                    stdin=PIPE,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                ) as proc, \
+                thread(
+                    keep_only_most_recent,
+                    proc.stderr,
+                    stderr_deque,
+                ) as (start_t_stderr, join_t_stderr), \
+                thread(
+                    input_to,
+                    proc.stdin,
+                ) as (start_t_stdin, join_t_stdin):
 
             try:
                 start_t_stderr()
@@ -167,7 +180,10 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
 
     chunk_generator.returncode = proc.returncode
     if proc.returncode:
-        raise IterableSubprocessError(proc.returncode, b''.join(stderr_deque)[-chunk_size:])
+        raise IterableSubprocessError(
+            proc.returncode,
+            b''.join(stderr_deque)[-chunk_size:],
+        )
 
 
 class IterableSubprocessError(SubprocessError):

--- a/datalad_next/iterable_subprocess/iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/iterable_subprocess.py
@@ -6,7 +6,12 @@ from threading import Thread
 
 
 @contextmanager
-def iterable_subprocess(program, input_chunks, chunk_size=65536):
+def iterable_subprocess(
+    program,
+    input_chunks,
+    chunk_size=65536,
+    cwd=None,
+):
     # This context starts a thread that populates the subprocess's standard input. It
     # also starts a threads that reads the process's standard error. Otherwise we risk
     # a deadlock - there is no output because the process is waiting for more input.
@@ -141,6 +146,7 @@ def iterable_subprocess(program, input_chunks, chunk_size=65536):
                     stdin=PIPE,
                     stdout=PIPE,
                     stderr=PIPE,
+                    cwd=cwd,
                 ) as proc, \
                 thread(
                     keep_only_most_recent,

--- a/datalad_next/runners/iter_subproc.py
+++ b/datalad_next/runners/iter_subproc.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+from pathlib import Path
 from typing import (
     Iterable,
     List,
@@ -20,6 +22,7 @@ def iter_subproc(
     *,
     input: Iterable[bytes] | None = None,
     chunk_size: int = COPY_BUFSIZE,
+    cwd: Path | None = None,
 ):
     """Context manager to communicate with a subprocess using iterables
 
@@ -87,6 +90,8 @@ def iter_subproc(
       subprocess's ``stdin``.
     chunk_size: int, optional
       Size of chunks to read from the subprocess's stdout/stderr in bytes.
+    cwd: Path
+      Working directory for the subprocess, passed to ``subprocess.Popen``.
 
     Returns
     -------
@@ -96,4 +101,5 @@ def iter_subproc(
         args,
         tuple() if input is None else input,
         chunk_size=chunk_size,
+        cwd=cwd,
     )

--- a/datalad_next/runners/tests/test_iter_subproc.py
+++ b/datalad_next/runners/tests/test_iter_subproc.py
@@ -1,0 +1,33 @@
+import pytest
+import sys
+
+from ..iter_subproc import (
+    iter_subproc,
+    IterableSubprocessError,
+)
+
+
+def test_iter_subproc_cwd(tmp_path):
+    test_content = 'some'
+    test_file_name = 'testfile'
+    test_file = tmp_path / test_file_name
+    test_file.write_text(test_content)
+
+    check_fx = \
+        "import sys\n" \
+        "if open('{input}').read() == '{content}':\n" \
+        "    print('okidoki')".format(
+            input=test_file_name,
+            content=test_content,
+        )
+    # we cannot read the test file without a full path, because
+    # CWD is not `tmp_path`
+    with pytest.raises(IterableSubprocessError) as e:
+        with iter_subproc([sys.executable, '-c', check_fx]):
+            pass
+        assert 'FileNotFoundError' in e.value
+
+    # but if we make it change to CWD, the same code runs
+    with iter_subproc([sys.executable, '-c', check_fx], cwd=tmp_path) as proc:
+        out = b''.join(proc)
+        assert b'okidoki' in out


### PR DESCRIPTION
Running in a particular working directory is a very common paradigm (think in a Git repository). So far, we used Git's `-C` option to perform the directory changes. This is fine, fast, and works universally.
    
However, recent discussion asked whether it would make sense to call annex commands via `git-annex`, rather than `git annex`. The former does not provide `-C`. This change readies the code for such a move.
    
Another use case for this is the passing of (many) file paths. With an option to run in a particular directory, the file names can be just that (not full paths). This can help to mitigate situations, where many file paths potentially exhaust the max command length.
