### PR TITLE
Patch RIA and ORA code to work on multiple client platforms

### DIFF
--- a/.codespell-exclude
+++ b/.codespell-exclude
@@ -1,0 +1,1 @@
+            froms=ds.repo.get_revisions()[1],

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,3 +17,5 @@ jobs:
         uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v1
+        with:
+          exclude_file: .codespell-exclude

--- a/changelog.d/20240514_212532_michael.hanke_patch_create_sibling_ria.md
+++ b/changelog.d/20240514_212532_michael.hanke_patch_create_sibling_ria.md
@@ -1,0 +1,10 @@
+### 💫 Enhancements and new features
+
+- A large 3k-line patch set replaces almost the entire RIA implementation,
+  including the ORA special remote, and the `create-sibling-ria` command.
+  The new implementation brings uniform support for Windows clients, progress
+  reporting for uploads and downloads via SSH, and a faster and more
+  robust behavior for SSH-based operations (based on the new remote
+  shell feature).
+  Fixes https://github.com/datalad/datalad-next/issues/654 via
+  https://github.com/datalad/datalad-next/pull/669 (by @christian-monch)

--- a/datalad_next/config/utils.py
+++ b/datalad_next/config/utils.py
@@ -73,6 +73,12 @@ def set_gitconfig_items_in_env(items: Mapping[str, str | Tuple[str, ...]]):
 
     Multi-value configuration keys are supported (values provided as a tuple).
 
+    Any item with a value of ``None`` will be posted into the ENV with an
+    empty string as value, i.e. the corresponding ``GIT_CONFIG_VALUE_{count}``
+    variable will be an empty string. ``None`` item values indicate that the
+    configuration key was unset on the command line, via the global option
+    ``-c``.
+
     No verification (e.g., of syntax compliance) is performed.
     """
     _clean_env_from_gitconfig_items()
@@ -83,7 +89,7 @@ def set_gitconfig_items_in_env(items: Mapping[str, str | Tuple[str, ...]]):
         values = value if isinstance(value, tuple) else (value,)
         for v in values:
             environ[f'GIT_CONFIG_KEY_{count}'] = key
-            environ[f'GIT_CONFIG_VALUE_{count}'] = v
+            environ[f'GIT_CONFIG_VALUE_{count}'] = '' if v is None else str(v)
             count += 1
     if count:
         environ['GIT_CONFIG_COUNT'] = str(count)

--- a/datalad_next/patches/add_method_url2transport_path.py
+++ b/datalad_next/patches/add_method_url2transport_path.py
@@ -1,0 +1,81 @@
+"""Add the method :meth:`url2transport_path` to RIA IO-abstraction classes
+
+This patch adds the method :meth:`url2transport_path` to the IO-abstraction
+classes: :class:`datalad.distributed.ora_remote.LocalIO`, and to the class
+:class:`datalad.distributed.ora_remote.HTTPRemoteIO`.
+
+This method is required by the patches that add Windows-client support to
+RIA-code. It converts internally used abstract paths to concrete paths that are
+platform- andIO-abstraction specific and on which IO-operations cam be
+performed.
+"""
+from __future__ import annotations
+
+import logging
+from re import compile
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+
+from datalad_next.consts import on_windows
+from . import apply_patch
+
+
+# The methods are patched into the ora_remote/ria_remote. Use the same logger.
+lgr = logging.getLogger('datalad.customremotes.ria_remote')
+
+
+drive_letter_matcher = compile('^/[A-Z]:')
+
+
+def str2windows_path(url_path: PurePosixPath):
+    path_str = str(url_path)
+    match = drive_letter_matcher.match(path_str)
+    if match:
+        if path_str[3] == '/':
+            return Path(*([f'{path_str[1]}:', '/'] + path_str[4:].split('/')))
+        else:
+            lgr.warning(f'Non-absolute Windows-path detected: {path_str}')
+            return Path(*([f'{path_str[1]}:'] + path_str[3:].split('/')))
+    else:
+        return Path(path_str)
+
+
+def local_io_url2transport_path(
+        self,
+        url_path: PurePosixPath
+) -> Path | PurePosixPath:
+    assert url_path.__class__ is PurePosixPath
+    if on_windows:
+        return str2windows_path(url_path)
+    else:
+        return Path(url_path)
+
+
+def http_remote_io_url2transport_path(
+        self,
+        url_path: PurePosixPath
+) -> Path | PurePosixPath:
+    assert url_path.__class__ is PurePosixPath
+    return url_path
+
+
+# Add a `url2transport_path`-method to `ora_remote.LocalIO`
+apply_patch(
+    'datalad.distributed.ora_remote',
+    'LocalIO',
+    'url2transport_path',
+    local_io_url2transport_path,
+    expect_attr_present=False,
+)
+
+
+# Add a `url2transport_path`-method to `ora_remote.HTTPRemoteIO`
+apply_patch(
+    'datalad.distributed.ora_remote',
+    'HTTPRemoteIO',
+    'url2transport_path',
+    http_remote_io_url2transport_path,
+    expect_attr_present=False,
+)

--- a/datalad_next/patches/customremotes_main.py
+++ b/datalad_next/patches/customremotes_main.py
@@ -10,6 +10,8 @@ This patch also adds a standard `close()` handler to special remotes, and calls
 that handler in a context manager to ensure releasing any resources. This
 replaces the custom `stop()` method, which is undocumented and only used by the
 `datalad-archive` special remote.
+
+This patch also adds code that allows to patch a class that is already loaded
 """
 
 from contextlib import closing
@@ -117,6 +119,11 @@ def patched_underscore_main(args: list, cls: Type[SpecialRemote]):
     """
     assert cls is not None
     from annexremote import Master
+
+    # Reload the class, to allow `cls` itself to be patched.
+    new_module = __import__(cls.__module__, fromlist=[cls.__name__])
+    cls = getattr(new_module, cls.__name__)
+
     master = Master()
     # this context manager use relies on patching in a close() below
     with closing(cls(master)) as remote:

--- a/datalad_next/patches/enabled.py
+++ b/datalad_next/patches/enabled.py
@@ -20,4 +20,6 @@ from . import (
     add_method_url2transport_path,
     # this replaces SSHRemoteIO entirely
     replace_sshremoteio,
+    # this replaces ORARemote entirely
+    replace_ora_remote,
 )

--- a/datalad_next/patches/enabled.py
+++ b/datalad_next/patches/enabled.py
@@ -20,6 +20,10 @@ from . import (
     add_method_url2transport_path,
     # this replaces SSHRemoteIO entirely
     replace_sshremoteio,
+    # The following patches try to fix ORA/RIA code
+    ria_utils,
     # this replaces ORARemote entirely
     replace_ora_remote,
+    # MUST be after `replace_sshremoteio` and `ria_utils`
+    replace_create_sibling_ria,
 )

--- a/datalad_next/patches/enabled.py
+++ b/datalad_next/patches/enabled.py
@@ -17,16 +17,5 @@ from . import (
     # the following two patches have been taken verbatim from datalad-ria
     ssh_exec,
     sshconnector,
-
-    add_method_url2transport_path,
-    # this replaces SSHRemoteIO entirely
-    replace_sshremoteio,
-    # The following patches try to fix ORA/RIA code
-    ria_utils,
-    # this replaces ORARemote entirely
-    replace_ora_remote,
-    # adapt the tests to the updated interface
-    fix_ria_ora_tests,
-    # MUST be after `replace_sshremoteio` and `ria_utils`
-    replace_create_sibling_ria,
+    patch_ria_ora,
 )

--- a/datalad_next/patches/enabled.py
+++ b/datalad_next/patches/enabled.py
@@ -17,6 +17,7 @@ from . import (
     # the following two patches have been taken verbatim from datalad-ria
     ssh_exec,
     sshconnector,
+
     add_method_url2transport_path,
     # this replaces SSHRemoteIO entirely
     replace_sshremoteio,
@@ -24,6 +25,8 @@ from . import (
     ria_utils,
     # this replaces ORARemote entirely
     replace_ora_remote,
+    # adapt the tests to the updated interface
+    fix_ria_ora_tests,
     # MUST be after `replace_sshremoteio` and `ria_utils`
     replace_create_sibling_ria,
 )

--- a/datalad_next/patches/enabled.py
+++ b/datalad_next/patches/enabled.py
@@ -17,6 +17,7 @@ from . import (
     # the following two patches have been taken verbatim from datalad-ria
     ssh_exec,
     sshconnector,
+    add_method_url2transport_path,
     # this replaces SSHRemoteIO entirely
     replace_sshremoteio,
 )

--- a/datalad_next/patches/fix_ria_ora_tests.py
+++ b/datalad_next/patches/fix_ria_ora_tests.py
@@ -1,0 +1,1028 @@
+"""Patch ria-, ora-, ria_utils-, and clone-tests to work with modified ria_utils
+
+The ria-utils-patches use an abstract path representation for RIA-store elements.
+This patch adapts the tests that use `ria_utils.create_store` and
+`ria_utils.create_ds_in_store` to these modifications.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import stat
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+from urllib.request import pathname2url
+
+from datalad.api import (
+    Dataset,
+    clone,
+    create_sibling_ria,
+)
+from datalad.cmd import (
+    WitlessRunner as Runner,
+    NoCapture,
+)
+from datalad.customremotes.ria_utils import (
+    UnknownLayoutVersion,
+    create_ds_in_store,
+    create_store,
+    get_layout_locations,
+)
+from datalad.distributed.ora_remote import (
+    LocalIO,
+    SSHRemoteIO,
+)
+from datalad.distributed.tests.ria_utils import (
+    common_init_opts,
+    get_all_files,
+    populate_dataset,
+)
+from datalad.support.exceptions import (
+    CommandError,
+    IncompleteResultsError,
+)
+from datalad.support.network import get_local_file_url
+from datalad.tests.utils_pytest import (
+    SkipTest,
+    assert_equal,
+    assert_false,
+    assert_in,
+    assert_not_in,
+    assert_raises,
+    assert_repo_status,
+    assert_result_count,
+    assert_status,
+    assert_true,
+    create_tree,
+    has_symlink_capability,
+    known_failure_githubci_win,
+    known_failure_windows,
+    rmtree,
+    serve_path_via_http,
+    skip_if_adjusted_branch,
+    swallow_logs,
+    with_tempfile,
+)
+
+from . import apply_patch
+
+
+def local_path2pure_posix_path(path: Path | str):
+    return PurePosixPath(pathname2url(str(path)))
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@with_tempfile
+def patched__postclonetest_prepare(lcl, storepath, storepath2, link):
+
+    from datalad.customremotes.ria_utils import (
+        create_ds_in_store,
+        create_store,
+        get_layout_locations,
+    )
+    from datalad.distributed.ora_remote import LocalIO
+
+    create_tree(lcl,
+                tree={
+                        'ds': {
+                            'test.txt': 'some',
+                            'subdir': {
+                                'subds': {'testsub.txt': 'somemore'},
+                                'subgit': {'testgit.txt': 'even more'}
+                            },
+                        },
+                      })
+
+    lcl = Path(lcl)
+    storepath = Path(storepath)
+    storepath2 = Path(storepath2)
+    # PATCH: introduce `ppp_storepath` and `ppp_storepath2` and use them instead
+    # of `storepath` and `storepath2`.
+    ppp_storepath = local_path2pure_posix_path(storepath)
+    ppp_storepath2 = local_path2pure_posix_path(storepath2)
+    link = Path(link)
+    link.symlink_to(storepath)
+
+    # create a local dataset with a subdataset
+    subds = Dataset(lcl / 'ds' / 'subdir' / 'subds').create(force=True)
+    subds.save()
+    # add a plain git dataset as well
+    subgit = Dataset(lcl / 'ds' / 'subdir' / 'subgit').create(force=True,
+                                                              annex=False)
+    subgit.save()
+    ds = Dataset(lcl / 'ds').create(force=True)
+    ds.save(version_tag='original')
+    assert_repo_status(ds.path)
+
+    io = LocalIO()
+
+    # Have a second store with valid ORA remote. This should not interfere with
+    # reconfiguration of the first one, when that second store is not the one we
+    # clone from. However, don't push data into it for easier get-based testing
+    # later on.
+    # Doing this first, so datasets in "first"/primary store know about this.
+    create_store(io, ppp_storepath2, '1')
+    url2 = "ria+{}".format(get_local_file_url(str(storepath2)))
+    for d in (ds, subds, subgit):
+        create_ds_in_store(io, ppp_storepath2, d.id, '2', '1')
+        d.create_sibling_ria(url2, "anotherstore", new_store_ok=True)
+        d.push('.', to='anotherstore', data='nothing')
+        store2_loc, _, _ = get_layout_locations(1, ppp_storepath2, d.id)
+        Runner(cwd=str(store2_loc)).run(['git', 'update-server-info'])
+
+    # Now the store to clone from:
+    create_store(io, ppp_storepath, '1')
+
+    # URL to use for upload. Point is, that this should be invalid for the clone
+    # so that autoenable would fail. Therefore let it be based on a to be
+    # deleted symlink
+    upl_url = "ria+{}".format(get_local_file_url(str(link)))
+
+    for d in (ds, subds, subgit):
+
+        # TODO: create-sibling-ria required for config! => adapt to RF'd
+        #       creation (missed on rebase?)
+        create_ds_in_store(io, ppp_storepath, d.id, '2', '1')
+        d.create_sibling_ria(upl_url, "store", new_store_ok=True)
+
+        if d is not subgit:
+            # Now, simulate the problem by reconfiguring the special remote to
+            # not be autoenabled.
+            # Note, however, that the actual intention is a URL, that isn't
+            # valid from the point of view of the clone (doesn't resolve, no
+            # credentials, etc.) and therefore autoenabling on git-annex-init
+            # when datalad-cloning would fail to succeed.
+            Runner(cwd=d.path).run(['git', 'annex', 'enableremote',
+                                    'store-storage',
+                                    'autoenable=false'])
+        d.push('.', to='store')
+        store_loc, _, _ = get_layout_locations(1, ppp_storepath, d.id)
+        Runner(cwd=str(store_loc)).run(['git', 'update-server-info'])
+
+    link.unlink()
+    # We should now have a store with datasets that have an autoenabled ORA
+    # remote relying on an inaccessible URL.
+    # datalad-clone is supposed to reconfigure based on the URL we cloned from.
+    # Test this feature for cloning via HTTP, SSH and FILE URLs.
+
+    return ds.id
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@known_failure_githubci_win  # in datalad/git-annex as e.g. of 20201218
+@with_tempfile(mkdir=True)
+@with_tempfile
+@with_tempfile
+def patched_test_ria_postclone_noannex(dspath=None, storepath=None, clonepath=None):
+
+    # Test for gh-5186: Cloning from local FS, shouldn't lead to annex
+    # initializing origin.
+
+    dspath = Path(dspath)
+    storepath = Path(storepath)
+    clonepath = Path(clonepath)
+    # PATCH: introduce `ppp_storepath` and use it instead of `storepath`.
+    ppp_storepath = local_path2pure_posix_path(storepath)
+
+    from datalad.customremotes.ria_utils import (
+        create_ds_in_store,
+        create_store,
+        get_layout_locations,
+    )
+    from datalad.distributed.ora_remote import LocalIO
+
+    # First create a dataset in a RIA store the standard way
+    somefile = dspath / 'a_file.txt'
+    somefile.write_text('irrelevant')
+    ds = Dataset(dspath).create(force=True)
+
+    io = LocalIO()
+    create_store(io, ppp_storepath, '1')
+    lcl_url = "ria+{}".format(get_local_file_url(str(storepath)))
+    create_ds_in_store(io, ppp_storepath, ds.id, '2', '1')
+    ds.create_sibling_ria(lcl_url, "store", new_store_ok=True)
+    ds.push('.', to='store')
+
+
+    # now, remove annex/ tree from store in order to see, that clone
+    # doesn't cause annex to recreate it.
+    store_loc, _, _ = get_layout_locations(1, storepath, ds.id)
+    annex = store_loc / 'annex'
+    rmtree(str(annex))
+    assert_false(annex.exists())
+
+    clone_url = get_local_file_url(str(storepath), compatibility='git') + \
+                '#{}'.format(ds.id)
+    clone("ria+{}".format(clone_url), clonepath)
+
+    # no need to test the cloning itself - we do that over and over in here
+
+    # bare repo in store still has no local annex:
+    assert_false(annex.exists())
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@with_tempfile
+def patched_test_setup_store(io_cls, io_args, store=None):
+    io = io_cls(*io_args)
+    store = Path(store)
+    # PATCH: introduce `ppp_store` and use it instead of `store`
+    ppp_store = local_path2pure_posix_path(store)
+    version_file = store / 'ria-layout-version'
+    error_logs = store / 'error_logs'
+
+    # invalid version raises:
+    assert_raises(UnknownLayoutVersion, create_store, io, ppp_store, '2')
+
+    # non-existing path should work:
+    create_store(io, ppp_store, '1')
+    assert_true(version_file.exists())
+    assert_true(error_logs.exists())
+    assert_true(error_logs.is_dir())
+    assert_equal([f for f in error_logs.iterdir()], [])
+
+    # empty target directory should work as well:
+    rmtree(str(store))
+    store.mkdir(exist_ok=False)
+    create_store(io, ppp_store, '1')
+    assert_true(version_file.exists())
+    assert_true(error_logs.exists())
+    assert_true(error_logs.is_dir())
+    assert_equal([f for f in error_logs.iterdir()], [])
+
+    # re-execution also fine:
+    create_store(io, ppp_store, '1')
+
+    # but version conflict with existing target isn't:
+    version_file.write_text("2|unknownflags\n")
+    assert_raises(ValueError, create_store, io, ppp_store, '1')
+    # TODO: check output reporting conflicting version "2"
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@with_tempfile
+def patched_test_setup_ds_in_store(io_cls, io_args, store=None):
+    io = io_cls(*io_args)
+    store = Path(store)
+    # PATCH: introduce `ppp_store` and use it instead of `store`
+    ppp_store = local_path2pure_posix_path(store)
+    # ATM create_ds_in_store doesn't care what kind of ID is provided
+    dsid = "abc123456"
+
+    ds_path = store / dsid[:3] / dsid[3:]  # store layout version 1
+    version_file = ds_path / 'ria-layout-version'
+    archives = ds_path / 'archives'
+    objects = ds_path / 'annex' / 'objects'
+    git_config = ds_path / 'config'
+
+    # invalid store version:
+    assert_raises(UnknownLayoutVersion,
+                  create_ds_in_store, io, ppp_store, dsid, '1', 'abc')
+
+    # invalid obj version:
+    assert_raises(UnknownLayoutVersion,
+                  create_ds_in_store, io, ppp_store, dsid, 'abc', '1')
+
+    # version 1
+    create_store(io, ppp_store, '1')
+    create_ds_in_store(io, ppp_store, dsid, '1', '1')
+    for p in [ds_path, archives, objects]:
+        assert_true(p.is_dir(), msg="Not a directory: %s" % str(p))
+    for p in [version_file]:
+        assert_true(p.is_file(), msg="Not a file: %s" % str(p))
+    assert_equal(version_file.read_text(), "1\n")
+
+    # conflicting version exists at target:
+    assert_raises(ValueError, create_ds_in_store, io, ppp_store, dsid, '2', '1')
+
+    # version 2
+    # Note: The only difference between version 1 and 2 are supposed to be the
+    #       key paths (dirhashlower vs mixed), which has nothing to do with
+    #       setup routine.
+    rmtree(str(store))
+    create_store(io, ppp_store, '1')
+    create_ds_in_store(io, ppp_store, dsid, '2', '1')
+    for p in [ds_path, archives, objects]:
+        assert_true(p.is_dir(), msg="Not a directory: %s" % str(p))
+    for p in [version_file]:
+        assert_true(p.is_file(), msg="Not a file: %s" % str(p))
+    assert_equal(version_file.read_text(), "2\n")
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+@with_tempfile
+def patched_test_initremote(store_path=None, store_url=None, ds_path=None):
+    ds = Dataset(ds_path).create()
+    store_path = Path(store_path)
+    # PATCH: introduce `ppp_store_path` and use it instead of `store_path`
+    ppp_store_path = local_path2pure_posix_path(store_path)
+    url = "ria+" + store_url
+    init_opts = common_init_opts + ['url={}'.format(url)]
+
+    # fail when there's no RIA store at the destination
+    assert_raises(CommandError, ds.repo.init_remote, 'ora-remote',
+                  options=init_opts)
+    # Doesn't actually create a remote if it fails
+    assert_not_in('ora-remote',
+                  [cfg['name']
+                   for uuid, cfg in ds.repo.get_special_remotes().items()]
+                  )
+
+    # now make it a store
+    io = LocalIO()
+    create_store(io, ppp_store_path, '1')
+    create_ds_in_store(io, ppp_store_path, ds.id, '2', '1')
+
+    # fails on non-RIA URL
+    assert_raises(CommandError, ds.repo.init_remote, 'ora-remote',
+                  options=common_init_opts + ['url={}'
+                                              ''.format(store_path.as_uri())]
+                  )
+    # Doesn't actually create a remote if it fails
+    assert_not_in('ora-remote',
+                  [cfg['name']
+                   for uuid, cfg in ds.repo.get_special_remotes().items()]
+                  )
+
+    ds.repo.init_remote('ora-remote', options=init_opts)
+    assert_in('ora-remote',
+              [cfg['name']
+               for uuid, cfg in ds.repo.get_special_remotes().items()]
+              )
+    assert_repo_status(ds.path)
+    # git-annex:remote.log should have:
+    #   - url
+    #   - common_init_opts
+    #   - archive_id (which equals ds id)
+    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'],
+                                  read_only=True)
+    assert_in("url={}".format(url), remote_log)
+    [assert_in(c, remote_log) for c in common_init_opts]
+    assert_in("archive-id={}".format(ds.id), remote_log)
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+# TODO: on crippled FS copytree to populate store doesn't seem to work.
+#       Or may be it's just the serving via HTTP that doesn't work.
+#       Either way, after copytree and fsck, whereis doesn't report
+#       the store as an available source.
+@skip_if_adjusted_branch
+@known_failure_windows  # see gh-4469
+@with_tempfile(mkdir=True)
+@serve_path_via_http
+@with_tempfile
+def patched_test_read_access(store_path=None, store_url=None, ds_path=None):
+
+    ds = Dataset(ds_path).create()
+    populate_dataset(ds)
+
+    files = [Path('one.txt'), Path('subdir') / 'two']
+    store_path = Path(store_path)
+    # PATCH: introduce `ppp_store_path` and use it instead of `store_path`
+    ppp_store_path = local_path2pure_posix_path(store_path)
+    url = "ria+" + store_url
+    init_opts = common_init_opts + ['url={}'.format(url)]
+
+    io = LocalIO()
+    create_store(io, ppp_store_path, '1')
+    create_ds_in_store(io, ppp_store_path, ds.id, '2', '1')
+    ds.repo.init_remote('ora-remote', options=init_opts)
+    fsck_results = ds.repo.fsck(remote='ora-remote', fast=True)
+    # Note: Failures in the special remote will show up as a success=False
+    # result for fsck -> the call itself would not fail.
+    for r in fsck_results:
+        if "note" in r:
+            # we could simply assert "note" to not be in r, but we want proper
+            # error reporting - content of note, not just its unexpected
+            # existence.
+            assert_equal(r["success"], "true",
+                         msg="git-annex-fsck failed with ORA over HTTP: %s" % r)
+        assert_equal(r["error-messages"], [])
+    store_uuid = ds.siblings(name='ora-remote',
+                             return_type='item-or-list',
+                             result_renderer='disabled')['annex-uuid']
+    here_uuid = ds.siblings(name='here',
+                            return_type='item-or-list',
+                            result_renderer='disabled')['annex-uuid']
+
+    # nothing in store yet:
+    for f in files:
+        known_sources = ds.repo.whereis(str(f))
+        assert_in(here_uuid, known_sources)
+        assert_not_in(store_uuid, known_sources)
+
+    annex_obj_target = str(store_path / ds.id[:3] / ds.id[3:]
+                           / 'annex' / 'objects')
+    shutil.rmtree(annex_obj_target)
+    shutil.copytree(src=str(ds.repo.dot_git / 'annex' / 'objects'),
+                    dst=annex_obj_target)
+
+    ds.repo.fsck(remote='ora-remote', fast=True)
+    # all in store now:
+    for f in files:
+        known_sources = ds.repo.whereis(str(f))
+        assert_in(here_uuid, known_sources)
+        assert_in(store_uuid, known_sources)
+
+    ds.drop('.')
+    res = ds.get('.')
+    assert_equal(len(res), 4)
+    assert_result_count(res, 4, status='ok', type='file', action='get',
+                        message="from ora-remote...")
+
+    # try whether the reported access URL is correct
+    one_url = ds.repo.whereis('one.txt', output='full'
+        )[store_uuid]['urls'].pop()
+    assert_status('ok', ds.download_url(urls=[one_url], path=str(ds.pathobj / 'dummy')))
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@with_tempfile
+@with_tempfile
+def patched_test_initremote_basic(url, io, store, ds_path, link):
+
+    ds_path = Path(ds_path)
+    store = Path(store)
+    # PATCH: introduce `ppp_store` and use it instead of `store`
+    ppp_store = local_path2pure_posix_path(store)
+    link = Path(link)
+    ds = Dataset(ds_path).create()
+    populate_dataset(ds)
+
+    init_opts = common_init_opts + ['url={}'.format(url)]
+
+    # fails on non-existing storage location
+    assert_raises(CommandError,
+                  ds.repo.init_remote, 'ria-remote', options=init_opts)
+    # Doesn't actually create a remote if it fails
+    assert_not_in('ria-remote',
+                  [cfg['name']
+                   for uuid, cfg in ds.repo.get_special_remotes().items()]
+                  )
+
+    # fails on non-RIA URL
+    assert_raises(CommandError, ds.repo.init_remote, 'ria-remote',
+                  options=common_init_opts + ['url={}'.format(store.as_uri())]
+                  )
+    # Doesn't actually create a remote if it fails
+    assert_not_in('ria-remote',
+                  [cfg['name']
+                   for uuid, cfg in ds.repo.get_special_remotes().items()]
+                  )
+
+    # set up store:
+    create_store(io, ppp_store, '1')
+    # still fails, since ds isn't setup in the store
+    assert_raises(CommandError,
+                  ds.repo.init_remote, 'ria-remote', options=init_opts)
+    # Doesn't actually create a remote if it fails
+    assert_not_in('ria-remote',
+                  [cfg['name']
+                   for uuid, cfg in ds.repo.get_special_remotes().items()]
+                  )
+    # set up the dataset as well
+    create_ds_in_store(io, ppp_store, ds.id, '2', '1')
+    # now should work
+    ds.repo.init_remote('ria-remote', options=init_opts)
+    assert_in('ria-remote',
+              [cfg['name']
+               for uuid, cfg in ds.repo.get_special_remotes().items()]
+              )
+    assert_repo_status(ds.path)
+    # git-annex:remote.log should have:
+    #   - url
+    #   - common_init_opts
+    #   - archive_id (which equals ds id)
+    remote_log = ds.repo.call_git(['cat-file', 'blob', 'git-annex:remote.log'],
+                                  read_only=True)
+    assert_in("url={}".format(url), remote_log)
+    [assert_in(c, remote_log) for c in common_init_opts]
+    assert_in("archive-id={}".format(ds.id), remote_log)
+
+    # re-configure with invalid URL should fail:
+    assert_raises(
+        CommandError,
+        ds.repo.call_annex,
+        ['enableremote', 'ria-remote'] + common_init_opts + [
+            'url=ria+file:///non-existing'])
+    # but re-configure with valid URL should work
+    if has_symlink_capability():
+        link.symlink_to(store)
+        new_url = 'ria+{}'.format(link.as_uri())
+        ds.repo.call_annex(
+            ['enableremote', 'ria-remote'] + common_init_opts + [
+                'url={}'.format(new_url)])
+        # git-annex:remote.log should have:
+        #   - url
+        #   - common_init_opts
+        #   - archive_id (which equals ds id)
+        remote_log = ds.repo.call_git(['cat-file', 'blob',
+                                       'git-annex:remote.log'],
+                                      read_only=True)
+        assert_in("url={}".format(new_url), remote_log)
+        [assert_in(c, remote_log) for c in common_init_opts]
+        assert_in("archive-id={}".format(ds.id), remote_log)
+
+    # we can deal with --sameas, which leads to a special remote not having a
+    # 'name' property, but only a 'sameas-name'. See gh-4259
+    try:
+        ds.repo.init_remote('ora2',
+                            options=init_opts + ['--sameas', 'ria-remote'])
+    except CommandError as e:
+        if 'Invalid option `--sameas' in e.stderr:
+            # annex too old - doesn't know --sameas
+            pass
+        else:
+            raise
+    # TODO: - check output of failures to verify it's failing the right way
+    #       - might require to run initremote directly to get the output
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@known_failure_windows  # see gh-4469
+@with_tempfile
+@with_tempfile
+@with_tempfile
+def patched_test_remote_layout(host, dspath, store, archiv_store):
+
+    dspath = Path(dspath)
+    store = Path(store)
+    archiv_store = Path(archiv_store)
+    # PATCH: introduce `ppp_store` and use it instead of `store`
+    ppp_store = local_path2pure_posix_path(store)
+    ppp_archiv_store = local_path2pure_posix_path(archiv_store)
+    ds = Dataset(dspath).create()
+    populate_dataset(ds)
+    assert_repo_status(ds.path)
+
+    # set up store:
+    io = SSHRemoteIO(host) if host else LocalIO()
+    if host:
+        store_url = "ria+ssh://{host}{path}".format(host=host,
+                                                    path=store)
+        arch_url = "ria+ssh://{host}{path}".format(host=host,
+                                                   path=archiv_store)
+    else:
+        store_url = "ria+{}".format(store.as_uri())
+        arch_url = "ria+{}".format(archiv_store.as_uri())
+
+    create_store(io, ppp_store, '1')
+
+    # TODO: Re-establish test for version 1
+    # version 2: dirhash
+    create_ds_in_store(io, ppp_store, ds.id, '2', '1')
+
+    # add special remote
+    init_opts = common_init_opts + ['url={}'.format(store_url)]
+    ds.repo.init_remote('store', options=init_opts)
+
+    # copy files into the RIA store
+    ds.push('.', to='store')
+
+    # we should see the exact same annex object tree
+    dsgit_dir, archive_dir, dsobj_dir = \
+        get_layout_locations(1, store, ds.id)
+    store_objects = get_all_files(dsobj_dir)
+    local_objects = get_all_files(ds.pathobj / '.git' / 'annex' / 'objects')
+    assert_equal(len(store_objects), 4)
+
+    if not ds.repo.is_managed_branch():
+        # with managed branches the local repo uses hashdirlower instead
+        # TODO: However, with dataset layout version 1 this should therefore
+        #       work on adjusted branch the same way
+        # TODO: Wonder whether export-archive-ora should account for that and
+        #       rehash according to target layout.
+        assert_equal(sorted([p for p in store_objects]),
+                     sorted([p for p in local_objects])
+                     )
+
+        if not io.get_7z():
+            raise SkipTest("No 7z available in RIA store")
+
+        # we can simply pack up the content of the remote into a
+        # 7z archive and place it in the right location to get a functional
+        # archive remote
+
+        create_store(io, ppp_archiv_store, '1')
+        create_ds_in_store(io, ppp_archiv_store, ds.id, '2', '1')
+
+        whereis = ds.repo.whereis('one.txt')
+        dsgit_dir, archive_dir, dsobj_dir = \
+            get_layout_locations(1, archiv_store, ds.id)
+        ds.export_archive_ora(archive_dir / 'archive.7z')
+        init_opts = common_init_opts + ['url={}'.format(arch_url)]
+        ds.repo.init_remote('archive', options=init_opts)
+        # now fsck the new remote to get the new special remote indexed
+        ds.repo.fsck(remote='archive', fast=True)
+        assert_equal(len(ds.repo.whereis('one.txt')), len(whereis) + 1)
+        # test creating an archive with filters on files
+        ds.export_archive_ora(archive_dir / 'archive2.7z', annex_wanted='(include=*.txt)')
+        # test with wanted expression of a specific remote
+        ds.repo.set_preferred_content("wanted", "include=subdir/*", remote="store")
+        ds.export_archive_ora(archive_dir / 'archive3.7z', remote="store")
+        # test with the current sha
+        ds.export_archive_ora(
+            archive_dir / 'archive4.7z',
+            froms=ds.repo.get_revisions()[1],
+            )
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@known_failure_windows  # see gh-4469
+@with_tempfile
+@with_tempfile
+def patched_test_version_check(host, dspath, store):
+
+    dspath = Path(dspath)
+    store = Path(store)
+    # PATCH: introduce `ppp_store` and use it instead of `store`
+    ppp_store = local_path2pure_posix_path(store)
+
+    ds = Dataset(dspath).create()
+    populate_dataset(ds)
+    assert_repo_status(ds.path)
+
+    # set up store:
+    io = SSHRemoteIO(host) if host else LocalIO()
+    if host:
+        store_url = "ria+ssh://{host}{path}".format(host=host,
+                                                    path=store)
+    else:
+        store_url = "ria+{}".format(store.as_uri())
+
+    create_store(io, ppp_store, '1')
+
+    # TODO: Re-establish test for version 1
+    # version 2: dirhash
+    create_ds_in_store(io, ppp_store, ds.id, '2', '1')
+
+    # add special remote
+    init_opts = common_init_opts + ['url={}'.format(store_url)]
+    ds.repo.init_remote('store', options=init_opts)
+    ds.push('.', to='store')
+
+    # check version files
+    remote_ds_tree_version_file = store / 'ria-layout-version'
+    dsgit_dir, archive_dir, dsobj_dir = \
+        get_layout_locations(1, store, ds.id)
+    remote_obj_tree_version_file = dsgit_dir / 'ria-layout-version'
+
+    assert_true(remote_ds_tree_version_file.exists())
+    assert_true(remote_obj_tree_version_file.exists())
+
+    with open(str(remote_ds_tree_version_file), 'r') as f:
+        assert_equal(f.read().strip(), '1')
+    with open(str(remote_obj_tree_version_file), 'r') as f:
+        assert_equal(f.read().strip(), '2')
+
+    # Accessing the remote should not yield any output regarding versioning,
+    # since it's the "correct" version. Note that "fsck" is an arbitrary choice.
+    # We need just something to talk to the special remote.
+    with swallow_logs(new_level=logging.INFO) as cml:
+        ds.repo.fsck(remote='store', fast=True)
+        # TODO: For some reason didn't get cml.assert_logged to assert
+        #       "nothing was logged"
+        assert not cml.out
+
+    # Now fake-change the version
+    with open(str(remote_obj_tree_version_file), 'w') as f:
+        f.write('X\n')
+
+    # Now we should see a message about it
+    with swallow_logs(new_level=logging.INFO) as cml:
+        ds.repo.fsck(remote='store', fast=True)
+        cml.assert_logged(level="INFO",
+                          msg="Remote object tree reports version X",
+                          regex=False)
+
+    # reading still works:
+    ds.drop('.')
+    assert_status('ok', ds.get('.'))
+
+    # but writing doesn't:
+    with open(str(Path(ds.path) / 'new_file'), 'w') as f:
+        f.write("arbitrary addition")
+    ds.save(message="Add a new_file")
+
+    with assert_raises((CommandError, IncompleteResultsError)):
+        ds.push('new_file', to='store')
+
+    # However, we can force it by configuration
+    ds.config.add("annex.ora-remote.store.force-write", "true", scope='local')
+    ds.push('new_file', to='store')
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+# git-annex-testremote is way too slow on crippled FS.
+# Use is_managed_branch() as a proxy and skip only here
+# instead of in a decorator
+@skip_if_adjusted_branch
+@known_failure_windows  # see gh-4469
+@with_tempfile
+@with_tempfile
+def patched_test_gitannex(host, store, dspath):
+    dspath = Path(dspath)
+    store = Path(store)
+    # PATCH: introduce `ppp_store` and use it instead of `store`
+    ppp_store = local_path2pure_posix_path(store)
+
+    ds = Dataset(dspath).create()
+
+    populate_dataset(ds)
+    assert_repo_status(ds.path)
+
+    # set up store:
+    io = SSHRemoteIO(host) if host else LocalIO()
+    if host:
+        store_url = "ria+ssh://{host}{path}".format(host=host,
+                                                    path=store)
+    else:
+        store_url = "ria+{}".format(store.as_uri())
+
+    create_store(io, ppp_store, '1')
+
+    # TODO: Re-establish test for version 1
+    # version 2: dirhash
+    create_ds_in_store(io, ppp_store, ds.id, '2', '1')
+
+    # add special remote
+    init_opts = common_init_opts + ['url={}'.format(store_url)]
+    ds.repo.init_remote('store', options=init_opts)
+
+    from datalad.support.external_versions import external_versions
+    if '8.20200330' < external_versions['cmd:annex'] < '8.20200624':
+        # https://git-annex.branchable.com/bugs/testremote_breeds_way_too_many_instances_of_the_externals_remote/?updated
+        raise SkipTest(
+            "git-annex might lead to overwhelming number of external "
+            "special remote instances")
+
+    # run git-annex-testremote
+    # note, that we don't want to capture output. If something goes wrong we
+    # want to see it in test build's output log.
+    ds.repo._call_annex(['testremote', 'store'], protocol=NoCapture)
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+@known_failure_windows
+@with_tempfile
+@with_tempfile
+@with_tempfile
+def patched_test_push_url(storepath=None, dspath=None, blockfile=None):
+
+    dspath = Path(dspath)
+    store = Path(storepath)
+    # PATCH: introduce `ppp_store` and use it instead of `store`
+    ppp_store = local_path2pure_posix_path(store)
+    blockfile = Path(blockfile)
+    blockfile.touch()
+
+    ds = Dataset(dspath).create()
+    populate_dataset(ds)
+    assert_repo_status(ds.path)
+    repo = ds.repo
+
+    # set up store:
+    io = LocalIO()
+    store_url = "ria+{}".format(store.as_uri())
+    create_store(io, ppp_store, '1')
+    create_ds_in_store(io, ppp_store, ds.id, '2', '1')
+
+    # initremote fails with invalid url (not a ria+ URL):
+    invalid_url = (store.parent / "non-existent").as_uri()
+    init_opts = common_init_opts + ['url={}'.format(store_url),
+                                    'push-url={}'.format(invalid_url)]
+    assert_raises(CommandError, ds.repo.init_remote, 'store', options=init_opts)
+
+    # initremote succeeds with valid but inaccessible URL (pointing to a file
+    # instead of a store):
+    block_url = "ria+" + blockfile.as_uri()
+    init_opts = common_init_opts + ['url={}'.format(store_url),
+                                    'push-url={}'.format(block_url)]
+    repo.init_remote('store', options=init_opts)
+
+    store_uuid = ds.siblings(name='store',
+                             return_type='item-or-list')['annex-uuid']
+    here_uuid = ds.siblings(name='here',
+                            return_type='item-or-list')['annex-uuid']
+
+    # but a push will fail:
+    assert_raises(CommandError, ds.repo.call_annex,
+                  ['copy', 'one.txt', '--to', 'store'])
+
+    # reconfigure w/ local overwrite:
+    repo.config.add("remote.store.ora-push-url", store_url, scope='local')
+    # push works now:
+    repo.call_annex(['copy', 'one.txt', '--to', 'store'])
+
+    # remove again (config and file from store)
+    repo.call_annex(['move', 'one.txt', '--from', 'store'])
+    repo.config.unset("remote.store.ora-push-url", scope='local')
+    repo.call_annex(['fsck', '-f', 'store'])
+    known_sources = repo.whereis('one.txt')
+    assert_in(here_uuid, known_sources)
+    assert_not_in(store_uuid, known_sources)
+
+    # reconfigure (this time committed)
+    init_opts = common_init_opts + ['url={}'.format(store_url),
+                                    'push-url={}'.format(store_url)]
+    repo.enable_remote('store', options=init_opts)
+
+    # push works now:
+    repo.call_annex(['copy', 'one.txt', '--to', 'store'])
+    known_sources = repo.whereis('one.txt')
+    assert_in(here_uuid, known_sources)
+    assert_in(store_uuid, known_sources)
+
+
+# taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+# Skipping on adjusted branch as a proxy for crippledFS. Write permissions of
+# the owner on a directory can't be revoked on VFAT. "adjusted branch" is a
+# bit broad but covers the CI cases. And everything RIA/ORA doesn't currently
+# properly run on crippled/windows anyway. Needs to be more precise when
+# RF'ing will hopefully lead to support on windows in principle.
+@skip_if_adjusted_branch
+@known_failure_windows
+@with_tempfile
+@with_tempfile
+def patched_test_permission(host, storepath, dspath):
+
+    # Test whether ORA correctly revokes and obtains write permissions within
+    # the annex object tree. That is: Revoke after ORA pushed a key to store
+    # in order to allow the object tree to safely be used with an ephemeral
+    # clone. And on removal obtain write permissions, like annex would
+    # internally on a drop (but be sure to restore if something went wrong).
+
+    dspath = Path(dspath)
+    storepath = Path(storepath)
+    # PATCH: introduce `ppp_storepath` and use it instead of `storepath`
+    ppp_storepath = local_path2pure_posix_path(storepath)
+    ds = Dataset(dspath).create()
+    populate_dataset(ds)
+    ds.save()
+    assert_repo_status(ds.path)
+    testfile = 'one.txt'
+
+    # set up store:
+    io = SSHRemoteIO(host) if host else LocalIO()
+    if host:
+        store_url = "ria+ssh://{host}{path}".format(host=host,
+                                                    path=storepath)
+    else:
+        store_url = "ria+{}".format(storepath.as_uri())
+
+    create_store(io, ppp_storepath, '1')
+    create_ds_in_store(io, ppp_storepath, ds.id, '2', '1')
+    _, _, obj_tree = get_layout_locations(1, storepath, ds.id)
+    assert_true(obj_tree.is_dir())
+    file_key_in_store = obj_tree / 'X9' / '6J' / 'MD5E-s8--7e55db001d319a94b0b713529a756623.txt' / 'MD5E-s8--7e55db001d319a94b0b713529a756623.txt'
+
+    init_opts = common_init_opts + ['url={}'.format(store_url)]
+    ds.repo.init_remote('store', options=init_opts)
+
+    store_uuid = ds.siblings(name='store',
+                             return_type='item-or-list')['annex-uuid']
+    here_uuid = ds.siblings(name='here',
+                            return_type='item-or-list')['annex-uuid']
+
+    known_sources = ds.repo.whereis(testfile)
+    assert_in(here_uuid, known_sources)
+    assert_not_in(store_uuid, known_sources)
+    assert_false(file_key_in_store.exists())
+
+    ds.repo.call_annex(['copy', testfile, '--to', 'store'])
+    known_sources = ds.repo.whereis(testfile)
+    assert_in(here_uuid, known_sources)
+    assert_in(store_uuid, known_sources)
+    assert_true(file_key_in_store.exists())
+
+    # Revoke write permissions from parent dir in-store to test whether we
+    # still can drop (if we can obtain the permissions). Note, that this has
+    # no effect on VFAT.
+    file_key_in_store.parent.chmod(file_key_in_store.parent.stat().st_mode &
+                                   ~stat.S_IWUSR)
+    # we can't directly delete; key in store should be protected
+    assert_raises(PermissionError, file_key_in_store.unlink)
+
+    # ORA can still drop, since it obtains permission to:
+    ds.repo.call_annex(['drop', testfile, '--from', 'store'])
+    known_sources = ds.repo.whereis(testfile)
+    assert_in(here_uuid, known_sources)
+    assert_not_in(store_uuid, known_sources)
+    assert_false(file_key_in_store.exists())
+
+
+# Overwrite `_postclonetest_prepare` to handle paths properly
+apply_patch(
+    'datalad.core.distributed.tests.test_clone',
+    None,
+    '_postclonetest_prepare',
+    patched__postclonetest_prepare,
+    'modify _postclonetest_prepare to use PurePosixPath-arguments '
+    'in RIA-methodes'
+)
+
+
+apply_patch(
+    'datalad.core.distributed.tests.test_clone',
+    None,
+    'test_ria_postclone_noannex',
+    patched_test_ria_postclone_noannex,
+    'modify test_ria_postclone_noannex to use PurePosixPath-arguments '
+    'in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.customremotes.tests.test_ria_utils',
+    None,
+    '_test_setup_store',
+    patched_test_setup_store,
+    'modify _test_setup_store to use PurePosixPath-arguments in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.customremotes.tests.test_ria_utils',
+    None,
+    '_test_setup_ds_in_store',
+    patched_test_setup_ds_in_store,
+    'modify _test_setup_ds_in_store to use PurePosixPath-arguments '
+    'in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ora_http',
+    None,
+    'test_initremote',
+    patched_test_initremote,
+    'modify test_initremote to use PurePosixPath-arguments in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ora_http',
+    None,
+    'test_read_access',
+    patched_test_read_access,
+    'modify test_read_access to use PurePosixPath-arguments in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ria_basics',
+    None,
+    '_test_initremote_basic',
+    patched_test_initremote_basic,
+    'modify _test_initremote_basic to use PurePosixPath-arguments '
+    'in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ria_basics',
+    None,
+    '_test_remote_layout',
+    patched_test_remote_layout,
+    'modify _test_remote_layout to use PurePosixPath-arguments in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ria_basics',
+    None,
+    '_test_version_check',
+    patched_test_version_check,
+    'modify _test_version_check to use PurePosixPath-arguments in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ria_basics',
+    None,
+    '_test_gitannex',
+    patched_test_gitannex,
+    'modify _test_gitannex to use PurePosixPath-arguments in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ria_basics',
+    None,
+    'test_push_url',
+    patched_test_push_url,
+    'modify test_push_url to use PurePosixPath-arguments in RIA-methods'
+)
+
+
+apply_patch(
+    'datalad.distributed.tests.test_ria_basics',
+    None,
+    '_test_permission',
+    patched_test_permission,
+    'modify _test_permission to use PurePosixPath-arguments in RIA-methods'
+)

--- a/datalad_next/patches/patch_ria_ora.py
+++ b/datalad_next/patches/patch_ria_ora.py
@@ -1,0 +1,22 @@
+"""This file collects all patches for ORA/RIA-related code.
+
+The patches have to goals:
+
+1. Improve stability and consolidate code by using persistent shell support in
+   class :class:`SSHRemoteIO`.
+
+2. Improve ORA/RIA-related code so that it also works on Windows.
+"""
+
+from . import (
+    add_method_url2transport_path,
+    # this replaces SSHRemoteIO entirely
+    replace_sshremoteio,
+    # The following patches add Windows-support to ORA/RIA code
+    ria_utils,
+    replace_ora_remote,
+    fix_ria_ora_tests,
+    # `replace_create_sibling_ria` be imported after `replace_sshremoteio`
+    # and `ria_utils`.
+    replace_create_sibling_ria,
+)

--- a/datalad_next/patches/replace_create_sibling_ria.py
+++ b/datalad_next/patches/replace_create_sibling_ria.py
@@ -1,0 +1,886 @@
+"""This file contains an updated :class:`CreateSiblingRia`-class.
+
+It replaces the :class:`CreateSiblingRia`-class in
+`datalad.distributed.create_sibling_ria`. The updated class uses `PurePosixPath`
+for all RIA-store path calculations. It uses `url2transport_path` to convert
+the abstract paths to concrete paths for the IO-abstraction.
+
+The updated class also uses a canonified representation of path-anchors in
+URL-paths. This allows to handle the differences in path-anchor encoding between
+git-annex and RFC 8089-style file-URLs.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import PurePosixPath
+
+from datalad.cmd import WitlessRunner as Runner
+from datalad.core.distributed.clone import decode_source_spec
+from datalad.customremotes.ria_utils import (
+    create_ds_in_store,
+    get_layout_locations,
+    verify_ria_url,
+)
+from datalad.distributed.ora_remote import (
+    LocalIO,
+    RemoteCommandFailedError,
+    RIARemoteError,
+    SSHRemoteIO,
+)
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    datasetmethod,
+    require_dataset,
+)
+from datalad.distribution.utils import _yield_ds_w_matching_siblings
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
+from datalad.interface.common_opts import (
+    recursion_flag,
+    recursion_limit,
+)
+from datalad.interface.results import get_status_dict
+from datalad.log import log_progress
+from datalad.support.annexrepo import AnnexRepo
+from datalad.support.constraints import (
+    EnsureBool,
+    EnsureChoice,
+    EnsureNone,
+    EnsureStr,
+)
+from datalad.support.exceptions import CommandError
+from datalad.support.gitrepo import GitRepo
+from datalad.support.param import Parameter
+from datalad.utils import quote_cmdlinearg
+
+from datalad_next.consts import on_windows
+from . import apply_patch
+from .replace_ora_remote import (
+    canonify_url,
+    de_canonify_url,
+)
+
+
+lgr = logging.getLogger('datalad.distributed.create_sibling_ria')
+
+
+# `CreateSiblingRia` taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732:
+@build_doc
+class CreateSiblingRia(Interface):
+    """Creates a sibling to a dataset in a RIA store
+
+    Communication with a dataset in a RIA store is implemented via two
+    siblings. A regular Git remote (repository sibling) and a git-annex
+    special remote for data transfer (storage sibling) -- with the former
+    having a publication dependency on the latter. By default, the name of the
+    storage sibling is derived from the repository sibling's name by appending
+    "-storage".
+
+    The store's base path is expected to not exist, be an empty directory,
+    or a valid RIA store.
+
+    Notes
+    -----
+
+
+    **RIA URL format**
+
+    Interactions with new or existing RIA stores require RIA URLs to identify
+    the store or specific datasets inside of it.
+
+    The general structure of a RIA URL pointing to a store takes the form
+    ``ria+[scheme]://<storelocation>`` (e.g.,
+    ``ria+ssh://[user@]hostname:/absolute/path/to/ria-store``, or
+    ``ria+file:///absolute/path/to/ria-store``)
+
+    The general structure of a RIA URL pointing to a dataset in a store (for
+    example for cloning) takes a similar form, but appends either the datasets
+    UUID or a "~" symbol followed by the dataset's alias name:
+    ``ria+[scheme]://<storelocation>#<dataset-UUID>`` or
+    ``ria+[scheme]://<storelocation>#~<aliasname>``.
+    In addition, specific version identifiers can be appended to the URL with an
+    additional "@" symbol:
+    ``ria+[scheme]://<storelocation>#<dataset-UUID>@<dataset-version>``,
+    where ``dataset-version`` refers to a branch or tag.
+
+
+    **RIA store layout**
+
+    A RIA store is a directory tree with a dedicated subdirectory for each
+    dataset in the store. The subdirectory name is constructed from the
+    DataLad dataset ID, e.g. ``124/68afe-59ec-11ea-93d7-f0d5bf7b5561``, where
+    the first three characters of the ID are used for an intermediate
+    subdirectory in order to mitigate files system limitations for stores
+    containing a large number of datasets.
+
+    By default, a dataset in a RIA store consists of two components:
+    A Git repository (for all dataset contents stored in Git) and a
+    storage sibling (for dataset content stored in git-annex).
+
+    It is possible to selectively disable either component using
+    ``storage-sibling 'off'`` or ``storage-sibling 'only'``, respectively.
+    If neither component is disabled, a dataset's subdirectory layout in a RIA
+    store contains a standard bare Git repository and an ``annex/`` subdirectory
+    inside of it.
+    The latter holds a Git-annex object store and comprises the storage sibling.
+    Disabling the standard git-remote (``storage-sibling='only'``) will result
+    in not having the bare git repository, disabling the storage sibling
+    (``storage-sibling='off'``) will result in not having the ``annex/``
+    subdirectory.
+
+    Optionally, there can be a further subdirectory ``archives`` with
+    (compressed) 7z archives of annex objects. The storage remote is able to
+    pull annex objects from these archives, if it cannot find in the regular
+    annex object store. This feature can be useful for storing large
+    collections of rarely changing data on systems that limit the number of
+    files that can be stored.
+
+    Each dataset directory also contains a ``ria-layout-version`` file that
+    identifies the data organization (as, for example, described above).
+
+    Lastly, there is a global ``ria-layout-version`` file at the store's
+    base path that identifies where dataset subdirectories themselves are
+    located. At present, this file must contain a single line stating the
+    version (currently "1"). This line MUST end with a newline character.
+
+    It is possible to define an alias for an individual dataset in a store by
+    placing a symlink to the dataset location into an ``alias/`` directory
+    in the root of the store. This enables dataset access via URLs of format:
+    ``ria+<protocol>://<storelocation>#~<aliasname>``.
+
+    Compared to standard git-annex object stores, the ``annex/`` subdirectories
+    used as storage siblings follow a different layout naming scheme
+    ('dirhashmixed' instead of 'dirhashlower').
+    This is mostly noted as a technical detail, but also serves to remind
+    git-annex powerusers to refrain from running git-annex commands
+    directly in-store as it can cause severe damage due to the layout
+    difference. Interactions should be handled via the ORA special remote
+    instead.
+
+
+    **Error logging**
+
+    To enable error logging at the remote end, append a pipe symbol and an "l"
+    to the version number in ria-layout-version (like so: ``1|l\\n``).
+
+    Error logging will create files in an "error_log" directory whenever the
+    git-annex special remote (storage sibling) raises an exception, storing the
+    Python traceback of it. The logfiles are named according to the scheme
+    ``<dataset id>.<annex uuid of the remote>.log`` showing "who" ran into this
+    issue with which dataset. Because logging can potentially leak personal
+    data (like local file paths for example), it can be disabled client-side
+    by setting the configuration variable
+    ``annex.ora-remote.<storage-sibling-name>.ignore-remote-config``.
+    """
+
+    # TODO: description?
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to process.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        url=Parameter(
+            args=("url",),
+            metavar="ria+<ssh|file|http(s)>://<host>[/path]",
+            doc="""URL identifying the target RIA store and access protocol. If
+            ``push_url||--push-url`` is given in addition, this is
+            used for read access only. Otherwise it will be used for write
+            access too and to create the repository sibling in the RIA store.
+            Note, that HTTP(S) currently is valid for consumption only thus
+            requiring to provide ``push_url||--push-url``.
+            """,
+            constraints=EnsureStr() | EnsureNone()),
+        push_url=Parameter(
+            args=("--push-url",),
+            metavar="ria+<ssh|file>://<host>[/path]",
+            doc="""URL identifying the target RIA store and access protocol for
+            write access to the storage sibling. If given this will also be used
+            for creation of the repository sibling in the RIA store.""",
+            constraints=EnsureStr() | EnsureNone()),
+        name=Parameter(
+            args=('-s', '--name',),
+            metavar='NAME',
+            doc="""Name of the sibling.
+            With `recursive`, the same name will be used to label all
+            the subdatasets' siblings.""",
+            constraints=EnsureStr() | EnsureNone(),
+            required=True),
+        storage_name=Parameter(
+            args=("--storage-name",),
+            metavar="NAME",
+            doc="""Name of the storage sibling (git-annex special remote).
+            Must not be identical to the sibling name. If not specified,
+            defaults to the sibling name plus '-storage' suffix. If only
+            a storage sibling is created, this setting is ignored, and
+            the primary sibling name is used.""",
+            constraints=EnsureStr() | EnsureNone()),
+        alias=Parameter(
+            args=('--alias',),
+            metavar='ALIAS',
+            doc="""Alias for the dataset in the RIA store.
+            Add the necessary symlink so that this dataset can be cloned from the RIA
+            store using the given ALIAS instead of its ID.
+            With `recursive=True`, only the top dataset will be aliased.""",
+            constraints=EnsureStr() | EnsureNone()),
+        post_update_hook=Parameter(
+            args=("--post-update-hook",),
+            doc="""Enable Git's default post-update-hook for the created
+            sibling. This is useful when the sibling is made accessible via a
+            "dumb server" that requires running 'git update-server-info'
+            to let Git interact properly with it.""",
+            action="store_true"),
+        shared=Parameter(
+            args=("--shared",),
+            metavar='{false|true|umask|group|all|world|everybody|0xxx}',
+            doc="""If given, configures the permissions in the
+            RIA store for multi-users access.
+            Possible values for this option are identical to those of
+            `git init --shared` and are described in its documentation.""",
+            constraints=EnsureStr() | EnsureBool() | EnsureNone()),
+        group=Parameter(
+            args=("--group",),
+            metavar="GROUP",
+            doc="""Filesystem group for the repository. Specifying the group is
+            crucial when [CMD: --shared=group CMD][PY: shared="group" PY]""",
+            constraints=EnsureStr() | EnsureNone()),
+        storage_sibling=Parameter(
+            args=("--storage-sibling",),
+            dest='storage_sibling',
+            metavar='MODE',
+            constraints=EnsureChoice('only') | EnsureBool() | EnsureNone(),
+            doc="""By default, an ORA storage sibling and a Git repository
+            sibling are created ([CMD: on CMD][PY: True|'on' PY]).
+            Alternatively, creation of the storage sibling can be disabled
+            ([CMD: off CMD][PY: False|'off' PY]), or a storage sibling
+            created only and no Git sibling
+            ([CMD: only CMD][PY: 'only' PY]). In the latter mode, no Git
+            installation is required on the target host."""),
+        existing=Parameter(
+            args=("--existing",),
+            constraints=EnsureChoice('skip', 'error', 'reconfigure'),
+            metavar='MODE',
+            doc="""Action to perform, if a (storage) sibling is already
+            configured under the given name and/or a target already exists.
+            In this case, a dataset can be skipped ('skip'), an existing target
+            repository be forcefully re-initialized, and the sibling
+            (re-)configured ('reconfigure'), or the command be instructed to
+            fail ('error').""", ),
+        new_store_ok=Parameter(
+            args=("--new-store-ok",),
+            action='store_true',
+            doc="""When set, a new store will be created, if necessary. Otherwise, a sibling
+            will only be created if the url points to an existing RIA store.""",
+        ),
+        recursive=recursion_flag,
+        recursion_limit=recursion_limit,
+        trust_level=Parameter(
+            args=("--trust-level",),
+            metavar="TRUST-LEVEL",
+            constraints=EnsureChoice('trust', 'semitrust', 'untrust', None),
+            doc="""specify a trust level for the storage sibling. If not
+            specified, the default git-annex trust level is used. 'trust'
+            should be used with care (see the git-annex-trust man page).""",),
+        disable_storage__=Parameter(
+            args=("--no-storage-sibling",),
+            dest='disable_storage__',
+            doc="""This option is deprecated. Use '--storage-sibling off'
+            instead.""",
+            action="store_false"),
+    )
+
+    @staticmethod
+    @datasetmethod(name='create_sibling_ria')
+    @eval_results
+    def __call__(url,
+                 name,
+                 *,  # note that `name` is required but not posarg in CLI
+                 dataset=None,
+                 storage_name=None,
+                 alias=None,
+                 post_update_hook=False,
+                 shared=None,
+                 group=None,
+                 storage_sibling=True,
+                 existing='error',
+                 new_store_ok=False,
+                 trust_level=None,
+                 recursive=False,
+                 recursion_limit=None,
+                 disable_storage__=None,
+                 push_url=None
+                 ):
+        if disable_storage__ is not None:
+            import warnings
+            warnings.warn("datalad-create-sibling-ria --no-storage-sibling "
+                          "is deprecated, use --storage-sibling off instead.",
+                          DeprecationWarning)
+            # recode to new setup
+            disable_storage__ = None
+            storage_sibling = False
+
+        if storage_sibling == 'only' and storage_name:
+            lgr.warning(
+                "Sibling name will be used for storage sibling in "
+                "storage-sibling-only mode, but a storage sibling name "
+                "was provided"
+            )
+
+        ds = require_dataset(
+            dataset, check_installed=True, purpose='create RIA sibling(s)')
+        res_kwargs = dict(
+            ds=ds,
+            action="create-sibling-ria",
+            logger=lgr,
+        )
+
+        # parse target URL
+        # Note: URL parsing is done twice ATM (for top-level ds). This can't be
+        # reduced to single instance, since rewriting url based on config could
+        # be different for subdatasets.
+        # PATCH: use canonified representation of `url` and `push_url`
+        url = canonify_url(url)
+        push_url = canonify_url(url)
+
+        try:
+            ssh_host, url_base_path_str, rewritten_url = \
+                verify_ria_url(push_url if push_url else url, ds.config)
+        except ValueError as e:
+            yield get_status_dict(
+                status='error',
+                message=str(e),
+                **res_kwargs
+            )
+            return
+
+        # PATCH: use `PurePosixPath` to represent the base path of the store
+        url_base_path = PurePosixPath(url_base_path_str)
+
+        if ds.repo.get_hexsha() is None or ds.id is None:
+            raise RuntimeError(
+                "Repository at {} is not a DataLad dataset, "
+                "run 'datalad create [--force]' first.".format(ds.path))
+
+        if not storage_sibling and storage_name:
+            lgr.warning(
+                "Storage sibling setup disabled, but a storage sibling name "
+                "was provided"
+            )
+
+        if storage_sibling and not storage_name:
+            storage_name = "{}-storage".format(name)
+
+        if storage_sibling and name == storage_name:
+            # leads to unresolvable, circular dependency with publish-depends
+            raise ValueError("sibling names must not be equal")
+
+        if not isinstance(url, str):
+            raise TypeError("url is not a string, but %s" % type(url))
+
+        # Query existing siblings upfront in order to fail early on
+        # existing=='error', since misconfiguration (particularly of special
+        # remotes) only to fail in a subdataset later on with that config, can
+        # be quite painful.
+        # TODO: messages - this is "create-sibling". Don't confuse existence of
+        #       local remotes with existence of the actual remote sibling
+        #       in wording
+        if existing == 'error':
+            failed = False
+            for dpath, sname in _yield_ds_w_matching_siblings(
+                    ds,
+                    (name, storage_name),
+                    recursive=recursive,
+                    recursion_limit=recursion_limit):
+                res = get_status_dict(
+                    status='error',
+                    message=(
+                        "a sibling %r is already configured in dataset %r",
+                        sname, dpath),
+                    type='sibling',
+                    name=sname,
+                    **res_kwargs,
+                )
+                failed = True
+                yield res
+            if failed:
+                return
+        # TODO: - URL parsing + store creation needs to be RF'ed based on
+        #         command abstractions
+        #       - more generally consider store creation a dedicated command or
+        #         option
+
+        io = SSHRemoteIO(ssh_host) if ssh_host else LocalIO()
+        try:
+            # determine the existence of a store by trying to read its layout.
+            # Because this raises a FileNotFound error if non-existent, we need
+            # to catch it
+            # PATCH: convert ria-layout-version location to a concreate path
+            # before giving it to an IO-abstraction.
+            io.read_file(io.url2transport_path(url_base_path / 'ria-layout-version'))
+        except (FileNotFoundError, RIARemoteError, RemoteCommandFailedError) as e:
+            if not new_store_ok:
+                # we're instructed to only act in case of an existing RIA store
+                res = get_status_dict(
+                    status='error',
+                    message="No store found at '{}'. Forgot "
+                            "--new-store-ok ?".format(url_base_path),
+                    **res_kwargs)
+                yield res
+                return
+
+        log_progress(
+            lgr.info, 'create-sibling-ria',
+            'Creating a new RIA store at %s', url_base_path,
+        )
+        create_store(io, url_base_path, '1')
+
+        yield from _create_sibling_ria(
+            ds,
+            url,
+            push_url,
+            name,
+            storage_sibling,
+            storage_name,
+            alias,
+            existing,
+            shared,
+            group,
+            post_update_hook,
+            trust_level,
+            res_kwargs)
+
+        if recursive:
+            # Note: subdatasets can be treated independently, so go full
+            # recursion when querying for them and _no_recursion with the
+            # actual call. Theoretically this can be parallelized.
+
+            for subds in ds.subdatasets(state='present',
+                                        recursive=True,
+                                        recursion_limit=recursion_limit,
+                                        return_type='generator',
+                                        result_renderer='disabled',
+                                        result_xfm='datasets'):
+                yield from _create_sibling_ria(
+                    subds,
+                    url,
+                    push_url,
+                    name,
+                    storage_sibling,
+                    storage_name,
+                    None,  # subdatasets can't have the same alias as the parent
+                    existing,
+                    shared,
+                    group,
+                    post_update_hook,
+                    trust_level,
+                    res_kwargs)
+
+
+def _create_sibling_ria(
+        ds,
+        url,
+        push_url,
+        name,
+        storage_sibling,
+        storage_name,
+        alias,
+        existing,
+        shared,
+        group,
+        post_update_hook,
+        trust_level,
+        res_kwargs):
+    # be safe across datasets
+    res_kwargs = res_kwargs.copy()
+    # update dataset
+    res_kwargs['ds'] = ds
+
+    if not isinstance(ds.repo, AnnexRepo):
+        # No point in dealing with a special remote when there's no annex.
+        # Note, that in recursive invocations this might only apply to some of
+        # the datasets. Therefore dealing with it here rather than one level up.
+        lgr.debug("No annex at %s. Ignoring special remote options.", ds.path)
+        storage_sibling = False
+        storage_name = None
+
+    # parse target URL
+    try:
+        ssh_host, url_base_path_str, rewritten_url = \
+            verify_ria_url(push_url if push_url else url, ds.config)
+    except ValueError as e:
+        yield get_status_dict(
+            status='error',
+            message=str(e),
+            **res_kwargs
+        )
+        return
+
+    # PATCH: use `PurePosixPath` to represent the base path of the RIA-store
+    url_base_path = PurePosixPath(url_base_path_str)
+
+    git_url = decode_source_spec(
+        # append dataset id to url and use magic from clone-helper:
+        url + '#{}'.format(ds.id),
+        cfg=ds.config
+    )['giturl']
+    git_push_url = decode_source_spec(
+        push_url + '#{}'.format(ds.id),
+        cfg=ds.config
+    )['giturl'] if push_url else None
+
+    # determine layout locations; go for a v1 store-level layout
+    repo_path, _, _ = get_layout_locations(1, url_base_path, ds.id)
+
+    ds_siblings = [
+        r['name'] for r in ds.siblings(
+            result_renderer='disabled',
+            return_type='generator')
+    ]
+    # Figure whether we are supposed to skip this very dataset
+    if existing == 'skip' and (
+            name in ds_siblings or (
+                storage_name and storage_name in ds_siblings)):
+        yield get_status_dict(
+            status='notneeded',
+            message="Skipped on existing sibling",
+            **res_kwargs
+        )
+        # if we skip here, nothing else can change that decision further
+        # down
+        return
+
+    # figure whether we need to skip or error due an existing target repo before
+    # we try to init a special remote.
+    if ssh_host:
+        from datalad import ssh_manager
+        ssh = ssh_manager.get_connection(
+            ssh_host,
+            use_remote_annex_bundle=False)
+        ssh.open()
+
+    exists = False
+    if existing in ['skip', 'error', 'reconfigure']:
+        config_path = repo_path / 'config'
+        # No .git -- if it's an existing repo in a RIA store it should be a
+        # bare repo.
+        # Theoretically we could have additional checks for whether we have
+        # an empty repo dir or a non-bare repo or whatever else.
+        if ssh_host:
+            try:
+                ssh('[ -e {p} ]'.format(p=quote_cmdlinearg(str(config_path))))
+                exists = True
+            except CommandError:
+                exists = False
+        else:
+            # PATCH: use concrete path for `config_path` to check for existence
+            exists = LocalIO().url2transport_path(config_path).exists()
+
+        if exists:
+            if existing == 'skip':
+                # 1. not rendered by default
+                # 2. message doesn't show up in ultimate result
+                #    record as shown by -f json_pp
+                yield get_status_dict(
+                    status='notneeded',
+                    message="Skipped on existing remote "
+                            "directory {}".format(repo_path),
+                    **res_kwargs
+                )
+                return
+            elif existing == 'error':
+                yield get_status_dict(
+                    status='error',
+                    message="remote directory {} already "
+                            "exists.".format(repo_path),
+                    **res_kwargs
+                )
+                return
+            else:
+                # reconfigure will be handled later in the code
+                pass
+
+    if storage_sibling == 'only':
+        lgr.info("create storage sibling '%s' ...", name)
+    else:
+        lgr.info("create sibling%s '%s'%s ...",
+            's' if storage_name else '',
+            name,
+            " and '{}'".format(storage_name) if storage_name else '',
+        )
+    create_ds_in_store(SSHRemoteIO(ssh_host) if ssh_host else LocalIO(),
+                       # PATCH: use abstract `url_base_path`
+                       url_base_path, ds.id, '2', '1', alias,
+                       init_obj_tree=storage_sibling is not False)
+    if storage_sibling:
+        # we are using the main `name`, if the only thing we are creating
+        # is the storage sibling
+        srname = name if storage_sibling == 'only' else storage_name
+
+        lgr.debug('init special remote %s', srname)
+        special_remote_options = [
+            'type=external',
+            'externaltype=ora',
+            'encryption=none',
+            'autoenable=true',
+            # PATCH: de-canonify `url`, because git-annex expects the path
+            # anchor in the netloc position.
+            f'url={de_canonify_url(url)}']
+        if push_url:
+            # PATCH: de-canonify `push_url`, because git-annex expects the path
+            # anchor in the netloc position.
+            special_remote_options.append(f'push-url={de_canonify_url(push_url)}')
+        try:
+            ds.repo.init_remote(
+                srname,
+                options=special_remote_options)
+        except CommandError as e:
+            if existing == 'reconfigure' \
+                    and 'There is already a special remote' \
+                    in e.stderr:
+                # run enableremote instead
+                lgr.debug(
+                    "special remote '%s' already exists. "
+                    "Run enableremote instead.",
+                    srname)
+                # TODO: Use AnnexRepo.enable_remote (which needs to get
+                #       `options` first)
+                ds.repo.call_annex([
+                    'enableremote',
+                    srname] + special_remote_options)
+            else:
+                yield get_status_dict(
+                    status='error',
+                    message="initremote failed.\nstdout: %s\nstderr: %s"
+                    % (e.stdout, e.stderr),
+                    **res_kwargs
+                )
+                return
+
+        if trust_level:
+            trust_cmd = [trust_level]
+            if trust_level == 'trust':
+                # Following git-annex 8.20201129-73-g6a0030a11, using `git
+                # annex trust` requires --force.
+                trust_cmd.append('--force')
+            ds.repo.call_annex(trust_cmd + [srname])
+        # get uuid for use in bare repo's config
+        uuid = ds.config.get("remote.{}.annex-uuid".format(srname))
+
+    if storage_sibling == 'only':
+        # we can stop here, the rest of the function is about setting up
+        # the git remote part of the sibling
+        yield get_status_dict(
+            status='ok',
+            **res_kwargs,
+        )
+        return
+
+    # 2. create a bare repository in-store:
+
+    lgr.debug("init bare repository")
+    # TODO: we should prob. check whether it's there already. How?
+    # Note: like the special remote itself, we assume local FS if no
+    # SSH host is specified
+    disabled_hook = repo_path / 'hooks' / 'post-update.sample'
+    enabled_hook = repo_path / 'hooks' / 'post-update'
+
+    if group:
+        chgrp_cmd = "chgrp -R {} {}".format(
+            quote_cmdlinearg(str(group)),
+            quote_cmdlinearg(str(repo_path)))
+
+    if ssh_host:
+        ssh('cd {rootdir} && git init --bare{shared}'.format(
+            rootdir=quote_cmdlinearg(str(repo_path)),
+            shared=" --shared='{}'".format(
+                quote_cmdlinearg(shared)) if shared else ''
+        ))
+
+        if storage_sibling:
+            # write special remote's uuid into git-config, so clone can
+            # which one it is supposed to be and enable it even with
+            # fallback URL
+            ssh("cd {rootdir} && git config datalad.ora-remote.uuid {uuid}"
+                "".format(rootdir=quote_cmdlinearg(str(repo_path)),
+                          uuid=uuid))
+
+        if post_update_hook:
+            ssh('mv {} {}'.format(quote_cmdlinearg(str(disabled_hook)),
+                                  quote_cmdlinearg(str(enabled_hook))))
+
+        if group:
+            # Either repository existed before or a new directory was
+            # created for it, set its group to a desired one if was
+            # provided with the same chgrp
+            ssh(chgrp_cmd)
+
+        # finally update server
+        if post_update_hook:
+            # Conditional on post_update_hook, since one w/o the other doesn't
+            # seem to make much sense.
+            ssh('cd {rootdir} && git update-server-info'.format(
+                rootdir=quote_cmdlinearg(str(repo_path))
+            ))
+    else:
+        gr = GitRepo(
+            # PATCH: convert `repo_path` to a concrete path before stringifying
+            # it and giving it to `GitRepo`.
+            str(LocalIO().url2transport_path(repo_path)),
+            create=True,
+            bare=True,
+            shared=shared if shared else None
+        )
+        if exists and existing == 'reconfigure':
+            # if the repo exists at the given path, the GitRepo would not
+            # (re)-run git init, and just return an instance of GitRepo;
+            # skip & error have been handled at this point
+            gr.init(
+                sanity_checks=False,
+                init_options=["--bare"] + ([f"--shared={shared}"] if shared else []),
+            )
+        if storage_sibling:
+            # write special remote's uuid into git-config, so clone can
+            # which one it is supposed to be and enable it even with
+            # fallback URL
+            gr.config.add("datalad.ora-remote.uuid", uuid, scope='local')
+
+        if post_update_hook:
+            # PATCH: convert `disabled_hook` to a concrete path before renaming
+            LocalIO().url2transport_path(disabled_hook).rename(enabled_hook)
+        if group:
+            if on_windows:
+                # PATCH: skip group-handling on Windows because there is no
+                # `chgrp`.
+                lgr.warning(
+                    "Group '%s' was provided, but chgrp is not available on "
+                    "Windows. Skipping.", group
+                )
+            else:
+                # No CWD needed here, since `chgrp` is expected to be found via PATH
+                # and the path it's operating on is absolute (repo_path). No
+                # repository operation involved.
+                Runner().run(chgrp_cmd)
+        # finally update server
+        if post_update_hook:
+            # Conditional on post_update_hook, since one w/o the other doesn't
+            # seem to make much sense.
+            gr.call_git(["update-server-info"])
+
+    # add a git remote to the bare repository
+    # Note: needs annex-ignore! Otherwise we might push into dirhash
+    # lower annex/object tree instead of mixed, since it's a bare
+    # repo. This in turn would be an issue, if we want to pack the
+    # entire thing into an archive. Special remote will then not be
+    # able to access content in the "wrong" place within the archive
+    lgr.debug("set up git remote")
+    if name in ds_siblings:
+        # otherwise we should have skipped or failed before
+        assert existing == 'reconfigure'
+    ds.config.set(
+        "remote.{}.annex-ignore".format(name),
+        value="true",
+        scope="local")
+    yield from ds.siblings(
+        'configure',
+        name=name,
+        # PATCH: convert `repo_path` as a concrete path before stringifying it
+        url=str(LocalIO().url2transport_path(repo_path))
+        if url.startswith("ria+file")
+        else git_url,
+        pushurl=git_push_url,
+        recursive=False,
+        # Note, that this should be None if storage_sibling was not set
+        publish_depends=storage_name,
+        result_renderer='disabled',
+        return_type='generator',
+        # Note, that otherwise a subsequent publish will report
+        # "notneeded".
+        fetch=True
+    )
+
+    yield get_status_dict(
+        status='ok',
+        **res_kwargs,
+    )
+
+
+# Replace the complete `CreateSiblingRia`-class
+apply_patch(
+    'datalad.distributed.create_sibling_ria',
+    None,
+    'CreateSiblingRia',
+    CreateSiblingRia,
+)
+
+
+class UnknownLayoutVersion(Exception):
+    pass
+
+known_versions_objt = ['1', '2']
+# Dataset tree versions we introduced so far. This is about the layout of
+# datasets in a RIA store
+known_versions_dst = ['1']
+
+
+def _ensure_version(io, base_url, version):
+    """Check a store or dataset version and make sure it is declared
+
+    Parameters
+    ----------
+    io: SSHRemoteIO or LocalIO
+    base_url: PurePosixPath
+      root path of a store or dataset
+    version: str
+      target layout version of the store (dataset tree)
+    """
+    version_file = base_url / 'ria-layout-version'
+    if io.exists(io.url2transport_path(version_file)):
+        existing_version = io.read_file(
+            io.url2transport_path(version_file)
+        ).split('|')[0].strip()
+        if existing_version != version.split('|')[0]:
+            # We have an already existing location with a conflicting version on
+            # record.
+            # Note, that a config flag after pipe symbol is fine.
+            raise ValueError("Conflicting version found at target: {}"
+                             .format(existing_version))
+        else:
+            # already exists, recorded version fits - nothing to do
+            return
+    # Note, that the following does create the base-path dir as well, since
+    # mkdir has parents=True:
+    io.mkdir(io.url2transport_path(base_url))
+    io.write_file(io.url2transport_path(version_file), version)
+
+
+def create_store(io, base_url, version):
+    """Helper to create a RIA store
+
+    Note, that this is meant as an internal helper and part of intermediate
+    RF'ing. Ultimately should lead to dedicated command or option for
+    create-sibling-ria.
+
+    Parameters
+    ----------
+    io: SSHRemoteIO or LocalIO
+      Respective execution instance.
+      Note: To be replaced by proper command abstraction
+    base_url: PurePosixPath
+      root url path of the store
+    version: str
+      layout version of the store (dataset tree)
+    """
+    assert isinstance(base_url, PurePosixPath)
+
+    # At store level the only version we know as of now is 1.
+    if version not in known_versions_dst:
+        raise UnknownLayoutVersion("RIA store layout version unknown: {}."
+                                   "Supported versions: {}"
+                                   .format(version, known_versions_dst))
+    _ensure_version(io, base_url, version)
+    error_logs = base_url / 'error_logs'
+    io.mkdir(io.url2transport_path(error_logs))

--- a/datalad_next/patches/replace_ora_remote.py
+++ b/datalad_next/patches/replace_ora_remote.py
@@ -1,0 +1,958 @@
+""" Patch ``datalad.distributed.ora_remote.ORARemote``
+
+This patch replaces the class :class:`datalad.distributed.ora_remote.ORARemote`
+with an updated version that should work properly on Linux, OSX, and Windows.
+
+The main difference to the original code is that all path-operations are
+performed on URL-paths. Those are represented by instances of `PurePosixPath`.
+All subclasses of :class:`BaseIO`, i.e. :class:`LocalIO`, :class:`SSHRemoteIO`,
+and :class:`HTTPRemoteIO`, are extended to contain the method
+:meth:`url2transport_path`. This method converts an URL-path into the correct
+path for the transport, i.e. the IO abstraction.
+
+Before methods on a subclass of :class:`BaseIO` that require a path are called,
+the generic URL-path is converted into the correct path for the IO-class by
+calling :meth:`url2transport_path` on the respective IO-class.
+
+The patch keeps changes to the necessary minimum. That means the source
+is mostly identical to the original. Besides the changes described above,
+more debug output was added.
+
+NOTE: this patch only provides :class:`ORARemote`. The patches that add a
+:meth:`url2transport_path`-method to :class:`LocalIO` and to :class:`HTTPRemoteIO`
+are contained in module ``datalad_next.patches.add_method_url2localpath``. The
+reason to keep them separate is that the patch from module
+``datalad_next.patches.replace_create_sibling_ria`` require them as well.
+For :class:`SSHRemoteIO` the method is included in the patch definition of
+:class:`SSHRemoteIO`, which is contained in the module
+``datalad_next.patches.replace_sshremoteio``.
+"""
+from __future__ import annotations
+
+import re
+import urllib.parse
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+from shlex import quote as sh_quote
+import logging
+
+from datalad.config import anything2bool
+from datalad.customremotes import (
+    ProtocolError,
+    SpecialRemote,
+)
+from datalad.distributed.ora_remote import (
+    HTTPRemoteIO,
+    LocalIO,
+    RIARemoteError,
+    SSHRemoteIO,
+    _get_datalad_id,
+    _get_gitcfg,
+    handle_errors,
+    NoLayoutVersion,
+)
+from datalad.support.annex_utils import _sanitize_key
+from datalad.support.annexrepo import AnnexRepo
+from datalad.customremotes.ria_utils import (
+    get_layout_locations,
+    UnknownLayoutVersion,
+    verify_ria_url,
+)
+from datalad.utils import on_windows
+
+from . import apply_patch
+
+
+lgr = logging.getLogger('datalad.customremotes.ria_remote')
+
+drive_letter_matcher = re.compile('^[A-Z]:')
+slash_drive_letter_matcher = re.compile('^/[A-Z]:')
+
+DEFAULT_BUFFER_SIZE = 65536
+
+
+def canonify_url(url: str | None):
+    """For file URLs on windows: put the drive letter into the path component"""
+    if not on_windows or url is None:
+        return url
+    url_parts = urllib.parse.urlparse(url)
+    if url_parts.scheme not in ('ria+file', 'file'):
+        return url
+
+    match = drive_letter_matcher.match(url_parts.netloc)
+    if not match:
+        return url
+
+    return f'{url_parts.scheme}:///{match.string}{url_parts.path}'
+
+
+def de_canonify_url(url: str | None):
+    """For file URLs on windows: put the drive letter into the netloc component"""
+    if not on_windows or url is None:
+        return url
+    url_parts = urllib.parse.urlparse(url)
+    if url_parts.scheme not in ('ria+file', 'file'):
+        return url
+
+    match = slash_drive_letter_matcher.match(url_parts.path)
+    if not match:
+        return url
+
+    return f'{url_parts.scheme}://{url_parts.path[1:3]}{url_parts.path[3:]}'
+
+
+# `ORARemote` taken from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732:
+class ORARemote(SpecialRemote):
+    """This is the class of RIA remotes.
+    """
+
+    dataset_tree_version = '1'
+    object_tree_version = '2'
+    # TODO: Move known versions. Needed by creation routines as well.
+    known_versions_objt = ['1', '2']
+    known_versions_dst = ['1']
+
+    @handle_errors
+    def __init__(self, annex):
+        super(ORARemote, self).__init__(annex)
+        if hasattr(self, 'configs'):
+            # introduced in annexremote 1.4.2 to support LISTCONFIGS
+            self.configs['url'] = "RIA store to use"
+            self.configs['push-url'] = "URL for pushing to the RIA store. " \
+                                       "Optional."
+            self.configs['archive-id'] = "Dataset ID (fallback: annex uuid. " \
+                                         "Should be set automatically by " \
+                                         "datalad"
+        # the local repo
+        self._repo = None
+        self.gitdir = None
+        self.name = None  # name of the special remote
+        self.gitcfg_name = None  # name in respective git remote
+
+        self.ria_store_url = None
+        self.ria_store_pushurl = None
+        # machine to SSH-log-in to access/store the data
+        # subclass must set this
+        self.storage_host = None
+        self.storage_host_push = None
+        # must be absolute, and POSIX (will be instance of PurePosixPath)
+        # subclass must set this
+        self.store_base_path = None
+        self.store_base_path_push = None
+        # by default we can read and write
+        self.read_only = False
+        self.force_write = None
+        self.ignore_remote_config = None
+        self.remote_log_enabled = None
+        self.remote_dataset_tree_version = None
+        self.remote_object_tree_version = None
+
+        # for caching the remote's layout locations:
+        self.remote_git_dir = None
+        self.remote_archive_dir = None
+        self.remote_obj_dir = None
+        # lazy IO:
+        self._io = None
+        self._push_io = None
+
+        # cache obj_locations:
+        self._last_archive_path = None
+        self._last_keypath = (None, None)
+
+        # SSH "streaming" buffer
+        self.buffer_size = DEFAULT_BUFFER_SIZE
+
+    # PATCH: add a helper to assert the type of a path.
+    @staticmethod
+    def _assert_pure_posix_path(path):
+        assert path.__class__ is PurePosixPath
+
+    # PATCH: add a close function to ensure that all IO-abstraction objects are
+    # closed.
+    def close(self):
+        if self._io:
+            self._io.close()
+            self._io = None
+        if self._push_io:
+            self._push_io.close()
+            self._push_io = None
+
+    def verify_store(self):
+        """Check whether the store exists and reports a layout version we
+        know
+
+        The layout of the store is recorded in base_path/ria-layout-version.
+        If the version found on the remote end isn't supported and `force-write`
+        isn't configured, sets the remote to read-only operation.
+        """
+        # THE PATCH: assert path type and perform operation on abstract path
+        self._assert_pure_posix_path(self.store_base_path)
+        dataset_tree_version_file = self.store_base_path / 'ria-layout-version'
+
+        # check dataset tree version
+        try:
+            self.remote_dataset_tree_version = \
+                self._get_version_config(dataset_tree_version_file)
+        except Exception as exc:
+            raise RIARemoteError("RIA store unavailable.") from exc
+        if self.remote_dataset_tree_version not in self.known_versions_dst:
+            # Note: In later versions, condition might change in order to
+            # deal with older versions.
+            raise UnknownLayoutVersion(f"RIA store layout version unknown: "
+                                       f"{self.remote_dataset_tree_version}")
+
+    def verify_ds_in_store(self):
+        """Check whether the dataset exists in store and reports a layout
+        version we know
+
+        The layout is recorded in
+        'dataset_somewhere_beneath_base_path/ria-layout-version.'
+        If the version found on the remote end isn't supported and `force-write`
+        isn't configured, sets the remote to read-only operation.
+        """
+
+        object_tree_version_file = self.remote_git_dir / 'ria-layout-version'
+
+        # check (annex) object tree version
+        try:
+            self.remote_object_tree_version =\
+                self._get_version_config(object_tree_version_file)
+        except Exception as e:
+            raise RIARemoteError("Dataset unavailable from RIA store.")
+        if self.remote_object_tree_version not in self.known_versions_objt:
+            raise UnknownLayoutVersion(f"RIA dataset layout version unknown: "
+                                       f"{self.remote_object_tree_version}")
+
+    def _load_local_cfg(self):
+
+        # this will work, even when this is not a bare repo
+        # but it is not capable of reading out dataset/branch config
+        self._repo = AnnexRepo(self.gitdir)
+
+        cfg_map = {"ora-force-write": "force_write",
+                   "ora-ignore-ria-config": "ignore_remote_config",
+                   "ora-buffer-size": "buffer_size",
+                   "ora-url": "ria_store_url",
+                   "ora-push-url": "ria_store_pushurl"
+                   }
+
+        # in initremote we may not have a reliable name of the git remote config
+        # yet. Go with the default.
+        gitcfg_name = self.gitcfg_name or self.name
+        if gitcfg_name:
+            for cfg, att in cfg_map.items():
+                value = self._repo.config.get(f"remote.{gitcfg_name}.{cfg}")
+                if value is not None:
+                    self.__setattr__(cfg_map[cfg], value)
+                    if cfg == "ora-url":
+                        self.ria_store_url_source = 'local'
+                    elif cfg == "ora-push-url":
+                        self.ria_store_pushurl_source = 'local'
+            if self.buffer_size:
+                try:
+                    self.buffer_size = int(self.buffer_size)
+                except ValueError:
+                    self.message(f"Invalid value of config "
+                                 f"'remote.{gitcfg_name}."
+                                 f"ora-buffer-size': {self.buffer_size}")
+                    self.buffer_size = DEFAULT_BUFFER_SIZE
+
+        if self.name:
+            # Consider deprecated configs if there's no value yet
+            if self.force_write is None:
+                self.force_write = self._repo.config.get(
+                    f'annex.ora-remote.{self.name}.force-write')
+                if self.force_write:
+                    self.message("WARNING: config "
+                                 "'annex.ora-remote.{}.force-write' is "
+                                 "deprecated. Use 'remote.{}.ora-force-write' "
+                                 "instead.".format(self.name, self.gitcfg_name))
+                    try:
+                        self.force_write = anything2bool(self.force_write)
+                    except TypeError:
+                        raise RIARemoteError("Invalid value of config "
+                                             "'annex.ora-remote.{}.force-write'"
+                                             ": {}".format(self.name,
+                                                           self.force_write))
+
+            if self.ignore_remote_config is None:
+                self.ignore_remote_config = self._repo.config.get(
+                    f"annex.ora-remote.{self.name}.ignore-remote-config")
+                if self.ignore_remote_config:
+                    self.message("WARNING: config "
+                                 "'annex.ora-remote.{}.ignore-remote-config' is"
+                                 " deprecated. Use "
+                                 "'remote.{}.ora-ignore-ria-config' instead."
+                                 "".format(self.name, self.gitcfg_name))
+                    try:
+                        self.ignore_remote_config = \
+                            anything2bool(self.ignore_remote_config)
+                    except TypeError:
+                        raise RIARemoteError(
+                            "Invalid value of config "
+                            "'annex.ora-remote.{}.ignore-remote-config': {}"
+                            "".format(self.name, self.ignore_remote_config))
+
+    def _load_committed_cfg(self, fail_noid=True):
+
+        # which repo are we talking about
+        self.gitdir = self.annex.getgitdir()
+
+        # go look for an ID
+        self.archive_id = self.annex.getconfig('archive-id')
+        if fail_noid and not self.archive_id:
+            # TODO: Message! "archive ID" is confusing. dl-id or annex-uuid
+            raise RIARemoteError(
+                "No archive ID configured. This should not happen.")
+
+        # what is our uuid?
+        self.uuid = self.annex.getuuid()
+
+        # RIA store URL(s)
+        self.ria_store_url = self.annex.getconfig('url')
+        if self.ria_store_url:
+            self.ria_store_url_source = 'annex'
+        self.ria_store_pushurl = self.annex.getconfig('push-url')
+        if self.ria_store_pushurl:
+            self.ria_store_pushurl_source = 'annex'
+
+        # TODO: This should prob. not be done! Would only have an effect if
+        #       force-write was committed annex-special-remote-config and this
+        #       is likely a bad idea.
+        self.force_write = self.annex.getconfig('force-write')
+        if self.force_write == "":
+            self.force_write = None
+
+        # Get the special remote name
+        # TODO: Make 'name' a property of `SpecialRemote`;
+        #       Same for `gitcfg_name`, `_repo`?
+        self.name = self.annex.getconfig('name')
+        if not self.name:
+            self.name = self.annex.getconfig('sameas-name')
+        if not self.name:
+            # TODO: Do we need to crash? Not necessarily, I think. We could
+            #       still find configs and if not - might work out.
+            raise RIARemoteError(
+                "Cannot determine special remote name, got: {}".format(
+                    repr(self.name)))
+        # Get the name of the remote entry in .git/config.
+        # Note, that this by default is the same as the stored name of the
+        # special remote, but can be different (for example after
+        # git-remote-rename). The actual connection is the uuid of the special
+        # remote, not the name.
+        try:
+            self.gitcfg_name = self.annex.getgitremotename()
+        except (ProtocolError, AttributeError):
+            # GETGITREMOTENAME not supported by annex version or by annexremote
+            # version.
+            # Lets try to find ourselves: Find remote with matching annex uuid
+            response = _get_gitcfg(self.gitdir,
+                                   r"^remote\..*\.annex-uuid",
+                                   regex=True)
+            response = response.splitlines() if response else []
+            candidates = set()
+            for line in response:
+                k, v = line.split()
+                if v == self.annex.getuuid():  # TODO: Where else? self.uuid?
+                    candidates.add(''.join(k.split('.')[1:-1]))
+            num_candidates = len(candidates)
+            if num_candidates == 1:
+                self.gitcfg_name = candidates.pop()
+            elif num_candidates > 1:
+                self.message("Found multiple used remote names in git "
+                             "config: %s" % str(candidates))
+                # try same name:
+                if self.name in candidates:
+                    self.gitcfg_name = self.name
+                    self.message("Choose '%s'" % self.name)
+                else:
+                    self.gitcfg_name = None
+                    self.message("Ignore git config")
+            else:
+                # No entry found.
+                # Possible if we are in "initremote".
+                self.gitcfg_name = None
+
+    def _load_cfg(self, gitdir, name):
+        # Whether or not to force writing to the remote. Currently used to
+        # overrule write protection due to layout version mismatch.
+        self.force_write = self._repo.config.get(
+            f'annex.ora-remote.{name}.force-write')
+
+        # whether to ignore config flags set at the remote end
+        self.ignore_remote_config = \
+            self._repo.config.get(
+                f'annex.ora-remote.{name}.ignore-remote-config')
+
+        # buffer size for reading files over HTTP and SSH
+        self.buffer_size = self._repo.config.get(
+            f"remote.{name}.ora-buffer-size")
+
+        if self.buffer_size:
+            self.buffer_size = int(self.buffer_size)
+
+    def _verify_config(self, fail_noid=True):
+        # try loading all needed info from (git) config
+
+        # first load committed config
+        self._load_committed_cfg(fail_noid=fail_noid)
+        # now local configs (possible overwrite of committed)
+        self._load_local_cfg()
+        # PATCH: use canonified URLs
+        self.ria_store_url = canonify_url(self.ria_store_url)
+        self.ria_store_pushurl = canonify_url(self.ria_store_pushurl)
+
+        # get URL rewriting config
+        url_cfgs = {k: v for k, v in self._repo.config.items()
+                    if k.startswith('url.')}
+
+        if self.ria_store_url:
+            self.storage_host, self.store_base_path, self.ria_store_url = \
+                verify_ria_url(self.ria_store_url, url_cfgs)
+
+        else:
+            # There's one exception to the precedence of local configs:
+            # Age-old "ssh-host" + "base-path" configs are only considered,
+            # if there was no RIA URL (local or committed). However, issue
+            # deprecation warning, if that situation is encountered:
+            host = None
+            path = None
+
+            if self.name:
+                host = self._repo.config.get(
+                    f'annex.ora-remote.{self.name}.ssh-host') or \
+                       self.annex.getconfig('ssh-host')
+                # Note: Special value '0' is replaced by None only after checking
+                # the repository's annex config. This is to uniformly handle '0' and
+                # None later on, but let a user's config '0' overrule what's
+                # stored by git-annex.
+                self.storage_host = None if host == '0' else host
+                path = self._repo.config.get(
+                    f'annex.ora-remote.{self.name}.base-path') or \
+                       self.annex.getconfig('base-path')
+                self.store_base_path = path.strip() if path else path
+
+            if path or host:
+                self.message("WARNING: base-path + ssh-host configs are "
+                             "deprecated and won't be considered in the future."
+                             " Use 'git annex enableremote {} "
+                             "url=<RIA-URL-TO-STORE>' to store a ria+<scheme>:"
+                             "//... URL in the special remote's config."
+                             "".format(self.name),
+                             type='info')
+
+
+        if not self.store_base_path:
+            raise RIARemoteError(
+                "No base path configured for RIA store. Specify a proper "
+                "ria+<scheme>://... URL.")
+
+        # the base path is ultimately derived from a URL, always treat as POSIX
+        self.store_base_path = PurePosixPath(self.store_base_path)
+        if not self.store_base_path.is_absolute():
+            raise RIARemoteError(
+                'Non-absolute RIA store base path configuration: %s'
+                '' % str(self.store_base_path))
+
+        if self.ria_store_pushurl:
+            if self.ria_store_pushurl.startswith("ria+http"):
+                raise RIARemoteError("Invalid push-url: {}. Pushing over HTTP "
+                                     "not implemented."
+                                     "".format(self.ria_store_pushurl))
+            self.storage_host_push, \
+            self.store_base_path_push, \
+            self.ria_store_pushurl = \
+                verify_ria_url(self.ria_store_pushurl, url_cfgs)
+            self.store_base_path_push = PurePosixPath(self.store_base_path_push)
+
+    def _get_version_config(self, path):
+        """ Get version and config flags from RIA store's layout file
+        """
+
+        if self.ria_store_url:
+            # construct path to ria_layout_version file for reporting
+            # PATCH: use abstract path
+            local_store_base_path = self.store_base_path
+            target_ri = (
+                self.ria_store_url[4:]
+                + "/"
+                + path.relative_to(local_store_base_path).as_posix()
+            )
+        elif self.storage_host:
+            target_ri = "ssh://{}{}".format(self.storage_host, path.as_posix())
+        else:
+            target_ri = path.as_uri()
+
+        try:
+            # PATCH: convert abstract path to io-specific concrete path
+            file_content = self.io.read_file(
+                self.io.url2transport_path(path)
+            ).strip().split('|')
+
+        # Note, that we enhance the reporting here, as the IO classes don't
+        # uniformly operate on that kind of RI (which is more informative
+        # as it includes the store base address including the access
+        # method).
+        except FileNotFoundError as exc:
+            raise NoLayoutVersion(
+                f"{target_ri} not found, "
+                f"self.ria_store_url: {self.ria_store_url}, "
+                f"self.store_base_path: {self.store_base_path}, "
+                f"self.store_base_path_push: {self.store_base_path_push}, "
+                f"path: {type(path)} {path}") from exc
+        except PermissionError as exc:
+            raise PermissionError(f"Permission denied: {target_ri}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"Failed to access {target_ri}") from exc
+
+        if not (1 <= len(file_content) <= 2):
+            self.message("invalid version file {}".format(path),
+                         type='info')
+            return None
+
+        remote_version = file_content[0]
+        remote_config_flags = file_content[1] \
+            if len(file_content) == 2 else None
+        if not self.ignore_remote_config and remote_config_flags:
+            # Note: 'or', since config flags can come from toplevel
+            #       (dataset-tree-root) as well as from dataset-level.
+            #       toplevel is supposed flag the entire tree.
+            self.remote_log_enabled = self.remote_log_enabled or \
+                                      'l' in remote_config_flags
+
+        return remote_version
+
+    def get_store(self):
+        """checks the remote end for an existing store and dataset
+
+        Furthermore reads and stores version and config flags, layout
+        locations, etc.
+        If this doesn't raise, the remote end should be fine to work with.
+        """
+        # make sure the base path is a platform path when doing local IO
+        # the incoming Path object is a PurePosixPath
+        # XXX this else branch is wrong: Incoming is PurePosixPath
+        # but it is subsequently assumed to be a platform path, by
+        # get_layout_locations() etc. Hence it must be converted
+        # to match the *remote* platform, not the local client
+
+        # cache remote layout directories
+        # PATCH: use the abstract `self.store_base_path` to calculate RIA-store
+        # directory paths.
+        self.remote_git_dir, self.remote_archive_dir, self.remote_obj_dir = \
+            self.get_layout_locations(self.store_base_path, self.archive_id)
+
+        read_only_msg = "Treating remote as read-only in order to " \
+                        "prevent damage by putting things into an unknown " \
+                        "version of the target layout. You can overrule this " \
+                        "by setting 'annex.ora-remote.<name>.force-write=true'."
+        try:
+            self.verify_store()
+        except UnknownLayoutVersion:
+            reason = "Remote dataset tree reports version {}. Supported " \
+                     "versions are: {}. Consider upgrading datalad or " \
+                     "fix the 'ria-layout-version' file at the RIA store's " \
+                     "root. ".format(self.remote_dataset_tree_version,
+                                     self.known_versions_dst)
+            self._set_read_only(reason + read_only_msg)
+        except NoLayoutVersion:
+            reason = "Remote doesn't report any dataset tree version. " \
+                     "Consider upgrading datalad or add a fitting " \
+                     "'ria-layout-version' file at the RIA store's " \
+                     "root."
+            self._set_read_only(reason + read_only_msg)
+
+        try:
+            self.verify_ds_in_store()
+        except UnknownLayoutVersion:
+            reason = "Remote object tree reports version {}. Supported" \
+                     "versions are {}. Consider upgrading datalad or " \
+                     "fix the 'ria-layout-version' file at the remote " \
+                     "dataset root. " \
+                     "".format(self.remote_object_tree_version,
+                               self.known_versions_objt)
+            self._set_read_only(reason + read_only_msg)
+        except NoLayoutVersion:
+            reason = "Remote doesn't report any object tree version. " \
+                     "Consider upgrading datalad or add a fitting " \
+                     "'ria-layout-version' file at the remote " \
+                     "dataset root. "
+            self._set_read_only(reason + read_only_msg)
+
+    @handle_errors
+    def initremote(self):
+        self._verify_config(fail_noid=False)
+        if not self.archive_id:
+            self.archive_id = _get_datalad_id(self.gitdir)
+            if not self.archive_id:
+                # fall back on the UUID for the annex remote
+                self.archive_id = self.annex.getuuid()
+
+        self.get_store()
+
+        self.annex.setconfig('archive-id', self.archive_id)
+        # Make sure, we store the potentially rewritten URL. But only, if the
+        # source was annex as opposed to a local config.
+        if self.ria_store_url and self.ria_store_url_source == 'annex':
+            self.annex.setconfig('url', self.ria_store_url)
+        if self.ria_store_pushurl and self.ria_store_pushurl_source == 'annex':
+            self.annex.setconfig('push-url', self.ria_store_pushurl)
+
+    def _local_io(self):
+        """Are we doing local operations?"""
+        # let's not make this decision dependent on the existence
+        # of a directory the matches the name of the configured
+        # store tree base dir. Such a match could be pure
+        # coincidence. Instead, let's do remote whenever there
+        # is a remote host configured
+        #return self.store_base_path.is_dir()
+
+        # TODO: Isn't that wrong with HTTP anyway?
+        #       + just isinstance(LocalIO)?
+        # XXX isinstance(LocalIO) would not work, this method is used
+        # before LocalIO is instantiated
+        return not self.storage_host
+
+    def _set_read_only(self, msg):
+
+        if not self.force_write:
+            self.read_only = True
+            self.message(msg, type='info')
+        else:
+            self.message("Was instructed to force write", type='info')
+
+    def _ensure_writeable(self):
+        if self.read_only:
+            raise RIARemoteError("Remote is treated as read-only. "
+                                 "Set 'ora-remote.<name>.force-write=true' to "
+                                 "overrule this.")
+        if isinstance(self.push_io, HTTPRemoteIO):
+            raise RIARemoteError("Write access via HTTP not implemented")
+
+    @property
+    def io(self):
+        if not self._io:
+            if self._local_io():
+                self._io = LocalIO()
+            elif self.ria_store_url.startswith("ria+http"):
+                # TODO: That construction of "http(s)://host/" should probably
+                #       be moved, so that we get that when we determine
+                #       self.storage_host. In other words: Get the parsed URL
+                #       instead and let HTTPRemoteIO + SSHRemoteIO deal with it
+                #       uniformly. Also: Don't forget about a possible port.
+
+                url_parts = self.ria_store_url[4:].split('/')
+                # we expect parts: ("http(s):", "", host:port, path)
+                self._io = HTTPRemoteIO(
+                    url_parts[0] + "//" + url_parts[2],
+                    self.buffer_size
+                )
+            elif self.storage_host:
+                self._io = SSHRemoteIO(self.storage_host, self.buffer_size)
+                from atexit import register
+                register(self._io.close)
+            else:
+                raise RIARemoteError(
+                    "Local object tree base path does not exist, and no SSH"
+                    "host configuration found.")
+        return self._io
+
+    @property
+    def push_io(self):
+        # Instance of an IOBase subclass for execution based on configured
+        # 'push-url' if such exists. Otherwise identical to `self.io`.
+        # Note, that once we discover we need to use the push-url (that is on
+        # TRANSFER_STORE and REMOVE), we should switch all operations to that IO
+        # instance instead of using different connections for read and write
+        # operations. Ultimately this is due to the design of annex' special
+        # remote protocol - we don't know which annex command is running and
+        # therefore we don't know whether to use fetch or push URL during
+        # PREPARE.
+
+        if not self._push_io:
+            if self.ria_store_pushurl:
+                self.message("switching ORA to push-url")
+                # Not-implemented-push-HTTP is ruled out already when reading
+                # push-url, so either local or SSH:
+                if not self.storage_host_push:
+                    # local operation
+                    self._push_io = LocalIO()
+                else:
+                    self._push_io = SSHRemoteIO(self.storage_host_push,
+                                                self.buffer_size)
+
+                # We have a new instance. Kill the existing one and replace.
+                from atexit import register, unregister
+                if hasattr(self.io, 'close'):
+                    unregister(self.io.close)
+                    self.io.close()
+
+                # XXX now also READ IO is done with the write IO
+                # this explicitly ignores the remote config
+                # that distinguishes READ from WRITE with different
+                # methods
+                self._io = self._push_io
+                if hasattr(self.io, 'close'):
+                    register(self.io.close)
+
+                self.storage_host = self.storage_host_push
+                self.store_base_path = self.store_base_path_push
+
+                # delete/update cached locations:
+                self._last_archive_path = None
+                self._last_keypath = (None, None)
+
+                self.remote_git_dir, \
+                self.remote_archive_dir, \
+                self.remote_obj_dir = \
+                    self.get_layout_locations(
+                        # PATCH: use abstract path to calculate RIA-store dirs
+                        self.store_base_path,
+                        self.archive_id
+                    )
+
+            else:
+                # no push-url: use existing IO
+                self._push_io = self._io
+
+        return self._push_io
+
+    @handle_errors
+    def prepare(self):
+
+        gitdir = self.annex.getgitdir()
+        self._repo = AnnexRepo(gitdir)
+        self._verify_config()
+
+        self.get_store()
+
+        # report active special remote configuration/status
+        self.info = {
+            'store_base_path': str(self.store_base_path),
+            'storage_host': 'local'
+            if self._local_io() else self.storage_host,
+        }
+
+        # TODO: following prob. needs hasattr instead:
+        if not isinstance(self.io, HTTPRemoteIO):
+            self.info['7z'] = ("not " if not self.io.get_7z() else "") + \
+                              "available"
+
+    @handle_errors
+    def transfer_store(self, key, filename):
+        self._ensure_writeable()
+
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
+
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        key_path = dsobj_dir / key_path
+
+        # PATCH: convert abstract path `key_path` to io-specific concrete path
+        # and use that.
+        transport_key_path = self.push_io.url2transport_path(key_path)
+        if self.push_io.exists(transport_key_path):
+            # if the key is here, we trust that the content is in sync
+            # with the key
+            return
+
+        self.push_io.mkdir(transport_key_path.parent)
+
+        # We need to copy to a temp location to let checkpresent fail while the
+        # transfer is still in progress and furthermore not interfere with
+        # administrative tasks in annex/objects.
+        # In addition include uuid, to not interfere with parallel uploads from
+        # different clones.
+        transfer_dir = \
+            self.remote_git_dir / "ora-remote-{}".format(self._repo.uuid) / "transfer"
+        # PATCH: convert abstract path `transfer_dir` to io-specific concrete
+        # path and use that
+        transport_transfer_dir = self.push_io.url2transport_path(transfer_dir)
+        self.push_io.mkdir(transport_transfer_dir)
+
+        tmp_path = transfer_dir / key
+        # PATCH: convert abstract path `transport_tmp_path` to io-specific
+        # concrete path and use that
+        transport_tmp_path = self.push_io.url2transport_path(tmp_path)
+        try:
+            self.push_io.put(filename, transport_tmp_path, self.annex.progress)
+            # copy done, atomic rename to actual target
+            self.push_io.rename(transport_tmp_path, transport_key_path)
+        except Exception as e:
+            # whatever went wrong, we don't want to leave the transfer location
+            # blocked
+            self.push_io.remove(transport_tmp_path)
+            raise e
+
+    @handle_errors
+    def transfer_retrieve(self, key, filename):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
+
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        abs_key_path = dsobj_dir / key_path
+        # PATCH: convert abstract path `abs_key_path` to io-specific
+        # concrete path and use that
+        transport_abs_key_path = self.io.url2transport_path(abs_key_path)
+
+        # sadly we have no idea what type of source gave checkpresent->true
+        # we can either repeat the checks, or just make two opportunistic
+        # attempts (at most)
+        try:
+            self.io.get(transport_abs_key_path, filename, self.annex.progress)
+        except Exception as e1:
+            if isinstance(self.io, HTTPRemoteIO):
+                # no client-side archive access over HTTP
+                # Note: This is intentional, as it would mean one additional
+                # request per key. However, server response to the GET can
+                # consider archives on their end.
+                raise
+            # catch anything and keep it around for a potential re-raise
+            try:
+                # PATCH: convert abstract path `archive_path` to io-specific
+                # concrete path and use that
+                transport_archive_path = self.io.url2transport_path(
+                    archive_path
+                )
+                self.io.get_from_archive(
+                    transport_archive_path,
+                    key_path,
+                    filename,
+                    self.annex.progress
+                )
+            except Exception as e2:
+                # TODO properly report the causes
+                raise RIARemoteError('Failed to obtain key: {}'
+                                     ''.format([str(e1), str(e2)]))
+
+    @handle_errors
+    def checkpresent(self, key):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
+
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        abs_key_path = dsobj_dir / key_path
+        # PATCH: convert abstract path `abs_key_path` to io-specific concrete
+        # path and use that
+        transport_abs_key_path = self.io.url2transport_path(abs_key_path)
+        if self.io.exists(transport_abs_key_path):
+            # we have an actual file for this key
+            return True
+        if isinstance(self.io, HTTPRemoteIO):
+            # no client-side archive access over HTTP
+            return False
+        # do not make a careful check whether an archive exists, because at
+        # present this requires an additional SSH call for remote operations
+        # which may be rather slow. Instead just try to run 7z on it and let
+        # it fail if no archive is around
+        # TODO honor future 'archive-mode' flag
+        # PATCH: convert abstract path `archive_path` to io-specific concrete
+        # path and use that
+        transport_archive_path = self.io.url2transport_path(archive_path)
+        return self.io.in_archive(transport_archive_path, key_path)
+
+    @handle_errors
+    def remove(self, key):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
+
+        self._ensure_writeable()
+
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        key_path = dsobj_dir / key_path
+        # PATCH: convert abstract path `key_path` to io-specific concrete path
+        # and use that
+        transport_key_path = self.push_io.url2transport_path(key_path)
+        if self.push_io.exists(transport_key_path):
+            self.push_io.remove(transport_key_path)
+        key_dir = key_path
+        # remove at most two levels of empty directories
+        for level in range(2):
+            key_dir = key_dir.parent
+            try:
+                # PATCH: convert abstract path `key_dir` to io-specific concrete
+                # path and use that
+                transport_key_dir = self.push_io.url2transport_path(key_dir)
+                self.push_io.remove_dir(transport_key_dir)
+            except Exception:
+                break
+
+    @handle_errors
+    def getcost(self):
+        # 100 is cheap, 200 is expensive (all relative to Config/Cost.hs)
+        # 100/200 are the defaults for local and remote operations in
+        # git-annex
+        # if we have the object tree locally, operations are cheap (100)
+        # otherwise expensive (200)
+        return '100' if self._local_io() else '200'
+
+    @handle_errors
+    def whereis(self, key):
+        # we need a file-system compatible name for the key
+        key = _sanitize_key(key)
+
+        dsobj_dir, archive_path, key_path = self._get_obj_location(key)
+        if isinstance(self.io, HTTPRemoteIO):
+            # display the URL for a request
+            # TODO: method of HTTPRemoteIO
+            # in case of a HTTP remote (unchecked for others), storage_host
+            # is not just a host, but a full URL without a path
+            return f'{self.storage_host}{dsobj_dir}/{key_path}'
+
+        return str(dsobj_dir / key_path) if self._local_io() \
+            else '{}: {}:{}'.format(
+                self.storage_host,
+                self.remote_git_dir,
+                sh_quote(str(key_path)),
+        )
+
+    @staticmethod
+    def get_layout_locations(base_path, dsid):
+        # PATCH: type of `base_path` is `PurePosixPath`
+        ORARemote._assert_pure_posix_path(base_path)
+        return get_layout_locations(1, base_path, dsid)
+
+    def _get_obj_location(self, key):
+        # Notes: - Changes to this method may require an update of
+        #          ORARemote._layout_version
+        #        - archive_path is always the same ATM. However, it might depend
+        #          on `key` in the future. Therefore build the actual filename
+        #          for the archive herein as opposed to `get_layout_locations`.
+
+        if not self._last_archive_path:
+            # PATCH: type of `base_path` is `PurePosixPath`
+            self._assert_pure_posix_path(self.remote_archive_dir)
+            self._last_archive_path = self.remote_archive_dir / 'archive.7z'
+
+        if self._last_keypath[0] != key:
+            if self.remote_object_tree_version == '1':
+                # PATCH: dir-hashes are always in platform format. We convert it
+                # to a platform-specific `Path` and then to `PurePosixPath`.
+                key_dir = PurePosixPath(Path(self.annex.dirhash_lower(key)))
+
+            # If we didn't recognize the remote layout version, we set to
+            # read-only and promised to at least try and read according to our
+            # current version. So, treat that case as if remote version was our
+            # (client's) version.
+            else:
+                # PATCH: dir-hashes are always in platform format. We convert it
+                # to a platform-specific `Path` and then to `PurePosixPath`.
+                key_dir = PurePosixPath(Path(self.annex.dirhash(key)))
+            # double 'key' is not a mistake, but needed to achieve the exact
+            # same layout as the annex/objects tree
+            # PATCH: use the abstract `key_dir` path
+            self._last_keypath = (key, key_dir / key / key)
+
+        self._assert_pure_posix_path(self.remote_obj_dir)
+        return self.remote_obj_dir, self._last_archive_path, \
+            self._last_keypath[1]
+
+
+apply_patch(
+    'datalad.distributed.ora_remote',
+    None,
+    'ORARemote',
+    ORARemote,
+)

--- a/datalad_next/patches/replace_sshremoteio.py
+++ b/datalad_next/patches/replace_sshremoteio.py
@@ -19,7 +19,12 @@ the call that opens a "shell", if ``self.ssh`` is an instance of
 The implementation also no longer assumes that local and remote platform are
 identical. This patch introduces an actual remote platform/system
 determination.
+
+This patch also adds the method :meth:`url2transport_path`, which is used to
+convert abstract paths, which are used in the patched RIA/ORA-code, into paths
+that SSHRemoteIO can operate on.
 """
+from __future__ import annotations
 from pathlib import (
     Path,
     PurePosixPath,
@@ -116,6 +121,13 @@ class SSHRemoteIO(IOBase):
             return
         self.servershell_context.__exit__(None, None, None)
         self.servershell_context = None
+
+    def url2transport_path(
+            self,
+            url_path: PurePosixPath
+    ) -> Path | PurePosixPath:
+        assert isinstance(url_path, PurePosixPath)
+        return url_path
 
     @property
     def remote_system(self):

--- a/datalad_next/patches/ria_utils.py
+++ b/datalad_next/patches/ria_utils.py
@@ -1,0 +1,218 @@
+"""Patch ria_utils.py tp work with abstract RIA-paths
+
+The ORARemote and CreateSiblingRia-patches use an abstract representation of
+all paths that are related to elements of a RIA-store, e.g. `ria-layout-version`
+or `ria-object-dir`. This patch adapts `ria_utils.py` to this modification.
+"""
+from __future__ import annotations
+import logging
+from pathlib import PurePosixPath
+
+from datalad.customremotes.ria_utils import (
+    UnknownLayoutVersion,
+    get_layout_locations,
+)
+
+from . import apply_patch
+
+
+lgr = logging.getLogger('datalad.customremotes.ria_utils')
+
+
+# The following two blocks of comments and definitions are verbatim copies from
+# `datalad.cutomremotes.ria_utils`
+
+# TODO: Make versions a tuple of (label, description)?
+# Object tree versions we introduced so far. This is about the layout within a
+# dataset in a RIA store
+known_versions_objt = ['1', '2']
+
+# Dataset tree versions we introduced so far. This is about the layout of
+# datasets in a RIA store
+known_versions_dst = ['1']
+
+
+# taken from `ria_utils._ensure_version` from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+def ria_utils__ensure_version(io, base_path, version):
+    """Check a store or dataset version and make sure it is declared
+
+    Parameters
+    ----------
+    io: SSHRemoteIO or LocalIO
+    base_path: PurePosixPath
+      root path of a store or dataset
+    version: str
+      target layout version of the store (dataset tree)
+    """
+    # PATCH: ensure that `base_path` is an instance of `PurePosixPath`.
+    assert base_path.__class__ is PurePosixPath
+
+    # PATCH: convert abstract `ria-layout-version`-path to concrete IO-specific
+    # path
+    version_file = io.url2transport_path(base_path / 'ria-layout-version')
+    if io.exists(version_file):
+        existing_version = io.read_file(version_file).split('|')[0].strip()
+        if existing_version != version.split('|')[0]:
+            # We have an already existing location with a conflicting version on
+            # record.
+            # Note, that a config flag after pipe symbol is fine.
+            raise ValueError("Conflicting version found at target: {}"
+                             .format(existing_version))
+        else:
+            # already exists, recorded version fits - nothing to do
+            return
+    # Note, that the following does create the base-path dir as well, since
+    # mkdir has parents=True:
+    # PATCH: convert abstract path `base_path` to concrete IO-specific path
+    # before handing it to `mkdir`.
+    io.mkdir(io.url2transport_path(base_path))
+    io.write_file(version_file, version)
+
+
+# taken from `ria_utils.create_store` from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+def ria_utils_create_store(io, base_path, version):
+    """Helper to create a RIA store
+
+    Note, that this is meant as an internal helper and part of intermediate
+    RF'ing. Ultimately should lead to dedicated command or option for
+    create-sibling-ria.
+
+    Parameters
+    ----------
+    io: SSHRemoteIO or LocalIO
+      Respective execution instance.
+      Note: To be replaced by proper command abstraction
+    base_path: PurePosixPath
+      root url path of the store
+    version: str
+      layout version of the store (dataset tree)
+    """
+    # PATCH: ensure that `base_path` is an instance of `PurePosixPath`.
+    assert isinstance(base_path, PurePosixPath)
+
+    # At store level the only version we know as of now is 1.
+    if version not in known_versions_dst:
+        raise UnknownLayoutVersion("RIA store layout version unknown: {}."
+                                   "Supported versions: {}"
+                                   .format(version, known_versions_dst))
+    _ensure_version(io, base_path, version)
+    error_logs = base_path / 'error_logs'
+    # PATCH: convert abstract path `error_logs` to concrete IO-specific path
+    # before handing it to `mkdir`.
+    io.mkdir(io.url2transport_path(error_logs))
+
+
+# taken from `ria_utils.create_ds_in_store` from datalad-core@864dc4ae24c8aac0ec4003604543b86de4735732
+def ria_utils_create_ds_in_store(io,
+                                 base_path,
+                                 dsid,
+                                 obj_version,
+                                 store_version,
+                                 alias=None,
+                                 init_obj_tree=True
+                                 ):
+    """Helper to create a dataset in a RIA store
+
+    Note, that this is meant as an internal helper and part of intermediate
+    RF'ing. Ultimately should lead to a version option for create-sibling-ria
+    in conjunction with a store creation command/option.
+
+    Parameters
+    ----------
+    io: SSHRemoteIO or LocalIO
+      Respective execution instance.
+      Note: To be replaced by proper command abstraction
+    base_path: PurePosixPath
+      root path of the store
+    dsid: str
+      dataset id
+    store_version: str
+      layout version of the store (dataset tree)
+    obj_version: str
+      layout version of the dataset itself (object tree)
+    alias: str, optional
+      alias for the dataset in the store
+    init_obj_tree: bool
+      whether or not to create the base directory for an annex objects tree (
+      'annex/objects')
+    """
+    # PATCH: ensure that `base_path` is an instance of `PurePosixPath`.
+    assert base_path.__class__ is PurePosixPath
+
+    # TODO: Note for RF'ing, that this is about setting up a valid target
+    #       for the special remote not a replacement for create-sibling-ria.
+    #       There's currently no git (bare) repo created.
+
+    try:
+        # TODO: This is currently store layout version!
+        #       Too entangled by current get_layout_locations.
+        dsgit_dir, archive_dir, dsobj_dir = \
+            get_layout_locations(int(store_version), base_path, dsid)
+    except ValueError as e:
+        raise UnknownLayoutVersion(str(e))
+
+    if obj_version not in known_versions_objt:
+        raise UnknownLayoutVersion("Dataset layout version unknown: {}. "
+                                   "Supported: {}"
+                                   .format(obj_version, known_versions_objt))
+
+    _ensure_version(io, dsgit_dir, obj_version)
+
+    # PATCH: convert abstract path `archive_dir` to concrete IO-specific path
+    # before handing it to `mkdir`.
+    io.mkdir(io.url2transport_path(archive_dir))
+    if init_obj_tree:
+        # PATCH: convert abstract path `dsobj_dir` to concrete IO-specific path
+        # before handing it to `mkdir`.
+        io.mkdir(io.url2transport_path(dsobj_dir))
+    if alias:
+        alias_dir = base_path / "alias"
+        # PATCH: convert abstract path `alias_dir` to concrete IO-specific path
+        # before handing it to `mkdir`.
+        io.mkdir(io.url2transport_path(alias_dir))
+        try:
+            # go for a relative path to keep the alias links valid
+            # when moving a store
+            io.symlink(
+                # PATCH: convert abstract relative path to concrete IO-specific
+                # path before handing it to `symlink`.
+                io.url2transport_path(
+                    PurePosixPath('..') / dsgit_dir.relative_to(base_path)
+                ),
+                # PATCH: convert abstract alias-path to concrete IO-specific path
+                # before handing it to `symlink`.
+                io.url2transport_path(alias_dir / alias)
+            )
+        except FileExistsError:
+            lgr.warning("Alias %r already exists in the RIA store, not adding an "
+                        "alias.", alias)
+
+
+_ensure_version = ria_utils__ensure_version
+
+
+# Overwrite `create_store` to handle paths properly
+apply_patch(
+    'datalad.customremotes.ria_utils',
+    None,
+    'create_store',
+    ria_utils_create_store,
+)
+
+
+# Overwrite `create_ds_in_store` to handle paths properly
+apply_patch(
+    'datalad.customremotes.ria_utils',
+    None,
+    'create_ds_in_store',
+    ria_utils_create_ds_in_store,
+)
+
+
+# Overwrite `_ensure_version` to handle paths properly
+apply_patch(
+    'datalad.customremotes.ria_utils',
+    None,
+    '_ensure_version',
+    ria_utils__ensure_version,
+)

--- a/datalad_next/patches/tests/test_add_method_url2transport_path.py
+++ b/datalad_next/patches/tests/test_add_method_url2transport_path.py
@@ -1,0 +1,46 @@
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+
+from ..add_method_url2transport_path import (
+    local_io_url2transport_path,
+    http_remote_io_url2transport_path,
+)
+
+
+def test_local_io_url2transport_path():
+
+    for url, transport_path in (
+            ('/a/b/c', '/a/b/c'),
+            ('/C:/a/b/c', '/C:/a/b/c'),
+            ('/C:a/b/c', '/C:a/b/c'),
+            ('C:/a/b/c', 'C:/a/b/c'),
+    ):
+        assert local_io_url2transport_path(
+            None,
+            PurePosixPath(url)
+        ) == Path(transport_path)
+
+
+def test_local_io_url2transport_path_windows_warning(monkeypatch):
+    monkeypatch.setattr(
+        'datalad_next.patches.add_method_url2transport_path.on_windows',
+        True,
+    )
+    warnings = []
+    monkeypatch.setattr(
+        'datalad_next.patches.add_method_url2transport_path.lgr.warning',
+        lambda x: warnings.append(x),
+    )
+    local_io_url2transport_path(None, PurePosixPath('/C:a/b/c'))
+    assert len(warnings) == 1
+
+
+def test_http_remote_io_url2transport_path():
+
+    for url in ('a/b/c', '/a/b/c', '/C:/a/b/c', '/C:a/b/c', 'C:/a/b/c'):
+        assert http_remote_io_url2transport_path(
+            None,
+            PurePosixPath(url)
+        ) == PurePosixPath(url)

--- a/datalad_next/patches/tests/test_replace_ora_remote.py
+++ b/datalad_next/patches/tests/test_replace_ora_remote.py
@@ -6,30 +6,43 @@ from ..replace_ora_remote import (
     canonify_url,
     de_canonify_url,
 )
-from datalad_next.utils import on_windows
 
 
 @pytest.mark.parametrize("scheme", ['ria+file', 'file'])
-def test_canonify(scheme):
+def test_canonify(scheme, monkeypatch):
     url_uncanonified = scheme + '://C:/a/b/c'
     url_canonified = scheme + ':///C:/a/b/c'
 
-    if on_windows:
-        assert canonify_url(url_canonified) == url_canonified
-        assert canonify_url(url_uncanonified) == url_canonified
-    else:
-        assert canonify_url(url_canonified) == url_canonified
-        assert canonify_url(url_uncanonified) == url_uncanonified
+    monkeypatch.setattr(
+        'datalad_next.patches.replace_ora_remote.on_windows',
+        True,
+    )
+    assert canonify_url(url_canonified) == url_canonified
+    assert canonify_url(url_uncanonified) == url_canonified
+
+    monkeypatch.setattr(
+        'datalad_next.patches.replace_ora_remote.on_windows',
+        False,
+    )
+    assert canonify_url(url_canonified) == url_canonified
+    assert canonify_url(url_uncanonified) == url_uncanonified
 
 
 @pytest.mark.parametrize("scheme", ['ria+file', 'file'])
-def test_de_canonify(scheme):
+def test_de_canonify(scheme, monkeypatch):
     url_uncanonified = scheme + '://C:/a/b/c'
     url_canonified = scheme + ':///C:/a/b/c'
 
-    if on_windows:
-        assert de_canonify_url(url_canonified) == url_uncanonified
-        assert de_canonify_url(url_uncanonified) == url_uncanonified
-    else:
-        assert de_canonify_url(url_canonified) == url_canonified
-        assert de_canonify_url(url_uncanonified) == url_uncanonified
+    monkeypatch.setattr(
+        'datalad_next.patches.replace_ora_remote.on_windows',
+        True,
+    )
+    assert de_canonify_url(url_canonified) == url_uncanonified
+    assert de_canonify_url(url_uncanonified) == url_uncanonified
+
+    monkeypatch.setattr(
+        'datalad_next.patches.replace_ora_remote.on_windows',
+        False,
+    )
+    assert de_canonify_url(url_canonified) == url_canonified
+    assert de_canonify_url(url_uncanonified) == url_uncanonified

--- a/datalad_next/patches/tests/test_replace_ora_remote.py
+++ b/datalad_next/patches/tests/test_replace_ora_remote.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from ..replace_ora_remote import (
+    canonify_url,
+    de_canonify_url,
+)
+from datalad_next.utils import on_windows
+
+
+@pytest.mark.parametrize("scheme", ['ria+file', 'file'])
+def test_canonify(scheme):
+    url_uncanonified = scheme + '://C:/a/b/c'
+    url_canonified = scheme + ':///C:/a/b/c'
+
+    if on_windows:
+        assert canonify_url(url_canonified) == url_canonified
+        assert canonify_url(url_uncanonified) == url_canonified
+    else:
+        assert canonify_url(url_canonified) == url_canonified
+        assert canonify_url(url_uncanonified) == url_uncanonified
+
+
+@pytest.mark.parametrize("scheme", ['ria+file', 'file'])
+def test_de_canonify(scheme):
+    url_uncanonified = scheme + '://C:/a/b/c'
+    url_canonified = scheme + ':///C:/a/b/c'
+
+    if on_windows:
+        assert de_canonify_url(url_canonified) == url_uncanonified
+        assert de_canonify_url(url_uncanonified) == url_uncanonified
+    else:
+        assert de_canonify_url(url_canonified) == url_canonified
+        assert de_canonify_url(url_uncanonified) == url_uncanonified

--- a/datalad_next/patches/tests/test_ria.py
+++ b/datalad_next/patches/tests/test_ria.py
@@ -4,7 +4,6 @@ from datalad_next.tests import skip_if_on_windows
 
 # we cannot yet run on windows. see
 # https://github.com/datalad/datalad-next/issues/654
-@skip_if_on_windows
 def test_ria_ssh_roundtrip(
         sshserver, existing_dataset, no_result_rendering,
         tmp_path):

--- a/docs/source/patches.rst
+++ b/docs/source/patches.rst
@@ -8,6 +8,7 @@ Patches that are automatically applied to DataLad when loading the
 .. autosummary::
    :toctree: generated
 
+   add_method_url2transport_path
    annexrepo
    cli_configoverrides
    commanderror
@@ -17,10 +18,18 @@ Patches that are automatically applied to DataLad when loading the
    create_sibling_gitlab
    customremotes_main
    distribution_dataset
+   fix_ria_ora_tests
    interface_utils
+   patch_ria_ora
    push_optimize
    push_to_export_remote
+   replace_create_sibling_ria
+   replace_ora_remote
+   replace_sshremoteio
+   ria_utils
    run
    siblings
+   ssh_exec
+   sshconnector
    test_keyring
    update


### PR DESCRIPTION
This PR addresses the issues with Windows-clients that use RIA-stores. It replaces the classes `datalad.distributed.ora_remote.ORARemote` and `datalad.distributed.create_sibling_ria.CreateSiblingRia` with updated versions that should work properly on Linux, OSX, and Windows.


##### What does it do?

The main difference to the original code is that all path-operations, e.g. to determine the location of `ria-layout-version`, are performed on URL-paths. Those are represented by instances of `PurePosixPath`. All subclasses of `BaseIO`, i.e. `LocalIO`, `SSHRemoteIO`, and `HTTPRemoteIO`, are extended to contain the method `url2transport_path`. This method converts an URL-path into the correct path for the respective IO abstraction.

Before methods on a subclass of `BaseIO` that require a path are called, the generic URL-path is converted into the correct path for the IO-class by calling `url2transport_path` on the respective IO-class.

A number of tests had to be adapted because the patched methods now assert the correct type for the abstract paths, i.e. `PurePosixPath`. This assertion made several tests fail because they provided OS-paths.

The PR keeps changes to the necessary minimum. That means the source is mostly identical to the original, except for the changes described above.


##### TODO

- [ ] Improve test coverage
