### PR TITLE
Make `iter_git|annexworktree()` robust to deleted files

### DIFF
--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -252,7 +252,14 @@ def iter_annexworktree(
         # we might be in a managed branch without link.
         path = Path(path)
         for res in results:
-            item = _get_worktree_item(path, get_fs_info=True, **res)
+            try:
+                item = _get_worktree_item(path, get_fs_info=True, **res)
+            except FileNotFoundError:
+                # there is nothing to open, yield non FS item
+                item = _get_worktree_item(path, get_fs_info=False, **res)
+                yield item
+                continue
+
             # determine would file we would open
             fp_src = None
             if item.annexobjpath is not None:

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -245,22 +245,22 @@ def _get_item(
 ) -> GitWorktreeItem | GitWorktreeFileSystemItem:
     if isinstance(type, str):
         type: GitTreeItemType = _mode_type_map[type]
+    item = None
     if link_target or fp:
         fullpath = basepath / ipath
-        item = GitWorktreeFileSystemItem.from_path(
-            fullpath,
-            link_target=link_target,
-        )
-        if type is not None:
-            item.gittype = type
-        if gitsha is not None:
-            item.gitsha = gitsha
-    else:
-        item = GitWorktreeItem(
-            name=ipath,
-            gittype=type,
-            gitsha=gitsha,
-        )
+        try:
+            item = GitWorktreeFileSystemItem.from_path(
+                fullpath,
+                link_target=link_target,
+            )
+        except FileNotFoundError:
+            pass
+    if item is None:
+        item = GitWorktreeItem(name=ipath)
+    if type is not None:
+        item.gittype = type
+    if gitsha is not None:
+        item.gitsha = gitsha
     # make sure the name/id is the path relative to the basepath
     item.name = PurePath(ipath)
     return item
@@ -323,7 +323,7 @@ def _get_fp_src(
     basepath: Path,
     item: GitWorktreeItem | GitWorktreeFileSystemItem,
 ) -> Path | None:
-    if not fp:
+    if not fp or isinstance(item, GitWorktreeItem):
         # no file pointer request, we are done
         return None
 

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -95,13 +95,13 @@ def test_iter_annexworktree_basic_fp(existing_dataset, no_result_rendering):
         iter_annexworktree(ds.pathobj, fp=True)
     ):
         fcount -= 1
-        if ai.fp:
+        if getattr(ai, 'fp', False):
             assert content_tmpl.format(
                 ai.name.name[5:]) == ai.fp.read().decode()
         else:
             assert (ai.annexobjpath and (
                 ds.pathobj / ai.annexobjpath).exists() is False) or (
-                    ai.name.exists() is False)
+                    (ds.pathobj / ai.name).exists() is False)
     assert not fcount
 
 

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -192,11 +192,11 @@ def prep_fp_tester(ds):
         reckless='availability',
     )
     # and also add a file to git directly and a have one untracked too
-    for i in ('untracked', 'ingit'):
+    for i in ('untracked', 'ingit', 'deleted'):
         (ds.pathobj / f'file_{i}').write_text(
             content_tmpl.format(i), encoding='utf-8')
         fcount += 1
-    ds.save('file_ingit', to_git=True)
+    ds.save(['file_ingit', 'file_deleted'], to_git=True)
     # and add symlinks (untracked and in git)
     if check_symlink_capability(
         ds.pathobj / '_dummy', ds.pathobj / '_dummy_target'
@@ -209,6 +209,7 @@ def prep_fp_tester(ds):
             lpath.symlink_to(tpath)
             fcount += 1
     ds.save('file_symlinkingit', to_git=True)
+    (ds.pathobj / 'file_deleted').unlink()
     return fcount, content_tmpl
 
 
@@ -221,7 +222,7 @@ def test_iter_gitworktree_basic_fp(existing_dataset, no_result_rendering):
         iter_gitworktree(ds.pathobj, fp=True)
     ):
         fcount -= 1
-        if ai.fp:
+        if getattr(ai, 'fp', False):
             # for annexed files the fp can be an annex pointer file.
             # in the context of `iter_gitworktree` this is not a
             # recognized construct


### PR DESCRIPTION
When reporting file pointers. Both stumbled over files that were still reported by `ls-file`, but did not exist on the filesystem anymore (this happens when a deletion is not committed/staged).

This change makes both iterators fall back on yielding a non-filesystem work tree item in this case.

The corresponding tests have been adjusted to cause and adapt to this case.

Closes #582