### PR TITLE
Disable (power)`shell` test on windows, known incompatibility

### DIFF
--- a/datalad_next/shell/tests/test_shell.py
+++ b/datalad_next/shell/tests/test_shell.py
@@ -462,6 +462,7 @@ def test_fixed_length_response_generator_bash():
 # This test mostly works on Windows systems because it executes a local powershell.
 @skip_if(not on_windows)
 def test_fixed_length_response_generator_powershell():
+    pytest.skip(f'Test disabled, see https://github.com/datalad/datalad-next/issues/662')
     with shell(
             ['powershell', '-Command', '-'],
             zero_command_rg_class=VariableLengthResponseGeneratorPowerShell,


### PR DESCRIPTION
The issues is tracked at https://github.com/datalad/datalad-next/issues/662 We cannot have a permanently failing test.

