### PR TITLE
Fix `datalad_next.utils.ParamDictator`

### DIFF
--- a/datalad_next/utils/__init__.py
+++ b/datalad_next/utils/__init__.py
@@ -216,7 +216,7 @@ class ParamDictator:
 
     def __getattr__(self, attr: str):
         if attr.startswith('__'):
-            return super().__getattr__(attr)
+            return super().__getattribute__(attr)
         return self.__params[attr]
 
     def __setattr__(self, attr: str, value: Any):

--- a/datalad_next/utils/tests/test_deprecated.py
+++ b/datalad_next/utils/tests/test_deprecated.py
@@ -1,3 +1,4 @@
+import warnings
 from datalad_next.utils.deprecate import deprecated
 
 import pytest
@@ -111,17 +112,17 @@ def test_deprecated():
     for func in [deprecated_function_param_value,
                  RandomClassParamValue().deprecated_method,
                  ]:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             res = func(inputmode='not-deprecated')
-            assert res == 'not-deprecated'
-            assert len(record) == 0
+        assert res == 'not-deprecated'
+        assert len(record) == 0
 
         for func in [deprecated_function_param,
                      RandomClassParam().deprecated_method]:
-            with pytest.warns(None) as record:
+            with warnings.catch_warnings(record=True) as record:
                 res = func(other_param='something!')
-                assert res == inputmode
-                assert len(record) == 0
+            assert res == inputmode
+            assert len(record) == 0
 
     # make sure it catches the parameter even if its a list
     for func in [deprecated_function_param_value,
@@ -132,10 +133,10 @@ def test_deprecated():
                 match="Use of values {'default'} for argument 'inputmode'"):
             res = func(inputmode=[inputmode])
             assert res == [inputmode]
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             res = func(inputmode=['not-deprecated'])
-            assert res == ['not-deprecated']
-            assert len(record) == 0
+        assert res == ['not-deprecated']
+        assert len(record) == 0
 
     # two decorators work as expected
     with pytest.warns(DeprecationWarning) as record:
@@ -153,7 +154,7 @@ def test_deprecated():
         # shouldn't matter if the parameter value is a list
         res = two_deprecated_values(mode=['1'])
         assert res == ['1']
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         res = two_deprecated_values(mode='safe')
-        assert res == 'safe'
-        assert len(record) == 0
+    assert res == 'safe'
+    assert len(record) == 0

--- a/datalad_next/utils/tests/test_paramdictator.py
+++ b/datalad_next/utils/tests/test_paramdictator.py
@@ -1,0 +1,12 @@
+import pytest
+
+from ..  import ParamDictator
+
+
+def test_paramdictator():
+    d = {'a': 1, 'b': 2}
+    pd = ParamDictator(d)
+    assert pd.a == 1
+    assert pd.b == 2
+    with pytest.raises(AssertionError):
+        assert pd.__dir__ is None


### PR DESCRIPTION
Fixes #609

Adds a regression test for `datalad_next.utils.ParamDictator`.