### PR TITLE
Introduce early check for submodule presence in status evaluation

### DIFF
--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -361,7 +361,7 @@ def _yield_hierarchy_items(
 
 def _yield_repo_untracked(
         path: Path,
-        untracked: str,
+        untracked: str | None,
 ) -> Generator[GitDiffItem, None, None]:
     """Yield items on all untracked content in a repository"""
     if untracked is None:

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -437,6 +437,14 @@ def _eval_submodule(basepath, item, eval_mode) -> None:
         return
 
     item_path = basepath / item.path
+
+    # this is the cheapest test for the theoretical chance that a submodule
+    # is present at `item_path`. This is beneficial even when we would only
+    # run a single call to `git rev-parse`
+    # https://github.com/datalad/datalad-next/issues/606
+    if not (item_path / '.git').exists():
+        return
+
     # get head commit, and whether a submodule is actually present,
     # and/or in adjusted mode
     subds_present, head_commit, adjusted = _get_submod_worktree_head(item_path)


### PR DESCRIPTION
This can dramatically boost performance with many submodules. Checking
the filesystem for a file is much cheaper than running `git rev-parse`.

When a subdataset is present, this obviously means an additional cost.
However, in comparison to the then following state evaluation, it should
still be cheap.

Worth it, IMHO.

Closes: #606