### PR TITLE
Skip tests when ran as root

### DIFF
--- a/datalad_next/annexremotes/tests/test_uncurl.py
+++ b/datalad_next/annexremotes/tests/test_uncurl.py
@@ -6,6 +6,7 @@ from datalad_next.consts import on_windows
 from datalad_next.tests.utils import (
     create_tree,
     skip_if_on_windows,
+    skip_if_root,
 )
 from datalad_next.constraints.dataset import EnsureDataset
 from datalad_next.exceptions import (
@@ -309,6 +310,7 @@ def test_uncurl_ria_access(tmp_path, no_result_rendering):
     assert (ds.pathobj / target_fname).read_text() == testfile_content
 
 
+@skip_if_root  # see https://github.com/datalad/datalad-next/issues/525
 def test_uncurl_store(tmp_path, existing_dataset, no_result_rendering):
     ds = existing_dataset
     testfile = ds.pathobj / 'testfile1.txt'

--- a/datalad_next/commands/tests/test_tree.py
+++ b/datalad_next/commands/tests/test_tree.py
@@ -10,6 +10,7 @@ from datalad_next.tests.utils import (
     get_deeply_nested_structure,
     skip_wo_symlink_capability,
     skip_if_on_windows,
+    skip_if_root,
     ok_good_symlink,
     ok_broken_symlink,
     run_main,
@@ -732,6 +733,7 @@ class TestTreeFilesystemIssues:
         with assert_raises(ValueError):
             Tree(tmp_path / 'nonexistent_dir', max_depth=1)
 
+    @skip_if_root  # see https://github.com/datalad/datalad-next/issues/525
     @skip_if_on_windows
     @skip_wo_symlink_capability
     def test_print_tree_permission_denied(self, tmp_path):
@@ -823,6 +825,7 @@ class TestTreeFilesystemIssues:
             ]
         assert set(expected) == set(actual)
 
+    @skip_if_root  # see https://github.com/datalad/datalad-next/issues/525
     @skip_if_on_windows
     @skip_wo_symlink_capability
     @pytest.mark.parametrize("include_files", (True, False))

--- a/datalad_next/gitremotes/tests/test_datalad_annex.py
+++ b/datalad_next/gitremotes/tests/test_datalad_annex.py
@@ -26,6 +26,7 @@ from datalad_next.tests.utils import (
     assert_status,
     eq_,
     rmtree,
+    skip_if_root,
 )
 from datalad_next.consts import on_windows
 from datalad_next.exceptions import CommandError
@@ -52,6 +53,7 @@ def eq_dla_branch_state(state, path, branch=DEFAULT_BRANCH):
     assert None, f'Could not find state for branch {branch} at {path}'
 
 
+@skip_if_root  # see https://github.com/datalad/datalad-next/issues/525
 def test_annex_remote(existing_noannex_dataset, tmp_path, no_result_rendering):
     remotepath = tmp_path / 'remote'
     # bypass the complications of folding a windows path into a file URL
@@ -63,6 +65,7 @@ def test_annex_remote(existing_noannex_dataset, tmp_path, no_result_rendering):
     _check_push_fetch_cycle(ds, dlaurl, remotepath, tmp_path)
 
 
+@skip_if_root  # see https://github.com/datalad/datalad-next/issues/525
 def test_export_remote(existing_noannex_dataset, tmp_path, no_result_rendering):
     remotepath = tmp_path / 'remote'
     # bypass the complications of folding a windows path into a file URL

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -32,6 +32,7 @@ from datalad.tests.utils_pytest import (
     ok_good_symlink,
     rmtree,
     skip_if_on_windows,
+    skip_if_root,
     skip_wo_symlink_capability,
     swallow_logs,
 )


### PR DESCRIPTION
There were a handful of tests reported in #525 that failed when ran as root. This PR implements the proposed solution to skip these tests when ran as root, using a preexisting pytest util from datalad-core.

fixes #525
