### PR TITLE
Define public API of `datalad_next.tests`

### DIFF
--- a/datalad_next/annexbackends/tests/test_base.py
+++ b/datalad_next/annexbackends/tests/test_base.py
@@ -1,7 +1,7 @@
 import logging
 import io
 
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     assert_raises,
     eq_,
 )

--- a/datalad_next/annexremotes/tests/test_archivist.py
+++ b/datalad_next/annexremotes/tests/test_archivist.py
@@ -9,7 +9,7 @@ from datalad_next.annexremotes.archivist import ArchivistRemote
 from datalad_next.datasets import Dataset
 from datalad_next.runners import CommandError
 
-from datalad_next.tests.utils import assert_result_count
+from datalad_next.tests import assert_result_count
 
 
 @pytest.fixture(autouse=False, scope="function")

--- a/datalad_next/annexremotes/tests/test_uncurl.py
+++ b/datalad_next/annexremotes/tests/test_uncurl.py
@@ -3,7 +3,7 @@ import pytest
 import re
 
 from datalad_next.consts import on_windows
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     create_tree,
     skip_if_on_windows,
     skip_if_root,

--- a/datalad_next/commands/tests/test_create_sibling_webdav.py
+++ b/datalad_next/commands/tests/test_create_sibling_webdav.py
@@ -5,7 +5,7 @@ from unittest.mock import (
 )
 from urllib.parse import quote as urlquote
 
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     assert_in,
     assert_in_results,
     assert_raises,

--- a/datalad_next/commands/tests/test_credentials.py
+++ b/datalad_next/commands/tests/test_credentials.py
@@ -18,7 +18,7 @@ from ..credentials import (
 )
 from datalad_next.exceptions import IncompleteResultsError
 from datalad_next.utils import external_versions
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     assert_in,
     assert_in_results,
     assert_raises,

--- a/datalad_next/commands/tests/test_download.py
+++ b/datalad_next/commands/tests/test_download.py
@@ -7,7 +7,7 @@ from datalad.api import (
     credentials,
     download,
 )
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     assert_result_count,
     assert_status,
 )

--- a/datalad_next/commands/tests/test_ls_file_collection.py
+++ b/datalad_next/commands/tests/test_ls_file_collection.py
@@ -9,7 +9,7 @@ from datalad.api import ls_file_collection
 from datalad_next.constraints.exceptions import CommandParametrizationError
 # we need this fixture
 from datalad_next.iter_collections.tests.test_iterzip import sample_zip
-from datalad_next.tests.marker import skipif_no_network
+from datalad_next.tests import skipif_no_network
 
 from ..ls_file_collection import LsFileCollectionParamValidator
 

--- a/datalad_next/commands/tests/test_status.py
+++ b/datalad_next/commands/tests/test_status.py
@@ -6,7 +6,7 @@ from datalad_next.constraints.exceptions import (
     CommandParametrizationError,
     ParameterConstraintContext,
 )
-from datalad_next.tests.utils import chpwd
+from datalad_next.utils import chpwd
 
 from ..status import (
     opt_eval_subdataset_state_values,

--- a/datalad_next/commands/tests/test_tree.py
+++ b/datalad_next/commands/tests/test_tree.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from os import sep
 
 import pytest
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     BasicGitTestRepo,
     assert_raises,
     create_tree,

--- a/datalad_next/credman/tests/test_credman.py
+++ b/datalad_next/credman/tests/test_credman.py
@@ -16,7 +16,7 @@ from ..manager import (
     CredentialManager,
     _get_cred_cfg_var,
 )
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     assert_in,
     assert_raises,
     eq_,

--- a/datalad_next/gitremotes/tests/test_datalad_annex.py
+++ b/datalad_next/gitremotes/tests/test_datalad_annex.py
@@ -19,17 +19,17 @@ from datalad.api import (
     Dataset,
     clone,
 )
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     DEFAULT_BRANCH,
     DEFAULT_REMOTE,
     assert_raises,
     assert_status,
     eq_,
-    rmtree,
     skip_if_root,
 )
 from datalad_next.consts import on_windows
 from datalad_next.exceptions import CommandError
+from datalad_next.utils import rmtree
 from ..datalad_annex import get_initremote_params_from_url
 
 

--- a/datalad_next/iter_collections/tests/test_iterdir.py
+++ b/datalad_next/iter_collections/tests/test_iterdir.py
@@ -2,11 +2,13 @@ import os
 from pathlib import PurePath
 import pytest
 
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     create_tree,
+)
+from datalad_next.utils import (
+    check_symlink_capability,
     rmtree,
 )
-from datalad_next.utils import check_symlink_capability
 
 from ..directory import (
     DirectoryItem,

--- a/datalad_next/iter_collections/tests/test_itergitdiff.py
+++ b/datalad_next/iter_collections/tests/test_itergitdiff.py
@@ -2,7 +2,7 @@ from pathlib import PurePosixPath
 import pytest
 import shutil
 
-from datalad_next.tests.utils import rmtree
+from datalad_next.utils import rmtree
 
 from ..gitdiff import (
     GitTreeItemType,

--- a/datalad_next/iter_collections/tests/test_itergittree.py
+++ b/datalad_next/iter_collections/tests/test_itergittree.py
@@ -4,7 +4,7 @@ from pathlib import (
 
 import pytest
 
-from datalad_next.tests.utils import rmtree
+from datalad_next.utils import rmtree
 
 from ..gittree import (
     GitTreeItem,

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -5,9 +5,10 @@ from pathlib import (
 
 import pytest
 
-from datalad_next.utils import check_symlink_capability
-
-from datalad_next.tests.utils import rmtree
+from datalad_next.utils import (
+    check_symlink_capability,
+    rmtree,
+)
 
 from ..gitworktree import (
     GitWorktreeItem,

--- a/datalad_next/iter_collections/tests/test_itertar.py
+++ b/datalad_next/iter_collections/tests/test_itertar.py
@@ -3,7 +3,7 @@ import pytest
 
 from datalad.api import download
 
-from datalad_next.tests.marker import skipif_no_network
+from datalad_next.tests import skipif_no_network
 
 from ..tarfile import (
     TarfileItem,

--- a/datalad_next/iter_collections/tests/test_utils.py
+++ b/datalad_next/iter_collections/tests/test_utils.py
@@ -1,4 +1,4 @@
-from datalad_next.tests.utils import skip_wo_symlink_capability
+from datalad_next.tests import skip_wo_symlink_capability
 
 from ..utils import FileSystemItem
 

--- a/datalad_next/patches/tests/test_cli_configoverrides.py
+++ b/datalad_next/patches/tests/test_cli_configoverrides.py
@@ -1,5 +1,5 @@
 from datalad_next.utils import chpwd
-from datalad_next.tests.utils import run_main
+from datalad_next.tests import run_main
 
 
 def test_cli_configoverrides(existing_dataset):

--- a/datalad_next/patches/tests/test_configuration.py
+++ b/datalad_next/patches/tests/test_configuration.py
@@ -1,8 +1,9 @@
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     assert_in_results,
     assert_raises,
-    chpwd,
 )
+from datalad_next.utils import chpwd
+
 from datalad.api import configuration
 from datalad_next.exceptions import IncompleteResultsError
 

--- a/datalad_next/patches/tests/test_push.py
+++ b/datalad_next/patches/tests/test_push.py
@@ -1,4 +1,4 @@
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     DEFAULT_REMOTE,
     assert_result_count,
 )

--- a/datalad_next/patches/tests/test_push_to_export_remote.py
+++ b/datalad_next/patches/tests/test_push_to_export_remote.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 from typing import Generator
 from unittest.mock import (
     MagicMock,
@@ -6,8 +7,7 @@ from unittest.mock import (
     patch,
 )
 
-from datalad_next.tests.utils import (
-    SkipTest,
+from datalad_next.tests import (
     assert_in,
     assert_in_results,
     eq_,
@@ -230,7 +230,7 @@ def test_get_export_log_entry():
 
 
 def test_is_valid_treeish():
-    raise SkipTest(
+    pytest.skip(
         "this test is skipped until issue "
         "https://github.com/datalad/datalad-next/issues/39 is solved")
 

--- a/datalad_next/patches/tests/test_run.py
+++ b/datalad_next/patches/tests/test_run.py
@@ -1,10 +1,7 @@
 import pytest
 
 from datalad_next.exceptions import IncompleteResultsError
-from datalad_next.tests.utils import (
-    SkipTest,
-    assert_result_count,
-)
+from datalad_next.tests import assert_result_count
 
 
 def test_substitution_config_default(existing_dataset, no_result_rendering):
@@ -12,7 +9,7 @@ def test_substitution_config_default(existing_dataset, no_result_rendering):
 
     if ds.config.get('datalad.run.substitutions.python') is not None:
         # we want to test default handling when no config is set
-        raise SkipTest(
+        pytest.skip(
             'Test assumptions conflict with effective configuration')
 
     # the {python} placeholder is not explicitly defined, but it has

--- a/datalad_next/tests/__init__.py
+++ b/datalad_next/tests/__init__.py
@@ -1,0 +1,55 @@
+"""Tooling for test implementations
+
+.. currentmodule:: datalad_next.tests
+.. autosummary::
+   :toctree: generated
+
+   BasicGitTestRepo
+   DEFAULT_BRANCH
+   DEFAULT_REMOTE
+   assert_in
+   assert_in_results
+   assert_result_count
+   assert_status
+   create_tree
+   eq_
+   get_deeply_nested_structure
+   ok_
+   ok_good_symlink
+   ok_broken_symlink
+   run_main
+   skip_if_on_windows
+   skip_if_root
+   skip_wo_symlink_capability
+   swallow_logs
+   skipif_no_network
+"""
+# TODO `assert_raises` is excluded above to avoid syntax errors in the docstring
+# rather than fixing those, we should replace it with `pytest.raises` entirely
+
+from .utils import (
+    BasicGitTestRepo,
+    DEFAULT_BRANCH,
+    DEFAULT_REMOTE,
+    assert_in,
+    assert_in_results,
+    assert_raises,
+    assert_result_count,
+    assert_status,
+    create_tree,
+    eq_,
+    get_deeply_nested_structure,
+    ok_,
+    ok_good_symlink,
+    ok_broken_symlink,
+    run_main,
+    skip_if_on_windows,
+    skip_if_root,
+    skip_wo_symlink_capability,
+    swallow_logs,
+)
+
+
+from .marker import (
+    skipif_no_network,
+)

--- a/datalad_next/tests/fixtures.py
+++ b/datalad_next/tests/fixtures.py
@@ -16,9 +16,8 @@ from datalad_next.runners import (
     call_git_lines,
     call_git_success,
 )
-from datalad_next.tests.utils import (
+from .utils import (
     HTTPPath,
-    SkipTest,
     WebDAVPath,
     assert_ssh_access,
     external_versions,
@@ -167,7 +166,7 @@ def datalad_cfg():
     here was only introduced with that version.
     """
     if external_versions['cmd:git'] < "2.32":
-        raise SkipTest(
+        pytest.skip(
             "Git configuration redirect via GIT_CONFIG_GLOBAL "
             "only supported since Git v2.32"
         )
@@ -561,15 +560,15 @@ def httpbin(httpbin_service):
     in some cases it is simply not desirable to run a test. For example,
     the appveyor workers are more or less constantly unable to access the
     public service. This fixture is evaluated at function-scope and
-    raises ``SkipTest`` whenever any of these undesired conditions is
+    skips the test whenever any of these undesired conditions is
     detected. Otherwise it just relays ``httpbin_service``.
     """
     if os.environ.get('DATALAD_TESTS_NONETWORK'):
-        raise SkipTest(
+        pytest.skip(
             'Not running httpbin-based test: NONETWORK flag set'
         )
     if 'APPVEYOR' in os.environ and 'DEPLOY_HTTPBIN_IMAGE' not in os.environ:
-        raise SkipTest(
+        pytest.skip(
             "Not running httpbin-based test on appveyor without "
             "docker-deployed instance -- too unreliable"
         )
@@ -591,7 +590,7 @@ def datalad_interactive_ui(monkeypatch):
        > assert ... datalad_interactive_ui.log
     """
     from datalad_next.uis import ui_switcher
-    from datalad_next.tests.utils import InteractiveTestUI
+    from .utils import InteractiveTestUI
 
     with monkeypatch.context() as m:
         m.setattr(ui_switcher, '_ui', InteractiveTestUI())
@@ -611,7 +610,7 @@ def datalad_noninteractive_ui(monkeypatch):
        > assert ... datalad_interactive_ui.log
     """
     from datalad_next.uis import ui_switcher
-    from datalad_next.tests.utils import TestUI
+    from .utils import TestUI
 
     with monkeypatch.context() as m:
         m.setattr(ui_switcher, '_ui', TestUI())
@@ -621,7 +620,7 @@ def datalad_noninteractive_ui(monkeypatch):
 @pytest.fixture(autouse=False, scope="session")
 def sshserver_setup(tmp_path_factory):
     if not os.environ.get('DATALAD_TESTS_SSH'):
-        raise SkipTest(
+        pytest.skip(
             "set DATALAD_TESTS_SSH=1 to enable")
 
     # query a bunch of recognized configuration environment variables,

--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -16,6 +16,7 @@ from datalad.tests.utils_pytest import (
     DEFAULT_BRANCH,
     DEFAULT_REMOTE,
     HTTPPath,
+    # TODO REMOVE FOR V2.0
     SkipTest,
     assert_in,
     assert_in_results,
@@ -30,6 +31,7 @@ from datalad.tests.utils_pytest import (
     ok_broken_symlink,
     ok_exists,
     ok_good_symlink,
+    # TODO REMOVE FOR V2.0
     rmtree,
     skip_if_on_windows,
     skip_if_root,
@@ -78,7 +80,7 @@ class WebDAVPath(object):
             from cheroot import wsgi
             from wsgidav.wsgidav_app import WsgiDAVApp
         except ImportError as e:
-            raise SkipTest('No WSGI capabilities. Install cheroot and/or wsgidav') from e
+            pytest.skip(f'No WSGI capabilities. Install cheroot and/or wsgidav ({e!r})')
 
         if self.auth:
             auth = {self.auth[0]: {'password': self.auth[1]}}

--- a/datalad_next/url_operations/tests/test_http.py
+++ b/datalad_next/url_operations/tests/test_http.py
@@ -4,7 +4,7 @@ import gzip
 import pytest
 import requests
 
-from datalad_next.tests.marker import skipif_no_network
+from datalad_next.tests import skipif_no_network
 
 from ..any import AnyUrlOperations
 from ..http import (

--- a/datalad_next/url_operations/tests/test_ssh.py
+++ b/datalad_next/url_operations/tests/test_ssh.py
@@ -3,7 +3,7 @@ import io
 
 import pytest
 
-from datalad_next.tests.utils import (
+from datalad_next.tests import (
     skip_if_on_windows,
 )
 from ..ssh import (

--- a/docs/source/pyutils.rst
+++ b/docs/source/pyutils.rst
@@ -26,6 +26,7 @@ packages.
    itertools
    iter_collections
    runners
+   tests
    tests.fixtures
    types
    uis


### PR DESCRIPTION
This pretty much takes the role of `datalad_next.tests.utils`. The new setup treats `tests` like any other sub-package and exposes reusable tools as a public API at the top-level.

In doing so, `SkipTest` was made obsolete and excluded from that API.

The usage of `rmtree` is altered to import from `datalad_next.utils`.

https://github.com/datalad/datalad-next/issues/613