### PR TITLE
Make `iter_diff()` robust to lstat-only changes

### DIFF
--- a/changelog.d/20240407_154322_michael.hanke_bf_639.md
+++ b/changelog.d/20240407_154322_michael.hanke_bf_639.md
@@ -1,0 +1,6 @@
+### 🐛 Bug Fixes
+
+- `next-status` no longer issues undesirable modification reports
+  that are based on mtime changes alone (i.e., no content change).
+  Fixes https://github.com/datalad/datalad-next/issues/639 via
+  https://github.com/datalad/datalad-next/pull/650 (by @mih)

--- a/datalad_next/iter_collections/gitdiff.py
+++ b/datalad_next/iter_collections/gitdiff.py
@@ -87,7 +87,7 @@ class GitDiffItem(GitTreeItem):
     """This is the percentage of similarity for copy-status and
     rename-status diff items, and the percentage of dissimilarity
     for modifications."""
-    modification_types: tuple[GitContainerModificationType] | None = None
+    modification_types: tuple[GitContainerModificationType, ...] | None = None
     """Qualifiers for modification types of container-type
     items (directories, submodules)."""
 

--- a/datalad_next/iter_collections/gitdiff.py
+++ b/datalad_next/iter_collections/gitdiff.py
@@ -23,7 +23,10 @@ from datalad_next.itertools import (
     decode_bytes,
     itemize,
 )
-from datalad_next.runners import call_git_oneline
+from datalad_next.runners import (
+    call_git,
+    call_git_oneline,
+)
 
 from .gittree import (
     GitTreeItem,
@@ -209,6 +212,19 @@ def iter_gitdiff(
     )
 
     cmd = _build_cmd(**kwargs)
+
+    if cmd[0] == 'diff-index':
+        # when we compare to the index, we need a refresh run to not have
+        # something like plain mtime changes trigger modification reports
+        # https://github.com/datalad/datalad-next/issues/639
+        call_git([
+            'update-index',
+            # must come first, we recurse ourselves
+            '--ignore-submodules',
+            # we want to continue the refresh when the index need updating
+            '-q',
+            '--refresh',
+        ])
 
     # when do we need to condense subdir reports into a single dir-report
     reported_dirs: set[str] = set()


### PR DESCRIPTION
With this change, a dedicate `update-index` refresh run is performed before running `diff-index`. This fixes undesired modification reports that are triggered by mtime-change only.

This comes at a performance cost. For a repo with 36k files (many-ish), this is about 5% of the total runtime:

```
%timeit next_status('.', result_renderer='disabled', untracked='all', recursive='datasets')
229 ms ± 537 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit next_status('.', result_renderer='disabled', untracked='all', recursive='datasets')
240 ms ± 2.59 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Closes #639