### PR TITLE
Add support subpackage for Git's pathspecs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,7 @@ build: off
 
 environment:
   # unless indicated otherwise, we test datalad_next
-  DTS: datalad_next
+  DTS: datalad_next.gitpathspecs datalad_next.iter_collections
   # SSH testing is done via a side-loaded container that provides a POSIX/SSHable
   # server environment
   DATALAD_TESTS_DOCKER_SSHD_SECKEY_DOWNLOADURL: https://ci.appveyor.com/api/projects/mih/datalad-ci-docker-containers/artifacts/recipes/sshd/id_rsa?job=sshd
@@ -131,75 +131,75 @@ environment:
       DATALAD_TESTS_SERVER_SSH_PATH: /Users/appveyor/DLTMP/riaroot
       DATALAD_TESTS_SERVER_LOCALPATH: /Users/appveyor/DLTMP/riaroot
 
-    # run a subset of the core tests on the oldest supported Python version
-    - job_name: datalad-core-1
-      DTS: >
-        datalad.cli
-        datalad.core
-      # do not run tests that ensure behavior we intentionally changed
-      # - test_gh1811: is included in next in an alternative implementation
-      # - test_librarymode: assumes that CLI config overrides end up in the
-      #   session `datalad.cfg.overrides`, but -next changes that behavior
-      #   to have `.overrides` be uniformly limited to instance overrides
-      KEYWORDS: not test_gh1811 and not test_librarymode
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-2
-      DTS: >
-        datalad.customremotes
-        datalad.dataset
-        datalad.distributed
-        datalad.downloaders
-        datalad.interface
-      # do not run tests that ensure behavior we intentionally changed
-      # - test_gh1811: is included in next in an alternative implementation
-      # - test_fake_gitlab: we have an updated variant in next
-      # - test_dryrun: we have an updated variant in next; what is disabled is
-      #   the one in test_create_sibling_gitlab.py. However, there is one with
-      #   identical name in test_create_sibling_ghlike.py, now also disabled
-      #   because MIH does not know better
-      KEYWORDS: not test_gh1811 and not test_fake_gitlab and not test_dryrun
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-3
-      DTS: >
-        datalad.distribution
-      KEYWORDS: not test_invalid_args
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-4
-      DTS: >
-        datalad.local
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-5
-      DTS: >
-        datalad.runner
-        datalad.support
-        datalad.tests
-        datalad.ui
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    ## run a subset of the core tests on the oldest supported Python version
+    #- job_name: datalad-core-1
+    #  DTS: >
+    #    datalad.cli
+    #    datalad.core
+    #  # do not run tests that ensure behavior we intentionally changed
+    #  # - test_gh1811: is included in next in an alternative implementation
+    #  # - test_librarymode: assumes that CLI config overrides end up in the
+    #  #   session `datalad.cfg.overrides`, but -next changes that behavior
+    #  #   to have `.overrides` be uniformly limited to instance overrides
+    #  KEYWORDS: not test_gh1811 and not test_librarymode
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-2
+    #  DTS: >
+    #    datalad.customremotes
+    #    datalad.dataset
+    #    datalad.distributed
+    #    datalad.downloaders
+    #    datalad.interface
+    #  # do not run tests that ensure behavior we intentionally changed
+    #  # - test_gh1811: is included in next in an alternative implementation
+    #  # - test_fake_gitlab: we have an updated variant in next
+    #  # - test_dryrun: we have an updated variant in next; what is disabled is
+    #  #   the one in test_create_sibling_gitlab.py. However, there is one with
+    #  #   identical name in test_create_sibling_ghlike.py, now also disabled
+    #  #   because MIH does not know better
+    #  KEYWORDS: not test_gh1811 and not test_fake_gitlab and not test_dryrun
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-3
+    #  DTS: >
+    #    datalad.distribution
+    #  KEYWORDS: not test_invalid_args
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-4
+    #  DTS: >
+    #    datalad.local
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-5
+    #  DTS: >
+    #    datalad.runner
+    #    datalad.support
+    #    datalad.tests
+    #    datalad.ui
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
 
 
 # do not run the CI if only documentation changes were made

--- a/datalad_next/gitpathspecs/__init__.py
+++ b/datalad_next/gitpathspecs/__init__.py
@@ -72,6 +72,8 @@ class GitPathSpec:
                     *GitPathSpec._split_prefix_pattern(
                         testpattern[len(testsubdir):])
                 )]
+            else:
+                return []
         elif str(self) == ':':
             return []
         elif 'glob' in self.spectypes:
@@ -104,6 +106,9 @@ class GitPathSpec:
         testpattern = self._get_joined_pattern()
         testsubdir = subdir
         tp = testpattern
+        if 'icase' in self.spectypes:
+            testsubdir = subdir.casefold()
+            tp = testpattern.casefold()
         while tp:
             if fnmatch.fnmatch(testsubdir, tp):
                 # tp is a match for subdir, subtract it from the full pattern.

--- a/datalad_next/gitpathspecs/__init__.py
+++ b/datalad_next/gitpathspecs/__init__.py
@@ -1,0 +1,238 @@
+#
+# Intentionally written without importing datalad code
+#
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fnmatch
+from itertools import chain
+
+
+@dataclass(frozen=True)
+class GitPathSpec:
+    # TODO think about adding support for another magic that represents
+    # the root of a repository hierarchy (amending 'top', which is
+    # the root of the working tree -- but presumably for a single repository
+    spectypes: tuple[str]
+    dirprefix: str
+    pattern: str
+
+    def __str__(self) -> str:
+        """Generate normalized (long-form) pathspec"""
+        if not self.spectypes and not self.dirprefix and not self.pattern:
+            return ':'
+        ps = ''
+        if self.spectypes:
+            ps += ':('
+            ps += ','.join(self.spectypes)
+            ps += ')'
+        ps += self._get_joined_pattern()
+        return ps
+
+    def _get_joined_pattern(self):
+        return f'{self.dirprefix if self.dirprefix else ""}' \
+            f'{"/" if self.dirprefix else ""}' \
+            f'{self.pattern if self.pattern else ""}'
+
+    def for_subdir(self, subdir: str) -> list[GitPathSpec]:
+        """
+        The following rules apply to particular magic pathspecs:
+
+        - 'top' are not modified. This makes them essentially
+          relative to the root of the respective repository
+
+        Parameters
+        ----------
+        subdir: str
+          Relative path in POSIX notation
+
+        split into sd_parts
+        split into pattern_parts
+
+        """
+        if not subdir:
+            return [self]
+        elif 'top' in self.spectypes:
+            # no need to mangle, these are treated as absolute to
+            # any repo they are evaluated one -- this means that
+            # they are OK to change their reference when moving
+            # into submodules
+            return [self]
+        elif 'literal' in self.spectypes:
+            testpattern = self._get_joined_pattern()
+            testsubdir = subdir if subdir.endswith('/') else f'{subdir}/'
+            # TODO icase
+            if (
+                ('icase' in self.spectypes
+                 and testpattern.casefold().startswith(testsubdir.casefold()))
+                or testpattern.startswith(testsubdir)
+            ):
+                return [GitPathSpec(
+                    self.spectypes,
+                    *GitPathSpec._split_prefix_pattern(
+                        testpattern[len(testsubdir):])
+                )]
+        elif str(self) == ':':
+            return []
+        elif 'glob' in self.spectypes:
+            raise NotImplementedError
+        else:
+            # "ordinary" pathspec with fnmatch
+            # we find the shortest and the longest match for the subdir
+            # and report the list of unique results.
+            # we do that, because we only have partial knowledge of a
+            # would-be matching path. Any '*' might potentially match
+            # more than just the subdir, thereby consuming more of the
+            # pathspec than we can know here.
+            #
+            # We report the shortest and longest detectable match -- not
+            # because this is a complete or correct solution, but because it
+            # adds support for relatively common usecases, e.g. `*item*.jpg`
+            # (match any .jpg file with "item" somewhere is its path.
+            # The shortest match for a translation to a "moreitem/" would cause
+            # a translated pathspec of `*item*.jpg` (already the initial '*'
+            # matches the full subdir, hence any FILEname inside that subdir
+            # would now be required to contain "item". The longest match,
+            # however, translates to `*.jpg`, which is more fitting for the
+            # underlying intentions.
+            return list(set(chain(
+                self._find_shortest_subspec_fnmatch(subdir, 'shortest'),
+                self._find_longest_subspec_fnmatch(subdir, 'longest'),
+            )))
+
+    def _find_longest_subspec_fnmatch(self, subdir: str, mode: str):
+        testpattern = self._get_joined_pattern()
+        testsubdir = subdir
+        tp = testpattern
+        while tp:
+            if fnmatch.fnmatch(testsubdir, tp):
+                # tp is a match for subdir, subtract it from the full pattern.
+                # we do not want to strip a '*', it has the potential to
+                # match more than just the present subdir
+                final = testpattern[len(tp) - (1 if tp.endswith('*') else 0):]
+                # strip initial directory separators, make no sense when
+                # porting to a subdir
+                final = final.lstrip('/')
+                if final:
+                    yield GitPathSpec(
+                        self.spectypes,
+                        *GitPathSpec._split_prefix_pattern(final)
+                    )
+                return
+            # get the next chunk
+            idx = index_any(tp.rindex, ['/', '*'], 0, len(tp))
+            if idx is None:
+                # we scanned the whole pattern and nothing matched
+                return
+            tp = tp[:idx]
+
+    def _find_shortest_subspec_fnmatch(self, subdir: str, mode: str):
+        testpattern = self._get_joined_pattern()
+        # add a trailing directory separator to prevent undesired
+        # matches of partial directory names
+        testsubdir = subdir if subdir.endswith('/') else f'{subdir}/'
+        tp = None
+        while tp is None or (len(tp) + 1 < len(testpattern)):
+            # get the next chunk
+            idx = index_any(
+                testpattern.index,
+                ['/', '*'],
+                0 if tp is None else (len(tp) + 1),
+                len(testpattern),
+            )
+            if idx is None:
+                # we scanned the whole pattern and nothing matched, use the
+                # full pattern with a trailing / (because we added that to
+                # testsubdir)
+                tp = f'{testpattern}/'
+            else:
+                tp = testpattern[:idx + 1]
+            if fnmatch.fnmatch(testsubdir, tp):
+                # tp is a match for subdir, subtract it from the full pattern.
+                # we do not want to strip a '*', it has the potential to
+                # match more than just the present subdir
+                final = testpattern[len(tp) - (1 if tp.endswith('*') else 0):]
+                if final:
+                    # do not emit a non-pathspec to avoid any downstream
+                    # processing giving a non-pattern is the same as not
+                    # given one
+                    yield GitPathSpec(
+                        self.spectypes,
+                        *GitPathSpec._split_prefix_pattern(final)
+                    )
+                return
+
+    @classmethod
+    def from_pathspec_str(
+        cls,
+        pathspec: str,
+    ) -> GitPathSpec:
+        spectypes = []
+        dirprefix = None
+        pattern = None
+
+        if pathspec.startswith(':('):
+            # long-form magic
+            magic, pattern = pathspec[2:].split(')', maxsplit=1)
+            spectypes = magic.split(',')
+        elif pathspec.startswith(':'):
+            # short-form magic
+            magic_signatures = {
+                '/': 'top',
+                '!': 'exclude',
+                '^': 'exclude',
+                ':': None,
+            }
+            pattern = pathspec[1:]
+            spectypes = []
+            for i in range(1, len(pathspec)):
+                sig = magic_signatures.get(pathspec[i])
+                if sig is None:
+                    pattern = pathspec[i:]
+                    break
+                spectypes.append(sig)
+        else:
+            pattern = pathspec
+
+        # TODO raise when glob and literal magic markers are present
+        # simultaneously
+        if 'glob' in spectypes and 'literal' in spectypes:
+            raise ValueError('glob magic is incompatible with literal magic')
+
+        # split off dirprefix
+        dirprefix, pattern = GitPathSpec._split_prefix_pattern(pattern)
+
+        return cls(
+            spectypes=tuple(spectypes),
+            dirprefix=dirprefix,
+            pattern=pattern,
+        )
+
+    @staticmethod
+    def _split_prefix_pattern(pathspec):
+        # > the pathspec up to the last slash represents a directory prefix.
+        # > The scope of that pathspec is limited to that subtree.
+        try:
+            last_slash_idx = pathspec[::-1].index('/')
+        except ValueError:
+            # everything is the pattern
+            dirprefix = None
+            pattern = pathspec
+        else:
+            dirprefix = pathspec[:-last_slash_idx - 1]
+            pattern = pathspec[-last_slash_idx:] \
+                if last_slash_idx > 0 else None
+        return dirprefix, pattern
+
+
+def index_any(fx, subs: list[str], start: int, end: int) -> int | None:
+    idx = []
+    for sub in subs:
+        try:
+            idx.append(fx(sub, start, end))
+        except ValueError:
+            pass
+    if not idx:
+        return None
+    else:
+        return min(idx)

--- a/datalad_next/gitpathspecs/tests/test_gitpathspec.py
+++ b/datalad_next/gitpathspecs/tests/test_gitpathspec.py
@@ -172,11 +172,34 @@ def pathspec_match_testground(tmp_path_factory):
                     None: {'match': ['sub/a?a/a.JPG']},
                     "sub/a?a": {
                         'specs': [':(literal,icase)a.jpg'],
+                        # given the spec transformation matches
                         # MIH would really expect to following,
-                        # but it is not coming :(
+                        # but it is not coming from Git :(
                         #'match': ['a.JPG'],
                         'match': [],
                     },
+                },
+            ),
+            dict(
+                ps=':(icase)A?A/a.jpg',
+                fordir={
+                    None: {'match': ['a?a/a.JPG', 'aba/a.JPG']},
+                    "aba": {
+                        'specs': [':(icase)a.jpg'],
+                        'match': ['a.JPG'],
+                    },
+                },
+            ),
+            dict(
+                ps=':(literal,icase)A?A/a.jpg',
+                fordir={
+                    None: {'match': ['a?a/a.JPG']},
+                    "a?a": {
+                        'specs': [':(literal,icase)a.jpg'],
+                        'match': ['a.JPG'],
+                    },
+                    # the target subdir does not match the pathspec
+                    "aba": {'specs': set()},
                 },
             ),
         ])

--- a/datalad_next/gitpathspecs/tests/test_gitpathspec.py
+++ b/datalad_next/gitpathspecs/tests/test_gitpathspec.py
@@ -1,0 +1,196 @@
+import pytest
+import subprocess
+
+from .. import (
+    GitPathSpec,
+)
+
+
+def _list_files(path, pathspecs):
+    return [
+        i for i in subprocess.run(
+            ['git', 'ls-files', '-z', '--other', '--', *pathspecs],
+            capture_output=True,
+            cwd=path,
+        ).stdout.decode('utf-8').split('\0')
+        if i
+    ]
+
+
+@pytest.fixture(scope="function")
+def pathspec_match_testground(tmp_path_factory):
+    """Create a Git repo with no commit and many untracked files
+
+    In this playground, `git ls-files --other` can be used to testrun
+    pathspecs.
+
+    See the top item in `testcases` for a summary of the content
+    """
+    p = tmp_path_factory.mktemp('pathspec_match')
+    subprocess.run(['git', 'init'], cwd=p, check=True)
+    p_sub = p / 'sub'
+    p_sub.mkdir()
+    for d in (p, p_sub):
+        p_a = d / 'aba'
+        p_b = d / 'a?a'
+        for sp in (p_a, p_b):
+            sp.mkdir()
+            for fname in ('a.txt', 'A.txt', 'a.JPG'):
+                (sp / fname).touch()
+    # add something that is unique to sub/
+    (p_sub / 'b.dat').touch()
+    yield p
+
+
+testcases = [
+    # valid
+    dict(
+        ps=':',
+        fordir={
+            None: {'specs': [':'],
+                   'match': [
+                       'a?a/A.txt', 'a?a/a.JPG', 'a?a/a.txt',
+                       'aba/A.txt', 'aba/a.JPG', 'aba/a.txt',
+                       'sub/a?a/A.txt', 'sub/a?a/a.JPG', 'sub/a?a/a.txt',
+                       'sub/aba/A.txt', 'sub/aba/a.JPG', 'sub/aba/a.txt',
+                       'sub/b.dat'],
+            },
+            'sub': {'specs': [],
+                    'match': [
+                        'a?a/A.txt', 'a?a/a.JPG', 'a?a/a.txt',
+                        'aba/A.txt', 'aba/a.JPG', 'aba/a.txt',
+                        'b.dat'],
+            },
+        },
+    ),
+    dict(
+        ps='aba',
+        fordir={
+            None: {'match': ['aba/A.txt', 'aba/a.JPG', 'aba/a.txt']},
+            'aba': {'specs': [],
+                    'match': ['A.txt', 'a.JPG', 'a.txt']},
+        },
+    ),
+    # same as above, but with a trailing slash
+    dict(
+        ps='aba/',
+        fordir={
+            None: {'match': ['aba/A.txt', 'aba/a.JPG', 'aba/a.txt']},
+            'aba': {'specs': [],
+                    'match': ['A.txt', 'a.JPG', 'a.txt']},
+        },
+    ),
+    dict(
+        ps=':(glob)aba/*.txt',
+        fordir={
+            None: {'match': ['aba/A.txt', 'aba/a.txt']},
+        },
+    ),
+    dict(
+        ps=':/aba/*.txt',
+        norm=':(top)aba/*.txt',
+        fordir={
+            None: {'match': ['aba/A.txt', 'aba/a.txt']},
+            # for a subdir a keeps matching the exact same items
+            # not only be name, but by location
+            'sub': {'specs': [':(top)aba/*.txt'],
+                    'match': ['../aba/A.txt', '../aba/a.txt']},
+        },
+    ),
+    dict(
+        ps='aba/*.txt',
+        fordir={
+            None: {'match': ['aba/A.txt', 'aba/a.txt']},
+            # not applicable
+            'sub': {'specs': []},
+            # but this is
+            'aba': {'specs': ['*.txt']},
+        },
+    ),
+    dict(
+        ps='sub/aba/*.txt',
+        fordir={
+            None: {'match': ['sub/aba/A.txt', 'sub/aba/a.txt']},
+            'sub': {'specs': ['aba/*.txt'],
+                    'match': ['aba/A.txt', 'aba/a.txt']},
+        },
+    ),
+    dict(
+        ps='*.JPG',
+        fordir={
+            None: {'match': ['a?a/a.JPG', 'aba/a.JPG', 'sub/a?a/a.JPG',
+                             'sub/aba/a.JPG']},
+            # unchanged
+            'sub': {'specs': ['*.JPG']},
+        },
+    ),
+    dict(
+        ps='*ba*.JPG',
+        fordir={
+            None: {'match': ['aba/a.JPG', 'sub/aba/a.JPG']},
+            'aba': {'specs': ['*ba*.JPG', '*.JPG'],
+                    'match': ['a.JPG']},
+        },
+    ),
+    dict(
+        ps=':(literal)a?a/a.JPG',
+        fordir={
+            None: dict(
+                match=['a?a/a.JPG'],
+            ),
+            "a?a": dict(
+                specs=[':(literal)a.JPG'],
+                match=['a.JPG'],
+            ),
+        },
+    ),
+    dict(
+        ps=':(literal,icase)SuB/A?A/a.jpg',
+        fordir={
+            None: {'match': ['sub/a?a/a.JPG']},
+            "sub/a?a": {
+                'specs': [':(literal,icase)a.jpg'],
+                # MIH would really expect to following,
+                # but it is not coming :(
+                #'match': ['a.JPG'],
+                'match': [],
+            },
+        },
+    ),
+    # invalid
+    #
+    # conceptual conflict and thereby unsupported by Git
+    # makes sense and is easy to catch that
+    dict(ps=':(glob,literal)broken', raises=ValueError),
+]
+
+
+def test_pathspecs(pathspec_match_testground):
+    tg = pathspec_match_testground
+
+    for testcase in testcases:
+        if testcase.get('raises'):
+            # test case states how `GitPathSpec` will blow up
+            # on this case. Verify and skip any further testing
+            # on this case
+            with pytest.raises(testcase['raises']):
+                GitPathSpec.from_pathspec_str(testcase['ps'])
+            continue
+        # create the instance
+        ps = GitPathSpec.from_pathspec_str(testcase['ps'])
+        # if no deviating normalized representation is given
+        # it must match the original one
+        assert str(ps) == testcase.get('norm', testcase['ps'])
+        # test translations onto subdirs now
+        # `None` is a special subdir that means "self", i.e.
+        # not translation other than normalization, we can use it
+        # to test matching behavior of the full pathspec
+        for subdir, target in testcase.get('fordir', {}).items():
+            # translate -- a single input pathspec can turn into
+            # multiple translated ones. This is due to
+            subdir_specs = [str(s) for s in ps.for_subdir(subdir)]
+            if 'specs' in target:
+                assert set(subdir_specs) == set(target['specs'])
+            if 'match' in target:
+                tg_subdir = tg / subdir if subdir else tg
+                assert _list_files(tg_subdir, subdir_specs) == target['match']


### PR DESCRIPTION
The main (if not only) purpose of this functionality is pathspec mangling/translation for handing them over to analog Git command calls on submodules -- for any Git command that supports pathspecs, but not recursion.

A simple example for such a command is `git ls-files --other`. It accepts pathspecs, but does not implement `--recurse-submodules` for listing untracked files.

The goal of this functionality is to be able to take pathspecs that is valid in the context of a top-level repository, and translate it such that the set of paths specs given to the same command running on/in a submodule/subdirectory gives the same results, as if the initial top-level invocation reported them (if it even could).

The included sketch of a testbattery uses ``git ls-files --other` for testing, rather than a formal description -- because the behavior of the implementation is more elaborate than the documentation at https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec suggests.

All testing is (for now) performed within a single repository, and with translation for execution in subdirectories.

The implementation is a rough sketch for exploring the problem, rather than anything polished.

Ping #587

Also see https://github.com/datalad/datalad/issues/6933

TODO:

- [x] ready tests for case-insensitive file systems
- [ ] support `:(glob)` pathspecs via `PurePath.match()`
- [ ] test `:(exclude)` pathspec handling
- [ ] test `:(attr:...)` pathspec handling
- [x] have another go at figuring out why the `icase` magic does not work as documented
- [ ] add optimization to bypass expensive translations when a pathspec is just a path with no wildcards
- [ ] Add constraint to validate pathspecs
- [ ] Add pathspec support to `iter_submodules()`. Alternatively, add pathspec support to `iter_gitworktree()`. However, the former could be less complex. We could take any reported submodule, and try to port any given pathspec to it, and report only submodule that has any match. In `iter_gitworktree()` we'd have the problem that `git ls-files` is totally silent if given a pathspec that points (exclusively) into a submodule.