### PR TITLE
Consolidate ENV patching on dedicated `patched_env()` helper

### DIFF
--- a/datalad_next/commands/create_sibling_webdav.py
+++ b/datalad_next/commands/create_sibling_webdav.py
@@ -9,7 +9,6 @@
 """High-level interface for creating a combi-target on a WebDAV capable server
  """
 import logging
-from unittest.mock import patch
 from urllib.parse import (
     quote as urlquote,
     urlunparse,
@@ -45,6 +44,7 @@ from datalad_next.constraints import (
 from datalad_next.utils import CredentialManager
 from datalad_next.utils import (
     get_specialremote_credential_properties,
+    patched_env,
     update_specialremote_credential,
     _yield_ds_w_matching_siblings,
 )
@@ -647,10 +647,9 @@ def _create_storage_sibling(
     ]
     # Add a git-annex webdav special remote. This requires to set
     # the webdav environment variables accordingly.
-    with patch.dict('os.environ', {
-            'WEBDAV_USERNAME': credential[0],
-            'WEBDAV_PASSWORD': credential[1],
-    }):
+    with patched_env(WEBDAV_USERNAME=credential[0],
+                     WEBDAV_PASSWORD=credential[1],
+    ):
         ds.repo.call_annex(cmd_args)
     yield get_status_dict(
         ds=ds,

--- a/datalad_next/gitremotes/datalad_annex.py
+++ b/datalad_next/gitremotes/datalad_annex.py
@@ -216,6 +216,7 @@ from datalad_next.runners import (
 from datalad_next.uis import ui_switcher as ui
 from datalad_next.utils import (
     external_versions,
+    patched_env,
     rmtree,
 )
 
@@ -501,7 +502,7 @@ class RepoAnnexGitRemote(object):
                 self._init_repoannex_type_web(ra)
             else:
                 # let git-annex-initremote take over
-                with patch.dict('os.environ', self.credential_env or {}):
+                with patched_env(**(self.credential_env or {})):
                     ra.call_annex(
                         ['initremote', 'origin'] + [
                             p for p in self.initremote_params

--- a/datalad_next/gitremotes/tests/test_datalad_annex.py
+++ b/datalad_next/gitremotes/tests/test_datalad_annex.py
@@ -12,7 +12,6 @@
 
 from pathlib import Path
 from stat import S_IREAD, S_IRGRP, S_IROTH
-from unittest.mock import patch
 from urllib.parse import quote as urlquote
 
 from datalad.api import (
@@ -29,7 +28,10 @@ from datalad_next.tests import (
 )
 from datalad_next.consts import on_windows
 from datalad_next.exceptions import CommandError
-from datalad_next.utils import rmtree
+from datalad_next.utils import (
+    patched_env,
+    rmtree,
+)
 from ..datalad_annex import get_initremote_params_from_url
 
 
@@ -298,11 +300,11 @@ def _check_typeweb(pushtmpl, clonetmpl, ds, server, clonepath):
     ])
     ds.repo.call_git(['push', '-u', 'dla', DEFAULT_BRANCH])
     # must override git-annex security setting for localhost
-    with patch.dict(
-            "os.environ", {
-                "GIT_CONFIG_COUNT": "1",
-                "GIT_CONFIG_KEY_0": "annex.security.allowed-ip-addresses",
-                "GIT_CONFIG_VALUE_0": "127.0.0.1"}):
+    with patched_env(**{
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "annex.security.allowed-ip-addresses",
+        "GIT_CONFIG_VALUE_0": "127.0.0.1"}
+    ):
         dsclone = clone(
             clonetmpl.format(url=server.url),
             clonepath)
@@ -327,11 +329,11 @@ def test_submodule_url(tmp_path, existing_noannex_dataset, http_server,
     tobesubds.repo.call_git(['push', '-u', 'dla', DEFAULT_BRANCH])
     # create a superdataset to register the subds to
     super = Dataset(tmp_path / 'super').create()
-    with patch.dict(
-            "os.environ", {
-                "GIT_CONFIG_COUNT": "1",
-                "GIT_CONFIG_KEY_0": "annex.security.allowed-ip-addresses",
-                "GIT_CONFIG_VALUE_0": "127.0.0.1"}):
+    with patched_env(**{
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "annex.security.allowed-ip-addresses",
+        "GIT_CONFIG_VALUE_0": "127.0.0.1"}
+    ):
         # this is the URL that matters
         # we intentionally use something that leaves a placeholder behind
         # in the submodule record

--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -15,7 +15,6 @@ from typing import (
     Optional,
     Union,
 )
-from unittest.mock import patch
 
 import datalad.core.distributed.push as mod_push
 from datalad_next.constraints import EnsureChoice
@@ -30,6 +29,7 @@ from datalad_next.utils import (
     get_specialremote_credential_envpatch,
     get_specialremote_credential_properties,
     needs_specialremote_credential_envpatch,
+    patched_env,
 )
 from . import apply_patch
 
@@ -224,7 +224,7 @@ def _transfer_data(repo: AnnexRepo,
 
     res_kwargs['target'] = target
 
-    with patch.dict('os.environ', env_patch):
+    with patched_env(**env_patch):
         try:
             for result in repo._call_annex_records_items_(
                 [

--- a/datalad_next/tests/fixtures.py
+++ b/datalad_next/tests/fixtures.py
@@ -8,7 +8,6 @@ import subprocess
 import pytest
 from tempfile import NamedTemporaryFile
 from time import sleep
-from unittest.mock import patch
 from urllib.request import urlopen
 
 from datalad_next.datasets import Dataset
@@ -16,6 +15,7 @@ from datalad_next.runners import (
     call_git_lines,
     call_git_success,
 )
+from datalad_next.utils import patched_env
 from .utils import (
     HTTPPath,
     WebDAVPath,
@@ -121,8 +121,7 @@ def tmp_keyring():
         # already when ConfigManager would open it for reading
         tf.close()
         backend.file_path = tf.name
-        with patch.dict(os.environ,
-                        {'DATALAD_TESTS_TMP_KEYRING_PATH': tf.name}):
+        with patched_env(DATALAD_TESTS_TMP_KEYRING_PATH=tf.name):
             yield backend
 
     backend.file_path = prev_fpath
@@ -179,7 +178,7 @@ def datalad_cfg():
         # we must close, because windows does not like the file being open
         # already when ConfigManager would open it for reading
         tf.close()
-        with patch.dict(os.environ, {'GIT_CONFIG_GLOBAL': tf.name}):
+        with patched_env(GIT_CONFIG_GLOBAL=tf.name):
             cfg.reload(force=True)
             yield cfg
     # reload to put the previous config in effect again

--- a/datalad_next/utils/__init__.py
+++ b/datalad_next/utils/__init__.py
@@ -12,6 +12,7 @@
    external_versions
    log_progress
    parse_www_authenticate
+   patched_env
    rmtree
    get_specialremote_param_dict
    get_specialremote_credential_properties
@@ -72,7 +73,7 @@ from .specialremote import (
     needs_specialremote_credential_envpatch,
     get_specialremote_credential_envpatch,
 )
-
+from .patch import patched_env
 
 # TODO REMOVE EVERYTHING BELOW FOR V2.0
 # https://github.com/datalad/datalad-next/issues/611

--- a/datalad_next/utils/patch.py
+++ b/datalad_next/utils/patch.py
@@ -1,2 +1,31 @@
+import contextlib
+from os import environ
+
 # legacy import
 from datalad_next.patches import apply_patch
+
+
+@contextlib.contextmanager
+def patched_env(**env):
+    """Context manager for patching the process environment
+
+    Any number of kwargs can be given. Keys represent environment variable
+    names, and values their values. A value of ``None`` indicates that
+    the respective variable should be unset, i.e., removed from the
+    environment.
+    """
+    preserve = {}
+    for name, val in env.items():
+        preserve[name] = environ.get(name, None)
+        if val is None:
+            del environ[name]
+        else:
+            environ[name] = str(val)
+    try:
+        yield
+    finally:
+        for name, val in preserve.items():
+            if val is None:
+                del environ[name]
+            else:
+                environ[name] = val

--- a/datalad_next/utils/tests/test_patch.py
+++ b/datalad_next/utils/tests/test_patch.py
@@ -1,0 +1,15 @@
+from ..patch import patched_env
+from os import environ
+
+
+def test_patched_env():
+    if 'HOME' in environ:
+        home = environ['HOME']
+        with patched_env(HOME=None):
+            assert 'HOME' not in environ
+        assert environ['HOME'] == home
+    unusual_name = 'DATALADPATCHENVTESTVAR'
+    if unusual_name not in environ:
+        with patched_env(**{unusual_name: 'dummy'}):
+            assert environ[unusual_name] == 'dummy'
+        assert unusual_name not in environ


### PR DESCRIPTION
This new helper has been lifted from #632, where is it used to do lean patching of subprocess ENVs. However, it is generally useful.

We should not need to import `unittest` for normal operations.