### PR TITLE
Discontinue usage of `Runner` functionality for Git calls

### DIFF
--- a/datalad_next/gitremotes/datalad_annex.py
+++ b/datalad_next/gitremotes/datalad_annex.py
@@ -210,8 +210,8 @@ from datalad_next.datasets import (
 from datalad_next.exceptions import CapturedException
 from datalad_next.runners import (
     CommandError,
-    NoCapture,
     StdOutCapture,
+    call_git,
 )
 from datalad_next.uis import ui_switcher as ui
 from datalad_next.utils import (
@@ -669,9 +669,9 @@ class RepoAnnexGitRemote(object):
                 pre_refs = sorted(self.mirrorrepo.for_each_ref_(),
                                   key=lambda x: x['refname'])
                 # must not capture -- git is talking to it directly from here
-                self.mirrorrepo._git_runner.run(
-                    ['git', 'receive-pack', self.mirrorrepo.path],
-                    protocol=NoCapture,
+                call_git(
+                    ['receive-pack', self.mirrorrepo.path],
+                    cwd=self.mirrorrepo.pathobj,
                 )
                 post_refs = sorted(self.mirrorrepo.for_each_ref_(),
                                    key=lambda x: x['refname'])
@@ -724,9 +724,9 @@ class RepoAnnexGitRemote(object):
                 # must not capture -- git is talking to it directly from here.
                 # the `self.mirrorrepo` access will ensure that the mirror
                 # is up-to-date
-                self.mirrorrepo._git_runner.run(
-                    ['git', 'upload-pack', self.mirrorrepo.path],
-                    protocol=NoCapture,
+                call_git(
+                    ['upload-pack', self.mirrorrepo.path],
+                    cwd=self.mirrorrepo.pathobj,
                 )
                 # everything has worked, if we used a credential, update it
                 self._store_credential()

--- a/datalad_next/utils/__init__.py
+++ b/datalad_next/utils/__init__.py
@@ -12,6 +12,7 @@
    external_versions
    log_progress
    parse_www_authenticate
+   patched_env
    rmtree
    get_specialremote_param_dict
    get_specialremote_credential_properties
@@ -72,7 +73,7 @@ from .specialremote import (
     needs_specialremote_credential_envpatch,
     get_specialremote_credential_envpatch,
 )
-
+from .patch import patched_env
 
 # TODO REMOVE EVERYTHING BELOW FOR V2.0
 # https://github.com/datalad/datalad-next/issues/611

--- a/datalad_next/utils/patch.py
+++ b/datalad_next/utils/patch.py
@@ -1,2 +1,31 @@
+import contextlib
+from os import environ
+
 # legacy import
 from datalad_next.patches import apply_patch
+
+
+@contextlib.contextmanager
+def patched_env(**env):
+    """Context manager for patching the process environment
+
+    Any number of kwargs can be given. Keys represent environment variable
+    names, and values their values. A value of ``None`` indicates that
+    the respective variable should be unset, i.e., removed from the
+    environment.
+    """
+    preserve = {}
+    for name, val in env.items():
+        preserve[name] = environ.get(name, None)
+        if val is None:
+            del environ[name]
+        else:
+            environ[name] = str(val)
+    try:
+        yield
+    finally:
+        for name, val in preserve.items():
+            if val is None:
+                del environ[name]
+            else:
+                environ[name] = val

--- a/datalad_next/utils/tests/test_patch.py
+++ b/datalad_next/utils/tests/test_patch.py
@@ -1,0 +1,15 @@
+from ..patch import patched_env
+from os import environ
+
+
+def test_patched_env():
+    if 'HOME' in environ:
+        home = environ['HOME']
+        with patched_env(HOME=None):
+            assert 'HOME' not in environ
+        assert environ['HOME'] == home
+    unusual_name = 'DATALADPATCHENVTESTVAR'
+    if unusual_name not in environ:
+        with patched_env(**{unusual_name: 'dummy'}):
+            assert environ[unusual_name] == 'dummy'
+        assert unusual_name not in environ


### PR DESCRIPTION
Elevates the `call_git..()` helpers to have enough functionality to replace the observed usage patterns for `GitRepo.call_git..()` and other `Repo` centric runner call pattern.

All these are replaced with `call_git..()` utility from `datalad-next`.

Closes #541