### PR TITLE
Fix a test that fails due to a PowerShell bug

### DIFF
--- a/datalad_next/shell/tests/test_shell.py
+++ b/datalad_next/shell/tests/test_shell.py
@@ -464,16 +464,11 @@ def test_fixed_length_response_generator_powershell():
             ['powershell', '-Command', '-'],
             zero_command_rg_class=VariableLengthResponseGeneratorPowerShell,
     ) as powershell:
-        result = loads(powershell('$PSVersionTable|ConvertTo-Json').stdout)['PSVersion']
-        powershell_version = 100 * result['Major'] + result['Minor']
-        if powershell_version == 501 and result['Build'] < 19041:
-            pytest.skip(
-                f'skipping test because of a bug in powershell '
-                f'version {powershell_version}'
-            )
 
         result = powershell(b'Write-Host -NoNewline 0123456789')
         assert result.returncode == 0
+        if result.stdout.startswith(b'\nOops,'):
+            pytest.skip(f'skipping test because powershell detected a bug')
         assert result.stdout == b'0123456789'
 
         # Check that only 10 bytes are consumed and any excess bytes show up


### PR DESCRIPTION
This commit fixes the test
`test_fixed_length_response_generator_powershell`, which fails on certain PowerShell-versions. The test is skipped on those versions.

Closes https://github.com/datalad/datalad-next/issues/662