### PR TITLE
Common helper to call Git subprocesses

### DIFF
--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -25,7 +25,7 @@ from datalad_next.itertools import (
     route_out,
     StoreOnly,
 )
-from datalad_next.runners import iter_subproc
+from datalad_next.runners import iter_git_subproc
 
 from .gitworktree import (
     GitWorktreeItem,
@@ -150,11 +150,10 @@ def iter_annexworktree(
     _annex_git_align: list[Any] = list()
 
     with \
-            iter_subproc(
+            iter_git_subproc(
                 # we get the annex key for any filename
                 # (or empty if not annexed)
-                ['git',
-                 'annex', 'find', '--anything', '--format=${key}\\n',
+                ['annex', 'find', '--anything', '--format=${key}\\n',
                  '--batch'],
                 # intersperse items with newlines to trigger a batch run
                 # this avoids string operations to append newlines to items
@@ -177,10 +176,9 @@ def iter_annexworktree(
                 ),
                 cwd=path,
             ) as gaf, \
-            iter_subproc(
+            iter_git_subproc(
                 # get the key properties JSON-lines style
-                ['git',
-                 'annex', 'examinekey', '--json', '--batch'],
+                ['annex', 'examinekey', '--json', '--batch'],
                 # use only non-empty keys as input to `git annex examinekey`.
                 input=intersperse(
                     # Add line ending to submit the key to batch processing in

--- a/datalad_next/iter_collections/gittree.py
+++ b/datalad_next/iter_collections/gittree.py
@@ -14,7 +14,7 @@ from pathlib import (
 )
 from typing import Generator
 
-from datalad_next.runners import iter_subproc
+from datalad_next.runners import iter_git_subproc
 from datalad_next.itertools import (
     decode_bytes,
     itemize,
@@ -118,9 +118,8 @@ def _get_tree_item(spec: str) -> GitTreeItem:
 
 
 def _git_ls_tree(path, *args):
-    with iter_subproc(
+    with iter_git_subproc(
             [
-                'git',
                 'ls-tree',
                 # we rely on zero-byte splitting below
                 '-z',

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -18,7 +18,7 @@ from typing import (
     Tuple,
 )
 
-from datalad_next.runners import iter_subproc
+from datalad_next.runners import iter_git_subproc
 from datalad_next.itertools import (
     decode_bytes,
     itemize,
@@ -291,9 +291,8 @@ def _lsfiles_line2props(
 
 
 def _git_ls_files(path, *args):
-    with iter_subproc(
+    with iter_git_subproc(
             [
-                'git',
                 'ls-files',
                 # we rely on zero-byte splitting below
                 '-z',

--- a/datalad_next/runners/__init__.py
+++ b/datalad_next/runners/__init__.py
@@ -17,6 +17,7 @@ of a Git repository.
    GitRunner
    Runner
    iter_subproc
+   iter_git_subproc
 
 Additional information on the design of the subprocess execution tooling
 is available from https://docs.datalad.org/design/threaded_runner.html
@@ -44,6 +45,7 @@ inspired by ``asyncio.SubprocessProtocol``.
 
 from .iter_subproc import (
     iter_subproc,
+    iter_git_subproc,
     IterableSubprocessError,
 )
 

--- a/datalad_next/runners/iter_subproc.py
+++ b/datalad_next/runners/iter_subproc.py
@@ -14,7 +14,7 @@ from datalad_next.iterable_subprocess.iterable_subprocess import (
 )
 from datalad_next.consts import COPY_BUFSIZE
 
-__all__ = ['iter_subproc']
+__all__ = ['iter_subproc', 'iter_git_subproc']
 
 
 def iter_subproc(
@@ -103,3 +103,20 @@ def iter_subproc(
         chunk_size=chunk_size,
         cwd=cwd,
     )
+
+
+def iter_git_subproc(
+    args: List[str],
+    **kwargs
+):
+    """``iter_subproc()`` wrapper for calling Git commands
+
+    All argument semantics are identical to those of ``iter_subproc()``,
+    except that ``args`` must not contain the Git binary, but need to be
+    exclusively arguments to it. The respective `git` command/binary is
+    automatically added internally.
+    """
+    cmd = ['git']
+    cmd.extend(args)
+
+    return iter_subproc(cmd, **kwargs)


### PR DESCRIPTION
This is a thin wrapper around `iter_subproc` that is to be used unconditionally whenever the command given to `iter_subproc` would start with `git`.

Presently, this wrapper does nothing but adding that `'git'` argument to the front of any argument list.

Eventually, it might be used to call a configurable Git binary, establish certain environment conditions for all Git calls, etc.

Right now, this is just cheap future-proofing.

Closes #584