### PR TITLE
Define public API of `datalad_next.iter_collections`

### DIFF
--- a/datalad_next/archive_operations/tarfile.py
+++ b/datalad_next/archive_operations/tarfile.py
@@ -24,7 +24,7 @@ from datalad_next.config import ConfigManager
 # is nice, and `__iter__()` only has `self`, such that
 # any customization would need to be infused in the whole
 # class. Potentially cumbersome.
-from datalad_next.iter_collections.tarfile import (
+from datalad_next.iter_collections import (
     TarfileItem,
     iter_tar,
 )

--- a/datalad_next/archive_operations/tests/test_tarfile.py
+++ b/datalad_next/archive_operations/tests/test_tarfile.py
@@ -9,7 +9,7 @@ from typing import Generator
 
 import pytest
 
-from datalad_next.iter_collections.utils import FileSystemItemType
+from datalad_next.iter_collections import FileSystemItemType
 from datalad_next.tests.marker import skipif_no_network
 
 from ..tarfile import TarArchiveOperations

--- a/datalad_next/archive_operations/tests/test_zipfile.py
+++ b/datalad_next/archive_operations/tests/test_zipfile.py
@@ -9,7 +9,7 @@ from typing import Generator
 
 import pytest
 
-from datalad_next.iter_collections.utils import FileSystemItemType
+from datalad_next.iter_collections import FileSystemItemType
 
 from ..zipfile import ZipArchiveOperations
 

--- a/datalad_next/archive_operations/zipfile.py
+++ b/datalad_next/archive_operations/zipfile.py
@@ -24,7 +24,7 @@ from datalad_next.config import ConfigManager
 # is nice, and `__iter__()` only has `self`, such that
 # any customization would need to be infused in the whole
 # class. Potentially cumbersome.
-from datalad_next.iter_collections.zipfile import (
+from datalad_next.iter_collections import (
     ZipfileItem,
     iter_zip,
 )

--- a/datalad_next/commands/ls_file_collection.py
+++ b/datalad_next/commands/ls_file_collection.py
@@ -48,23 +48,17 @@ from datalad_next.uis import (
 )
 from datalad_next.utils import ensure_list
 
-from datalad_next.iter_collections.directory import iter_dir
-from datalad_next.iter_collections.tarfile import iter_tar
-from datalad_next.iter_collections.zipfile import iter_zip
-from datalad_next.iter_collections.utils import (
+from datalad_next.iter_collections import (
     FileSystemItemType,
-    compute_multihash_from_fp,
-)
-from datalad_next.iter_collections.gittree import (
     GitTreeItemType,
-    iter_gittree,
-)
-from datalad_next.iter_collections.gitworktree import (
     GitWorktreeFileSystemItem,
-    iter_gitworktree,
-)
-from datalad_next.iter_collections.annexworktree import (
+    compute_multihash_from_fp,
     iter_annexworktree,
+    iter_dir,
+    iter_gittree,
+    iter_gitworktree,
+    iter_tar,
+    iter_zip,
 )
 
 

--- a/datalad_next/commands/status.py
+++ b/datalad_next/commands/status.py
@@ -27,12 +27,10 @@ from datalad_next.constraints import (
 )
 from datalad_next.constraints.dataset import EnsureDataset
 
-from datalad_next.iter_collections.gitdiff import (
+from datalad_next.iter_collections import (
     GitDiffStatus,
     GitTreeItemType,
     GitContainerModificationType,
-)
-from datalad_next.iter_collections.gitstatus import (
     iter_gitstatus,
 )
 from datalad_next.uis import (

--- a/datalad_next/iter_collections/__init__.py
+++ b/datalad_next/iter_collections/__init__.py
@@ -17,12 +17,69 @@ collections.
 .. autosummary::
    :toctree: generated
 
-   annexworktree
-   directory
-   gitdiff
-   gittree
-   gitworktree
-   tarfile
-   zipfile
-   utils
+   iter_annexworktree
+   iter_dir
+   iter_gitdiff
+   iter_gitstatus
+   iter_gittree
+   iter_gitworktree
+   iter_tar
+   iter_zip
+   TarfileItem
+   ZipfileItem
+   FileSystemItem
+   FileSystemItemType
+   GitTreeItemType
+   GitWorktreeItem
+   GitWorktreeFileSystemItem
+   GitDiffItem
+   GitDiffStatus
+   GitContainerModificationType
 """
+
+from .tarfile import (
+    # TODO move to datalad_next.types?
+    TarfileItem,
+    iter_tar,
+)
+from .zipfile import (
+    # TODO move to datalad_next.types?
+    ZipfileItem,
+    iter_zip,
+)
+# TODO move to datalad_next.types?
+from .utils import (
+    # TODO move to datalad_next.types?
+    FileSystemItemType,
+    # TODO move to datalad_next.types?
+    FileSystemItem,
+    compute_multihash_from_fp,
+)
+from .directory import iter_dir
+from .gittree import (
+    # TODO move to datalad_next.types?
+    GitTreeItemType,
+    iter_gittree,
+)
+from .gitworktree import (
+    # TODO move to datalad_next.types?
+    GitWorktreeItem,
+    # TODO move to datalad_next.types?
+    GitWorktreeFileSystemItem,
+    iter_gitworktree,
+)
+from .annexworktree import (
+    iter_annexworktree,
+)
+from .gitdiff import (
+    # TODO move to datalad_next.types?
+    GitDiffItem,
+    # TODO move to datalad_next.types?
+    GitDiffStatus,
+    # TODO move to datalad_next.types?
+    GitContainerModificationType,
+    iter_gitdiff,
+)
+from .gitstatus import (
+    iter_gitstatus,
+)


### PR DESCRIPTION
See https://github.com/datalad/datalad-next/issues/613

Quite a few candidates to move to `datalad_next.types` have been identified.