### PR TITLE
Enable `call_git*()` helpers to force running Git with LC_ALL=C

### DIFF
--- a/datalad_next/patches/push_optimize.py
+++ b/datalad_next/patches/push_optimize.py
@@ -433,6 +433,8 @@ def _sync_remote_annex_branch(repo, target, is_annex_repo):
             lgr.debug(
                 "Sync local annex branch from pushurl after remote "
                 'availability update.')
+        # XXX when this is changed to `call_git()`,
+        # make sure to `force_c_locale=True`
         repo.call_git(fetch_cmd)
         # If no CommandError was raised, it means that remote has git-annex
         # but local repo might not be an annex yet. Since there is nothing to "sync"

--- a/datalad_next/patches/push_to_export_remote.py
+++ b/datalad_next/patches/push_to_export_remote.py
@@ -98,6 +98,8 @@ def get_export_records(repo: AnnexRepo) -> Generator:
         all other values are strings.
     """
     try:
+        # XXX when this is changed to `call_git()`, make sure to use
+        # `force_c_locale=True`
         for line in repo.call_git_items_(["cat-file", "blob", "git-annex:export.log"]):
             result_dict = dict(zip(
                 [

--- a/datalad_next/repo_utils/worktree.py
+++ b/datalad_next/repo_utils/worktree.py
@@ -18,6 +18,9 @@ def get_worktree_head(
             # (and we only report the first item below, to take it off again)
             ['rev-parse', '-q', '--symbolic-full-name', 'HEAD', '--'],
             cwd=path,
+            # we are doing error message parsing below, fix the language
+            # to avoid making it even more fragile
+            force_c_locale=True,
         )[0]
     except (NotADirectoryError, FileNotFoundError) as e:
         raise ValueError('path not found') from e

--- a/datalad_next/runners/tests/test_git.py
+++ b/datalad_next/runners/tests/test_git.py
@@ -27,6 +27,10 @@ def test_call_git_lines():
     lines = call_git_lines(['--version'])
     assert len(lines) == 1
     assert lines[0].startswith('git version')
+    # check that we can force Git into LC_ALL mode.
+    # this test is only meaningful on systems that
+    # run with some other locale
+    call_git_lines(['-h'])[0].casefold().startswith('usage')
 
 
 def test_call_git_oneline():


### PR DESCRIPTION
Needed whenever output has to be parsed.

Closes #641