### PR TITLE
`datalad-annex::` Test for a repository deposit before establishing mirrorrepo 

### DIFF
--- a/datalad_next/gitremotes/datalad_annex.py
+++ b/datalad_next/gitremotes/datalad_annex.py
@@ -220,17 +220,13 @@ from datalad_next.runners import (
 )
 from datalad_next.uis import ui_switcher as ui
 from datalad_next.utils import (
-    external_versions,
-    patched_env,
-    rmtree,
-)
-
-from datalad_next.utils import (
     CredentialManager,
+    external_versions,
     get_specialremote_credential_envpatch,
     get_specialremote_credential_properties,
     needs_specialremote_credential_envpatch,
     patched_env,
+    rmtree,
     specialremote_credential_envmap,
     update_specialremote_credential,
 )

--- a/datalad_next/gitremotes/datalad_annex.py
+++ b/datalad_next/gitremotes/datalad_annex.py
@@ -318,6 +318,11 @@ class RepoAnnexGitRemote(object):
         # https://www.git-scm.com/docs/gitremote-helpers#_options
         self.options = {}
 
+        # we want to go for verbose output whenever datalad's log level is
+        # debug or even more verbose. This makes it unnecessary to call
+        # git directly with multiple `-v` options
+        self.verbosity_threshold = 1 if lgr.getEffectiveLevel() > 10 else 10
+
         # ID of the tree to export, if needed
         self.exporttree = None
 
@@ -645,7 +650,7 @@ class RepoAnnexGitRemote(object):
         # 1 is the default level of verbosity,
         # and higher values of <n> correspond to the number of -v flags
         # passed on the command line
-        if self.options.get('verbosity', 1) >= level:
+        if self.options.get('verbosity', self.verbosity_threshold) >= level:
             print('[DATALAD-ANNEX]', *args, file=self.errstream)
 
     def send(self, msg):

--- a/datalad_next/patches/push_optimize.py
+++ b/datalad_next/patches/push_optimize.py
@@ -444,9 +444,17 @@ def _sync_remote_annex_branch(repo, target, is_annex_repo):
     except mod_push.CommandError as e:
         # it is OK if the remote doesn't have a git-annex branch yet
         # (e.g. fresh repo)
-        # TODO is this possible? we just copied? Maybe check if anything
+        # Is this even possible? we just copied? Maybe check if anything
         # was actually copied?
-        if "fatal: couldn't find remote ref git-annex" not in e.stderr.lower():
+        # Yes, this is possible. The current implementation of the datalad-annex
+        # special remote would run into this situation. It would copy annex objects
+        # to a new location just fine, but until a repository deposit was made
+        # (and this implementation of push only does this as a second step), it
+        # could not retrieve any refs from the remote.
+        # the following conditional tests for the common prefix of the respective
+        # error message by Git and the Git-channeled error message from the
+        # datalad-annex remote helper.
+        if "fatal: couldn't find remote ref" not in e.stderr.lower():
             raise
         lgr.debug('Remote does not have a git-annex branch: %s', e)
 


### PR DESCRIPTION
The `mirrorrepo` property of the datalad-annex Git remote helper implementation creates an empty repository, if the remote has no refs (or does not exist). This is sensible behavior for enabling initial pushes.

However, it leads to successful but empty clones/fetches for any misspecified URL or connectivity failure. This is undesirable.

This change adds an explicit test for an available/accessible repository deposit, whenever a clone/fetch is performed. Wrong URL specifications or connectivity issues will now lead to an explicit error exit. This fact is communicated via a non-verbose message, and the full error is available at verbosity level 2, i.e. with a `git clone -v`.

- Closes: https://github.com/datalad/datalad-next/issues/636

TODO

- [x] Add test
- [x] Look into test failure with create-sibling-webdav