### PR TITLE
Change semantics of `PathBasedItem` names

### DIFF
--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -57,7 +57,6 @@ from datalad_next.iter_collections.utils import (
 )
 from datalad_next.iter_collections.gittree import (
     GitTreeItemType,
-    GitTreeItem,
     iter_gittree,
 )
 from datalad_next.iter_collections.gitworktree import (

--- a/datalad_next/commands/tests/test_ls_file_collection.py
+++ b/datalad_next/commands/tests/test_ls_file_collection.py
@@ -40,9 +40,9 @@ def _check_archive_member_result(r, collection):
     # a collection identifier, here the tar location
     assert 'collection' in r
     assert r['collection'] == collection
-    # an item identifier, here a path of an archive member
+    # an item identifier, here a str-path of an archive member
     assert 'item' in r
-    assert isinstance(r['item'], PurePath)
+    assert isinstance(r['item'], str)
     # item type info, here some filesystem-related category
     assert 'type' in r
     assert r['type'] in ('file', 'directory', 'symlink', 'hardlink')

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -134,6 +134,8 @@ def iter_annexworktree(
     Yields
     ------
     :class:`AnnexWorktreeItem` or :class:`AnnexWorktreeFileSystemItem`
+      The ``name`` attribute of an item is a ``PurePath`` instance with
+      the corresponding (relative) path, in platform conventions.
     """
 
     glsf = iter_gitworktree(

--- a/datalad_next/iter_collections/directory.py
+++ b/datalad_next/iter_collections/directory.py
@@ -47,6 +47,11 @@ def iter_dir(
     Yields
     ------
     :class:`DirectoryItem`
+      The ``name`` attribute of an item is a ``Path`` instance, with the
+      format matching the main ``path`` argument. When an absolute ``path``
+      is given, item names are absolute paths too. When a relative path is
+      given, it is relative to CWD, and items names are relative paths
+      (relative to CWD) too.
     """
     for c in path.iterdir():
         # c could disappear while this is running. Example: temp files managed

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -43,11 +43,12 @@ lgr = logging.getLogger('datalad.ext.next.iter_collections.gitworktree')
 
 @dataclass
 class GitWorktreeItem(GitTreeItem):
-    pass
+    name: PurePath
 
 
 @dataclass
 class GitWorktreeFileSystemItem(FileSystemItem):
+    name: PurePath
     # gitsha is not the sha1 of the file content, but the output
     # of `git hash-object` which does something like
     # `printf "blob $(wc -c < "$file_name")\0$(cat "$file_name")" | sha1sum`
@@ -133,6 +134,8 @@ def iter_gitworktree(
     Yields
     ------
     :class:`GitWorktreeItem` or :class:`GitWorktreeFileSystemItem`
+      The ``name`` attribute of an item is a ``PurePath`` instance with
+      the corresponding (relative) path, in platform conventions.
     """
     # we force-convert to Path to prevent delayed crashing when reading from
     # the file system. The docs already ask for that, but it is easy to

--- a/datalad_next/iter_collections/tests/test_itergittree.py
+++ b/datalad_next/iter_collections/tests/test_itergittree.py
@@ -35,7 +35,8 @@ def test_iter_gittree(existing_dataset, no_result_rendering):
     probe.write_text('probe')
     ds.save()
     assert any(
-        i.name == PurePosixPath(f'subdir/{probe_name}')
+        # let's query a Path instance here, to get that covered too
+        i.path == PurePosixPath(f'subdir/{probe_name}')
         and i.gitsha == expected_probe_sha
         and (
             i.gittype in (GitTreeItemType.file, GitTreeItemType.executablefile)
@@ -48,7 +49,7 @@ def test_iter_gittree(existing_dataset, no_result_rendering):
         # if we check the prior version, we do not see it (hence the
         # tree-ish passing is working
         assert not any(
-            i.name == PurePosixPath(f'subdir/{probe_name}')
+            i.path == PurePosixPath(f'subdir/{probe_name}')
             for i in iter_gittree(ds.pathobj, 'HEAD~1')
         )
 
@@ -57,11 +58,11 @@ def test_iter_gittree(existing_dataset, no_result_rendering):
     tracked_toplevel_items = list(
         iter_gittree(ds.pathobj, 'HEAD', recursive='no'))
     assert not any(
-        i.name == PurePosixPath(f'subdir/{probe_name}')
+        i.name == f'subdir/{probe_name}'
         for i in tracked_toplevel_items
     )
     assert any(
-        i.name == PurePosixPath('subdir')
+        i.name == 'subdir'
         and (True if is_crippled_fs
              else 'eb4aa65f42b90178837350571a227445b996cf90')
         and i.gittype == GitTreeItemType.directory
@@ -71,7 +72,7 @@ def test_iter_gittree(existing_dataset, no_result_rendering):
     tracked_subdir_items = list(iter_gittree(probe.parent, 'HEAD'))
     assert len(tracked_subdir_items) == 1
     probe_item = tracked_subdir_items[0]
-    assert probe_item.name == PurePosixPath(probe_name)
+    assert probe_item.name == probe_name
     assert probe_item.gitsha == expected_probe_sha
 
 
@@ -83,7 +84,7 @@ def test_name_starting_with_tab(existing_dataset, no_result_rendering):
     tabbed_name = ds.pathobj / tabbed_file_name
     tabbed_name.write_text('name of this file starts with a tab')
     ds.save()
-    iter_names = [item.name for item in iter_gittree(ds.pathobj, 'HEAD')]
+    iter_names = [item.path for item in iter_gittree(ds.pathobj, 'HEAD')]
     assert PurePosixPath(tabbed_file_name) in iter_names
 
 

--- a/datalad_next/iter_collections/tests/test_itertar.py
+++ b/datalad_next/iter_collections/tests/test_itertar.py
@@ -51,7 +51,7 @@ def test_iter_tar(sample_tar_xz):
                    'md5': 'ba1f2511fc30423bdbb183fe33f3dd0f'}
     targets = [
         TarfileItem(
-            name=PurePosixPath('test-archive'),
+            name='test-archive',
             type=FileSystemItemType.directory,
             size=0,
             mtime=1683657433,
@@ -59,16 +59,16 @@ def test_iter_tar(sample_tar_xz):
             uid=1000,
             gid=1000),
         TarfileItem(
-            name=PurePosixPath('test-archive') / '123.txt',
+            name='test-archive/123.txt',
             type=FileSystemItemType.symlink,
             size=0,
             mtime=1683657414,
             mode=511,
             uid=1000,
             gid=1000,
-            link_target=PurePosixPath('subdir') / 'onetwothree_again.txt'),
+            link_target='subdir/onetwothree_again.txt'),
         TarfileItem(
-            name=PurePosixPath('test-archive') / '123_hard.txt',
+            name='test-archive/123_hard.txt',
             type=FileSystemItemType.file,
             size=4,
             mtime=1683657364,
@@ -77,7 +77,7 @@ def test_iter_tar(sample_tar_xz):
             gid=1000,
             link_target=None),
         TarfileItem(
-            name=PurePosixPath('test-archive') / 'subdir',
+            name='test-archive/subdir',
             type=FileSystemItemType.directory,
             size=0,
             mtime=1683657400,
@@ -85,7 +85,7 @@ def test_iter_tar(sample_tar_xz):
             uid=1000,
             gid=1000),
         TarfileItem(
-            name=PurePosixPath('test-archive') / 'subdir' / 'onetwothree_again.txt',
+            name='test-archive/subdir/onetwothree_again.txt',
             type=FileSystemItemType.file,
             size=4,
             mtime=1683657400,
@@ -94,14 +94,14 @@ def test_iter_tar(sample_tar_xz):
             gid=1000,
             link_target=None),
         TarfileItem(
-            name=PurePosixPath('test-archive') / 'onetwothree.txt',
+            name='test-archive/onetwothree.txt',
             type=FileSystemItemType.hardlink,
             size=0,
             mtime=1683657364,
             mode=436,
             uid=1000,
             gid=1000,
-            link_target=PurePosixPath('test-archive') / '123_hard.txt'),
+            link_target='test-archive/123_hard.txt'),
     ]
     ires = []
     for i in iter_tar(sample_tar_xz, fp=True):

--- a/datalad_next/iter_collections/tests/test_iterzip.py
+++ b/datalad_next/iter_collections/tests/test_iterzip.py
@@ -4,7 +4,6 @@ from pathlib import PurePosixPath
 
 from ..zipfile import (
     FileSystemItemType,
-    _ZipFileDirPath,
     ZipfileItem,
     iter_zip,
 )
@@ -24,7 +23,7 @@ def sample_zip(tmp_path_factory):
 
     Layout::
 
-        test-archive
+        test-archive/
         ├── onetwothree.txt
         └── subdir/
             └── onetwothree<>again.txt
@@ -48,25 +47,25 @@ def test_iter_zip(sample_zip):
         'SHA1': 'b5dfcec4d1b6166067226fae102f7fbcf6bd1bd4',
         'md5': 'd700214df5487801e8ee23d31e60382a',
     }
-    root = PurePosixPath('test-archive')
+    root = 'test-archive'
     targets = [
         ZipfileItem(
-            name=_ZipFileDirPath(root),
+            name=f'{root}/',
             type=FileSystemItemType.directory,
             size=0,
         ),
         ZipfileItem(
-            name=root / 'onetwothree.txt',
+            name=f'{root}/onetwothree.txt',
             type=FileSystemItemType.file,
             size=8,
         ),
         ZipfileItem(
-            name=_ZipFileDirPath(root, 'subdir'),
+            name=f'{root}/subdir/',
             type=FileSystemItemType.directory,
             size=0,
         ),
         ZipfileItem(
-            name=root / 'subdir' / 'onetwothree<>again.txt',
+            name=f'{root}/subdir/onetwothree<>again.txt',
             type=FileSystemItemType.file,
             size=8,
         ),
@@ -89,15 +88,3 @@ def test_iter_zip(sample_zip):
         r.mtime = None
     for t in targets:
         assert t in ires
-
-
-def test_zip_dir_path():
-    zp1 = _ZipFileDirPath("a/b")
-    zp2 = _ZipFileDirPath("a/b")
-    zp3 = _ZipFileDirPath("a/c")
-    pp = PurePosixPath("a/b")
-
-    assert zp1.as_posix()[-1] == '/'
-    assert zp1 == zp2
-    assert zp1 != zp3
-    assert zp1 != pp


### PR DESCRIPTION
Previously, the `name` attribute was some kind of `PurePath` instance. The precise nature varied across item types and corresponding iterators.

This led to two problems:

- Performance (see #581): the creation of a Path instance is not particularly cheap. If a consumer does not need such an instance, and unconditional creation is a waste of resources
- Abstraction (see #430): the Path representation of a path-like name does not always match the exact semantics of the original name (it might have a trailing slash that has a purpose, etc)

Both problems are now addressed by relaxing the type of `.name` of a `PathBasedItem`. It can now be anything. Consumers that require an actual Path instance can use the `.path` attribute. An analog access is also implemented for `.link_target` (which now remains literal), that is accompanied by `.link_target_path`, where it was necessary.

This change in approach removed the need for the `_ZipFileDirPath` workaround that was used to re-establish compatibility of a Path-based `.name` with the conventions in a `ZipFile` collection/container. With the `.name` attribute retaining its native semantics, the workaround is no longer needed as was removed.

In order to document the (lack of) implemented homogeneous conventions for path-based items, the docstrings of all iterators have been amended with information on the nature of the `.name` attribute yielded by them. The corresponding data classes have received docstrings for the newly added properties for Path access.

These properties uniformly use the `cached_property` decorator. For the lifetime of an item, the nature of such a path should never change, and caching it automatically addresses the significant creation cost on accessing a path representation repeatedly.

Closes #554
Closes #581