### PR TITLE
Add benchmark and codspeed integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -303,7 +303,7 @@ for:
       # run tests on installed module, not source tree files
       - |
         cd __testhome__
-        python -m pytest -s -v --durations 20 -m "not (turtle)" -k "$KEYWORDS" --cov=datalad_next --cov datalad --cov-config=../.coveragerc --pyargs ${DTS}
+        python -m pytest -s -v --durations 20 -m "not (turtle)" -k "$KEYWORDS" --cov=datalad_next --cov datalad --cov-config=../.coveragerc --benchmark-disable --pyargs ${DTS}
 
     after_test:
       - python -m coverage xml
@@ -370,7 +370,7 @@ for:
       - cmd: md __testhome__
       - cmd: cd __testhome__
         # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-      - cmd: python -m pytest -s -v --durations 20 -m "not (turtle)" -k "%KEYWORDS%" --cov=datalad_next --cov-config=..\.coveragerc --pyargs %DTS%
+      - cmd: python -m pytest -s -v --durations 20 -m "not (turtle)" -k "%KEYWORDS%" --cov=datalad_next --cov-config=..\.coveragerc --benchmark-disable --pyargs %DTS%
 
     after_test:
       - cmd: python -m coverage xml

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,59 @@
+name: codspeed-benchmarks
+
+on:
+  # Run on pushes to the main branch
+  push:
+    branches:
+      - "main"
+  # Run on pull requests
+  pull_request:
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          # codspeed needs 3.12 for trace generation
+          python-version: 3.12
+      - name: Set up environment
+        run: |
+          git config --global user.email "test@github.land"
+          git config --global user.name "GitHub Almighty"
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install git-annex
+        id: gitannex
+        run: |
+          python -m pip install datalad-installer
+          datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok git-annex -m snapshot
+          . "${HOME}/dlinstaller_env.sh"
+          # make the PATH modification available to the following steps of the
+          # workflow
+          echo "PATH=$PATH" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements-devel.txt
+          python -m pip install pytest-codspeed
+      - name: Debug
+        env:
+          PATH: ${{ steps.gitannex.outputs.PATH }}
+        run: |
+          git annex version
+          python -m pytest --codspeed datalad_next
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@v2
+        env:
+          CODSPEED_LOG: debug 
+          PATH: ${{ steps.gitannex.outputs.PATH }}
+        with:
+          # a token is not needed for public projects, but we leave it here
+          # until things are working
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: |
+            bash -c ". ${HOME}/dlinstaller_env.sh; python -m pytest --codspeed datalad_next"

--- a/datalad_next/iter_collections/tests/test_itergitstatus.py
+++ b/datalad_next/iter_collections/tests/test_itergitstatus.py
@@ -185,14 +185,19 @@ def test_status_norec(modified_dataset):
     _assert_testcases(st, test_cases)
 
 
-def test_status_smrec(modified_dataset):
-    st = {
-        item.name: item
-        for item in iter_gitstatus(
-            path=modified_dataset.pathobj, recursive='submodules',
-            eval_submodule_state='full', untracked='all',
-        )
-    }
+def test_status_smrec(modified_dataset, benchmark):
+    def _benchmark():
+        return list(iter_gitstatus(
+            path=modified_dataset.pathobj,
+            recursive='submodules',
+            eval_submodule_state='full',
+            untracked='all',
+        ))
+
+    # first exec the key function as a benchmark
+    items = benchmark(_benchmark)
+
+    st = {item.name: item for item in items}
     # in this mode we expect ALL results of a 'repository' mode recursion,
     # including the submodule-type items, plus additional ones from within
     # the submodules
@@ -200,14 +205,19 @@ def test_status_smrec(modified_dataset):
                                 test_cases_submodule_recursion))
 
 
-def test_status_monorec(modified_dataset):
-    st = {
-        item.name: item
-        for item in iter_gitstatus(
-            path=modified_dataset.pathobj, recursive='monolithic',
-            eval_submodule_state='full', untracked='all',
-        )
-    }
+def test_status_monorec(modified_dataset, benchmark):
+    def _benchmark():
+        return list(iter_gitstatus(
+            path=modified_dataset.pathobj,
+            recursive='monolithic',
+            eval_submodule_state='full',
+            untracked='all',
+        ))
+
+    # first exec the key function as a benchmark
+    items = benchmark(_benchmark)
+
+    st = {item.name: item for item in items}
     # in this mode we expect ALL results of a 'repository' mode recursion,
     # including the submodule-type items, plus additional ones from within
     # the submodules

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ devel =
     pytest
     pytest-cov
     coverage
+    pytest-benchmark
     # for iterable_subprocess
     psutil
     # for webdav testing


### PR DESCRIPTION
This changeset adds two (arbitrary) benchmarks via `pytest-benchmark`. This works fine.

It disables the execution of benchmarks (but not the benchmarked implementations) on Appveyor.

It adds a codspeed GitHub action to run and submit benchmarks to codspeed.io.

The latter implementation follows the docs, but it not working. As one can see in `.github/workflows/codspeed.yml` and comparing to the actions logs:

- the installation (with git-annex) works
- the debug-step runs the very same test configuration as the codspeed runner, and passes
- the codspeed run fails, because it cannot find git-annex installed.

This behavior is independent of specific approach to set up git-annex. The exact same behavior is observed when git-annex is installed as a system package (via NeuroDebian). So the failure is not easily attributable to some kind of environment sanitization.

Any ideas what could happen here?