### PR TITLE
Atomic UrlOperations.upload for ssh- and file-URLs 

### DIFF
--- a/datalad_next/url_operations/base.py
+++ b/datalad_next/url_operations/base.py
@@ -179,6 +179,11 @@ class UrlOperations:
                timeout: float | None = None) -> Dict:
         """Upload from a local file or stream to a URL
 
+        Whenever possible, uploads are performed atomically This means that the
+        destination will never see a partially uploaded file. It will either
+        see the previous content (or nothing) or the newly uploaded content.
+        Note: this is not supported by all implementations of URL-operations.
+
         Parameters
         ----------
         from_path: Path or None

--- a/datalad_next/url_operations/tests/test_file.py
+++ b/datalad_next/url_operations/tests/test_file.py
@@ -38,8 +38,7 @@ def test_file_url_download(tmp_path):
         ops.download(test_url, download_path)
 
 
-@pytest.mark.parametrize('atomic', [True, False])
-def test_file_url_upload(tmp_path, monkeypatch, atomic):
+def test_file_url_upload(tmp_path, monkeypatch):
     payload = 'payload'
     payload_file = tmp_path / 'payload'
     test_upload_path = tmp_path / 'myfile'
@@ -48,13 +47,13 @@ def test_file_url_upload(tmp_path, monkeypatch, atomic):
     # missing source file
     # standard exception, makes no sense to go custom thinks mih
     with pytest.raises(FileNotFoundError):
-        ops.upload(payload_file, test_upload_url, atomic=atomic)
+        ops.upload(payload_file, test_upload_url)
     # no empty targets lying around
     assert not test_upload_path.exists()
 
     # now again
     payload_file.write_text(payload)
-    props = ops.upload(payload_file, test_upload_url, hash=['md5'], atomic=atomic)
+    props = ops.upload(payload_file, test_upload_url, hash=['md5'])
     assert test_upload_path.read_text() == 'payload'
     assert props['content-length'] == len(payload)
     assert props['md5'] == '321c3cf486ed509164edec1e1981fec8'
@@ -65,7 +64,7 @@ def test_file_url_upload(tmp_path, monkeypatch, atomic):
         m.setattr(sys, 'stdin',
                   io.TextIOWrapper(io.BytesIO(
                       bytes(payload, encoding='utf-8'))))
-        props = ops.upload(None, from_stdin_url, hash=['md5'], atomic=atomic)
+        props = ops.upload(None, from_stdin_url, hash=['md5'])
         assert props['md5'] == '321c3cf486ed509164edec1e1981fec8'
         assert props['content-length'] == len(payload)
 

--- a/datalad_next/url_operations/tests/test_ssh.py
+++ b/datalad_next/url_operations/tests/test_ssh.py
@@ -49,8 +49,7 @@ def test_ssh_url_download(tmp_path, monkeypatch, sshserver):
 
 # path magic inside the test is posix only
 @skip_if_on_windows
-@pytest.mark.parametrize('atomic', [True, False])
-def test_ssh_url_upload(tmp_path, monkeypatch, sshserver, atomic):
+def test_ssh_url_upload(tmp_path, monkeypatch, sshserver):
     ssh_url, ssh_localpath = sshserver
     payload = 'surprise!'
     payload_path = tmp_path / 'payload'
@@ -60,7 +59,7 @@ def test_ssh_url_upload(tmp_path, monkeypatch, sshserver, atomic):
 
     # standard error if local source is not around
     with pytest.raises(FileNotFoundError):
-        ops.upload(payload_path, upload_url, atomic=atomic)
+        ops.upload(payload_path, upload_url)
 
     payload_path.write_text(payload)
     # upload creates parent dirs, so the next just works.
@@ -69,7 +68,7 @@ def test_ssh_url_upload(tmp_path, monkeypatch, sshserver, atomic):
     # server-side preconditions first.
     # this functionality is not about exposing a full
     # remote FS abstraction -- just upload
-    ops.upload(payload_path, upload_url, atomic=atomic)
+    ops.upload(payload_path, upload_url)
     assert upload_path.read_text() == payload
 
 


### PR DESCRIPTION
This PR addresses issue [datalad-ria #102](https://github.com/datalad/datalad-ria/issues/102) and touches on issue #454 where atomic upload operations are discussed as well.

The PR also adds atomic upload to files. This can prevent data loss in the case where multiple threads write to the same file concurrently.

All ssh- and file-uploads should be atomic, which means an `atomic`-parameter that controls atomicity on a per-call basis is not necessary.
