### PR TITLE
New `iter_gitdiff`

### DIFF
--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -19,6 +19,7 @@ collections.
 
    annexworktree
    directory
+   gitdiff
    gittree
    gitworktree
    tarfile

--- a/datalad_next/iter_collections/gitdiff.py
+++ b/datalad_next/iter_collections/gitdiff.py
@@ -1,0 +1,306 @@
+"""Report on the difference of two Git tree-ishes or the worktree
+
+The main functionality is provided by the :func:`iter_gitdiff()` function.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from functools import cached_property
+import logging
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+import subprocess
+from typing import Generator
+
+from datalad_next.runners import iter_subproc
+from datalad_next.itertools import (
+    decode_bytes,
+    itemize,
+)
+
+from .gittree import (
+    GitTreeItem,
+    GitTreeItemType,
+    _mode_type_map,
+)
+
+lgr = logging.getLogger('datalad.ext.next.iter_collections.gitdiff')
+
+
+# TODO Could be `StrEnum`, came with PY3.11
+class GitDiffStatus(Enum):
+    """Enumeration of statuses for diff items
+    """
+    addition = 'A'
+    copy = 'C'
+    deletion = 'D'
+    modification = 'M'
+    rename = 'R'
+    typechange = 'T'
+    unmerged = 'U'
+    unknown = 'X'
+
+
+_diffstatus_map = {
+    'A': GitDiffStatus.addition,
+    'C': GitDiffStatus.copy,
+    'D': GitDiffStatus.deletion,
+    'M': GitDiffStatus.modification,
+    'R': GitDiffStatus.rename,
+    'T': GitDiffStatus.typechange,
+    'U': GitDiffStatus.unmerged,
+    'X': GitDiffStatus.unknown,
+}
+
+
+@dataclass
+class GitDiffItem(GitTreeItem):
+    """``GitTreeItem`` with "previous" property values given a state comparison
+    """
+    prev_name: str | None = None
+    prev_gitsha: str | None = None
+    prev_gittype: GitTreeItemType | None = None
+
+    status: GitDiffStatus | None = None
+    percentage: int | None = None
+    """This is the percentage of similarity for copy-status and
+    rename-status diff items, and the percentage of dissimilarity
+    for modifications."""
+
+    @cached_property
+    def prev_path(self) -> PurePosixPath:
+        """Returns the item ``prev_name`` as a ``PurePosixPath``
+        instance"""
+        if self.prev_name:
+            return PurePosixPath(self.prev_name)
+
+
+def iter_gitdiff(
+    path: Path,
+    from_treeish: str | None,
+    to_treeish: str | None,
+    *,
+    recursive: str = 'repository',
+    find_renames: int | None = None,
+    find_copies: int | None = None,
+) -> Generator[GitTreeItem, None, None]:
+    """
+    Notes on 'no' recursion mode
+
+    When comparing to the worktree, ``git diff-index`` always reports on
+    subdirectories. For homogeneity with the report on a committed tree,
+    a non-recursive mode emulation is implemented. It compresses all reports
+    from a direct subdirectory into a single report on that subdirectory.
+    The ``gitsha`` of that directory item will always be ``None``. Moreover,
+    no type or typechange inspection, or further filesystem queries are
+    performed. Therefore, ``prev_gittype`` will always be ``None``, and
+    any change other than the addition of the directory will be labeled
+    as a ``GitDiffStatus.modification``.
+
+    Parameters
+    ----------
+    path: Path
+      Path of a directory in a Git repository to report on. This directory
+      need not be the root directory of the repository, but must be part of
+      the repository. If the directory is not the root directory of a
+      non-bare repository, the iterator is constrained to items underneath
+      that directory.
+    recursive: {'repository', 'no'}, optional
+      Behavior for recursion into subtrees. By default (``repository``),
+      all tree within the repository underneath ``path``) are reported,
+      but not tree within submodules. If ``no``, only direct children
+      are reported on.
+
+    Yields
+    ------
+    :class:`GitDiffItem`
+      The ``name`` and ``prev_name`` attributes of an item are a ``str`` with
+      the corresponding (relative) path, as reported by Git
+      (in POSIX conventions).
+    """
+    # we force-convert to Path to give us the piece of mind we want.
+    # The docs already ask for that, but it is easy to
+    # forget/ignore and leads to non-obvious errors. Running this once is
+    # a cheap safety net
+    path = Path(path)
+
+    # from   : to   : description
+    # ---------------------------
+    # HEAD   : None : compare to worktree, not with the index (diff-index)
+    # HEAD~2 : HEAD : compare trees (diff-tree)
+    # None   : HEAD~2 : compare tree with its parents (diff-tree)
+    # None   : None : exception
+
+    common_args = [
+        '--no-rename-empty',
+        # ignore changes above CWD
+        '--relative',
+        '--raw',
+        '-z',
+    ]
+    if find_renames is not None:
+        common_args.append(f'--find-renames={find_renames}%')
+    if find_copies is not None:
+        common_args.append(f'--find-copies={find_copies}%')
+        # if someone wants to look for copies, we actually look
+        # for copies. This is expensive, but IMHO is the one
+        # thing that makes this useful
+        # TODO possibly we only want to enable this when
+        # find_copies==100 (exact copies), based on the assumption
+        # that this is cheaper than reading all file content.
+        # but if that is actually true remains to be tested
+        common_args.append(f'--find-copies-harder')
+
+    if from_treeish is None and to_treeish is None:
+        raise ValueError(
+            'either `from_treeish` or `to_treeish` must not be None')
+    elif to_treeish is None:
+        cmd = ['diff-index', *common_args, from_treeish]
+    else:
+        # diff NOT against the working tree
+        cmd = ['diff-tree', *common_args]
+        if recursive == 'repository':
+            cmd.append('-r')
+        if from_treeish is None:
+            cmd.append(to_treeish)
+        else:
+            # two tree-ishes given
+            cmd.extend((from_treeish, to_treeish))
+
+    # when do we need to condense subdir reports into a single dir-report
+    reported_dirs = set()
+    _single_dir = (cmd[0] == 'diff-index') and recursive == 'no'
+    # diff-tree reports the compared tree when no from is given, we need
+    # to skip that output below
+    skip_first = (cmd[0] == 'diff-tree') and from_treeish is None
+    pending_props = None
+    for line in _git_diff_something(path, cmd):
+        if skip_first:
+            # RAW output format starts with hash that is being compared
+            # we ignore it
+            skip_first = False
+            continue
+        if pending_props:
+            pending_props.append(line)
+            if pending_props[4][0] in ('C', 'R'):
+                # for copies and renames we expect a second path
+                continue
+            item = _get_diff_item(pending_props, _single_dir, reported_dirs,
+                                  from_treeish, path)
+            if item:
+                yield item
+            pending_props = None
+        elif line.startswith(':'):
+            pending_props = line[1:].split(' ')
+        else:  # pragma: no cover
+            raise RuntimeError(
+                'we should not get here, unexpected diff output')
+    if pending_props:
+        item = _get_diff_item(pending_props, _single_dir, reported_dirs,
+                              from_treeish, path)
+        if item:
+            yield item
+
+
+def _get_diff_item(
+        spec: list,
+        single_dir: bool,
+        reported_dirs: set,
+        from_treeish: str | None,
+        cwd: Path,
+) -> GitDiffItem:
+    props: dict[str, str | int | GitTreeItemType] = {}
+    props.update(
+        (k, _mode_type_map.get(v, None))
+        for k, v in (('prev_gittype', spec[0]),
+                     ('gittype', spec[1]))
+    )
+    props.update(
+        (k, None if v == (40 * '0') else v)
+        for k, v in (('prev_gitsha', spec[2]),
+                     ('gitsha', spec[3]))
+    )
+    status = spec[4]
+    props['status'] = _diffstatus_map[status[0]]
+    if len(status) > 1:
+        props['percentage'] = int(status[1:])
+
+    if status == 'A':
+        # this is an addition, we want `name` in the right place
+        props['name'] = spec[5]
+    else:
+        props['prev_name'] = spec[5]
+        props['name'] = spec[6] if len(spec) > 6 else spec[5]
+
+    if not single_dir:
+        return GitDiffItem(**props)
+
+    # we decide on mangling the actual report to be on the containing directory
+    # only, or to withhold it entirely
+    dname_l = (props['name'] or props['prev_name']).split('/', maxsplit=1)
+    if len(dname_l) < 2:
+        # nothing in a subdirectory
+        return GitDiffItem(**props)
+    dname = dname_l[0]
+    if dname in reported_dirs:
+        # nothing else todo, we already reported
+        return
+
+    reported_dirs.add(dname)
+    return _mangle_item_for_singledir(props, dname, from_treeish, cwd)
+
+
+def _mangle_item_for_singledir(props, dname, from_treeish, cwd):
+    # at this point we have a change report on subdirectory content
+    # we only get here when comparing `from_treeish` to the worktree.
+    props['name'] = dname
+    # non-committed change -> no SHA (this ignored the index,
+    # like we do elsewhere too)
+    props['gitsha'] = None
+    props['gittype'] = GitTreeItemType.directory
+    try:
+        props['prev_gitsha'] = subprocess.run(
+            ['git', 'rev-parse', '-q', f'{from_treeish}:./{dname}'],
+            capture_output=True,
+            check=True,
+            cwd=cwd,
+        ).stdout.decode('utf-8').rstrip()
+        # if we get here, we know that the name was valid in
+        # `from_treeish` too
+        props['prev_name'] = dname
+        # it would require more calls to figure out the mode and infer
+        # a possible type change. For now, we do not go there
+        props['prev_gittype'] = None
+        props['status'] = GitDiffStatus.modification
+    except subprocess.CalledProcessError:
+        # the was nothing with this name in `from_treeish`, but now
+        # it exists. We compare to the worktree, but not any untracked
+        # content -- this means that we likely compare across multiple
+        # states and the directory become tracked after `from_treeish`.
+        # let's call it an addition
+        props['prev_gitsha'] = None
+        props['prev_gittype'] = None
+        props['status'] = GitDiffStatus.addition
+
+    return GitDiffItem(**props)
+
+
+def _git_diff_something(path, args):
+    with iter_subproc(
+            [
+                'git',
+                # take whatever is coming in
+                *args,
+            ],
+            cwd=path,
+    ) as r:
+        yield from decode_bytes(
+            itemize(
+                r,
+                sep=b'\0',
+                keep_ends=False,
+            )
+        )

--- a/datalad_next/iter_collections/tests/test_itergitdiff.py
+++ b/datalad_next/iter_collections/tests/test_itergitdiff.py
@@ -1,0 +1,240 @@
+from pathlib import PurePosixPath
+import pytest
+import shutil
+
+from datalad_next.tests.utils import rmtree
+
+from ..gitdiff import (
+    GitTreeItemType,
+    GitDiffStatus,
+    iter_gitdiff,
+)
+
+
+def test_iter_gitdiff_invalid():
+    with pytest.raises(ValueError):
+        # no meaningful comparison
+        list(iter_gitdiff('.', None, None))
+
+
+def test_iter_gitdiff_basic(existing_dataset, no_result_rendering):
+    ds = existing_dataset
+    dsp = ds.pathobj
+    # we compare based on the last state of the corresponding
+    # branch if there is any, or the HEAD of the current
+    # branch
+    comp_base = ds.repo.get_corresponding_branch() or 'HEAD'
+    # we use two distinct content blobs below, hardcode sha here
+    # for readability
+    empty_sha = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
+    content = '123'
+    content_sha = 'd800886d9c86731ae5c4a62b0b77c437015e00d2'
+    status_args = (
+        # we always test against the root of the dataset
+        dsp,
+        comp_base,
+        # we always compare to the worktree
+        None,
+    )
+    diff_args = (
+        # we always test against the root of the dataset
+        dsp,
+        # we always compare to last committed state
+        f'{comp_base}~1', comp_base,
+    )
+    # clean dataset, no items
+    assert list(iter_gitdiff(*status_args)) == []
+    testpath = dsp / 'sub' / 'test'
+    testpath.parent.mkdir()
+    testpath.touch()
+    # dataset with untracked file, no items
+    assert list(iter_gitdiff(*status_args)) == []
+    ds.save(to_git=True)
+    # clean dataset again, no items
+    assert list(iter_gitdiff(*status_args)) == []
+    # added file
+    diff = list(iter_gitdiff(*diff_args))
+    assert len(diff) == 1
+    di = diff[0]
+    assert di.status == GitDiffStatus.addition
+    assert di.name == 'sub/test'
+    assert di.prev_name is di.prev_gitsha is di.prev_gittype is None
+    assert di.gitsha == empty_sha
+    assert di.gittype == GitTreeItemType.file
+    # modified file
+    testpath.write_text(content)
+    diff = list(iter_gitdiff(*status_args))
+    assert len(diff) == 1
+    di = diff[0]
+    # labeled as modified
+    assert di.status == GitDiffStatus.modification
+    # the name is plain str in POSIX
+    assert di.name == di.prev_name == 'sub/test'
+    # path conversion yield POSIX relpath
+    assert di.path == di.prev_path == PurePosixPath(testpath.relative_to(dsp))
+    # unstaged modification reports no shasum
+    assert di.gitsha is None
+    assert di.prev_gitsha == empty_sha
+    assert di.gittype == di.prev_gittype == GitTreeItemType.file
+    # make clean
+    ds.save(to_git=True)
+    moved_testpath = testpath.parent / 'moved_test'
+    testpath.rename(moved_testpath)
+    # renamed file, unstaged, reported as deletion, we do not see the addition
+    # yet (untracked)
+    diff = list(iter_gitdiff(*status_args))
+    assert len(diff) == 1
+    di = diff[0]
+    assert di.status == GitDiffStatus.deletion
+    assert di.name == di.prev_name == 'sub/test'
+    assert di.prev_gitsha == content_sha
+    assert di.prev_gittype == GitTreeItemType.file
+    assert di.gitsha is di.gittype is None
+    # make clean
+    ds.save(to_git=True)
+    # now we can look at the rename
+    diff = list(iter_gitdiff(*diff_args, find_renames=100))
+    assert len(diff) == 1
+    di = diff[0]
+    assert di.status == GitDiffStatus.rename
+    assert di.name == 'sub/moved_test'
+    assert di.prev_name == 'sub/test'
+    assert di.gitsha == di.prev_gitsha == content_sha
+    assert di.prev_gittype is di.gittype is GitTreeItemType.file
+    assert di.percentage == 100
+    # now a copy
+    shutil.copyfile(moved_testpath, testpath)
+    ds.save(to_git=True)
+    diff = list(iter_gitdiff(*diff_args, find_copies=100))
+    assert len(diff) == 1
+    di = diff[0]
+    assert di.status == GitDiffStatus.copy
+    assert di.name == 'sub/test'
+    assert di.prev_name == 'sub/moved_test'
+    assert di.gitsha == di.prev_gitsha == content_sha
+    assert di.percentage == 100
+    # now replace file with submodule
+    testpath.unlink()
+    # we must safe to appease datalad's content collision detection
+    ds.save(to_git=True)
+    # intermediate smoke test for describing a single tree (diff from parents)
+    diff = list(iter_gitdiff(dsp, None, comp_base))
+    assert len(diff) == 1
+    assert diff[0].status == GitDiffStatus.deletion
+    # now cause typechange
+    ds.create(testpath)
+    diff = list(iter_gitdiff(
+        dsp,
+        # because we have an intermediate safe, compare to two states
+        # back
+        f'{comp_base}~2', comp_base,
+    ))
+    assert len(diff) == 2
+    # let's ignore the uninteresting .gitmodules addition for further tests
+    di = [i for i in diff if i.name != '.gitmodules'][0]
+    assert di.status == GitDiffStatus.typechange
+    assert di.name == di.prev_name == 'sub/test'
+    assert di.gitsha != di.prev_gitsha
+    assert di.prev_gitsha == content_sha
+    assert di.prev_gittype == GitTreeItemType.file
+    assert di.gittype == GitTreeItemType.submodule
+
+
+def test_iter_gitdiff_nonroot(existing_dataset, no_result_rendering):
+    ds = existing_dataset
+    comp_base = ds.repo.get_corresponding_branch() or 'HEAD'
+    # all tests are concerned with running not in the dataset root
+    root = ds.pathobj
+    nonroot = root / 'sub'
+    nonroot.mkdir()
+    status_args = (nonroot, comp_base, None)
+    diff_args = (nonroot, f'{comp_base}~1', comp_base)
+
+    # nothing to report, no problem
+    assert list(iter_gitdiff(*status_args)) == []
+    # change above CWD is not reported
+    (root / 'rootfile').touch()
+    ds.save(to_git=True)
+    assert list(iter_gitdiff(*diff_args)) == []
+    # check worktree modification detection too
+    (root / 'rootfile').write_text('some')
+    assert list(iter_gitdiff(*status_args)) == []
+    # and now test that reporting is relative to
+    # CWD
+    (nonroot / 'nonrootfile').touch()
+    ds.save(to_git=True)
+    assert list(iter_gitdiff(*diff_args))[0].name == 'nonrootfile'
+    (nonroot / 'nonrootfile').write_text('other')
+    assert list(iter_gitdiff(*diff_args))[0].name == 'nonrootfile'
+
+
+def test_iter_gitdiff_nonrec(existing_dataset, no_result_rendering):
+    ds = existing_dataset
+    dsp = ds.pathobj
+    comp_base = ds.repo.get_corresponding_branch() or 'HEAD'
+    subdir = dsp / 'sub'
+    subdir.mkdir()
+    for fn in ('f1.txt', 'f2.txt'):
+        (subdir / fn).touch()
+    ds.save(to_git=True)
+    diff = list(iter_gitdiff(dsp, f'{comp_base}~1', comp_base, recursive='no'))
+    assert len(diff) == 1
+    di = diff[0]
+    assert di.name == 'sub'
+    assert di.gittype == GitTreeItemType.directory
+    assert di.status == GitDiffStatus.addition
+    di_tree = di
+    # same behavior for a worktree modification
+    for fn in ('f1.txt', 'f2.txt'):
+        (subdir / fn).write_text('modified')
+    diff = list(iter_gitdiff(dsp, f'{comp_base}~1', None, recursive='no'))
+    assert len(diff) == 1
+    di = diff[0]
+    # these are identical to the diff-tree based report
+    for p in ('name', 'gittype', 'prev_gitsha', 'prev_gittype'):
+        assert getattr(di, p) == getattr(di_tree, p)
+    # and there are different
+    # not staged, no gitsha
+    assert di.gitsha is None
+    # it does no type inference for the previous state (expensive)
+    assert di.prev_gittype is None
+
+    # when the directory existed in the from-state it becomes a
+    # modification
+    diff = list(iter_gitdiff(dsp, f'{comp_base}~1', None, recursive='no'))
+    assert len(diff) == 1
+    diff[0].status == GitDiffStatus.modification
+
+    # now remove the subdir
+    rmtree(subdir)
+    diff = list(iter_gitdiff(dsp, comp_base, None, recursive='no'))
+    assert len(diff) == 1
+    # it still reports a modification, even though the directory is empty/gone.
+    # it would require a filesystem STAT to detect a deletion, and a further
+    # type investigation in `from_treeish` to detect a type change.
+    # This is not done until there is evidence for a real use case
+    diff[0].status == GitDiffStatus.modification
+
+
+def test_iter_gitdiff_typechange_issue6791(
+        existing_dataset, no_result_rendering):
+    # verify that we can handle to problem described in
+    # https://github.com/datalad/datalad/issues/6791
+    #
+    # a subdataset is wiped out (uncommitted) and replaced by a file
+    ds = existing_dataset
+    ds.create('subds')
+    rmtree(ds.pathobj / 'subds')
+    (ds.pathobj / 'subds').touch()
+    diff = list(iter_gitdiff(
+        ds.pathobj,
+        ds.repo.get_corresponding_branch() or 'HEAD', None,
+    ))
+    assert len(diff) == 1
+    di = diff[0]
+    assert di.status == GitDiffStatus.typechange
+    assert di.name == di.prev_name == 'subds'
+    # unstaged change
+    assert di.gitsha is None
+    assert di.prev_gittype == GitTreeItemType.submodule
+    assert di.gittype == GitTreeItemType.file


### PR DESCRIPTION
This is a step towards https://github.com/datalad/datalad-next/issues/586 -- it implements comparison of Git tree-ishes with each other, or with *tracked* content in the worktree (ie., so support for untracked content).

Noteworthy items:

- includes test to verify that it does not suffer from https://github.com/datalad/datalad/issues/6791
- support for finding copies and renames (useful for https://github.com/datalad/datalad/issues/2160)
- uses `prev_gittype` for deletions (addresses https://github.com/datalad/datalad/issues/6877)

Performance notes

Comparing with `status` from datalad-core, on the studyforrest superdataset (11 subdatasets, ~4k files):

```
In [4]: %timeit status('.', result_renderer='disabled', untracked='no', recursive=True)
368 ms ± 10 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %timeit list(iter_gitdiff(".", "HEAD", None, recursive='submodules'))
11.2 ms ± 41.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

3% of the original runtime. The result being "all-clean" in both cases.

```
❯ multitime -n5 -q git status -uno
===> multitime results
1: -q git status -uno
            Mean        Std.Dev.    Min         Median      Max
real        0.013       0.001       0.012       0.013       0.014       
user        0.006       0.003       0.002       0.006       0.012       
sys         0.009       0.004       0.004       0.008       0.013       
```