### PR TITLE
Robustify tests of `iterable_subprocess`

### DIFF
--- a/datalad_next/iterable_subprocess/test_iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/test_iterable_subprocess.py
@@ -332,9 +332,9 @@ def test_error_returncode_available_from_generator_with_exception():
     assert ls.returncode != 0
 
 
-def test_success_returncode_available_from_generator_with_exception():
+def test_returncode_available_from_generator_with_exception():
     with pytest.raises(StopIteration):
         with iterable_subprocess(['echo', 'a'], ()) as echo:
             while True:
                 next(echo)
-    assert echo.returncode == 0
+    assert echo.returncode in (0, -15)

--- a/datalad_next/iterable_subprocess/test_iterable_subprocess.py
+++ b/datalad_next/iterable_subprocess/test_iterable_subprocess.py
@@ -337,4 +337,11 @@ def test_returncode_available_from_generator_with_exception():
         with iterable_subprocess(['echo', 'a'], ()) as echo:
             while True:
                 next(echo)
+    # On a Linux system, all exceptions that are raised before the subprocess
+    # exited will lead to a -15 return code. If StopIteration is raised, the
+    # subprocess will either have terminated which results in a 0-return code,
+    # or the subprocess is still running and will therefore be terminated which
+    # results in a -15 return code. Any other exception than StopIteration,
+    # e.g. a CommandError because echo could not be found, would lead to an
+    # early test-exit and not proceed to the assign-statement.
     assert echo.returncode in (0, -15)


### PR DESCRIPTION
This PR modifies the test `datalad_next.iterable_subprocess.test_iterable_subprocess.test_success_returncode_available_from_generator_with_exception` to simply check for a non-`None` return code instead of checking for a `0` return code.

The reason is that a `StopIteration`-exception that occurs before the subprocess has terminated might lead to a non-`0` return code, thus failing the test. Some environments might trigger such an early exception, e.g. due to some unexpected stdout-configuration. In other words, we cannot guarantee a `0` return code in all environments. But we can guarantee, that a return code is available when the `iterable_subprocess`-context is exited with an exception.

The test is renamed to `test_returncode_available_from_generator_with_exception`.

This should make the test robust enough to prevent [this test failure](https://bugs.debian.org/1061739).
