### PR TITLE
Update versions of GitHub actions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,6 +14,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v1

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -12,9 +12,9 @@ jobs:
       run: |
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
           architecture: x64
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install mypy
         run: python -m pip install mypy  # you can pin your preferred version
       - name: Get Python changed files

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -21,7 +21,7 @@ jobs:
         run: python -m pip install mypy  # you can pin your preferred version
       - name: Get Python changed files
         id: changed-py-files
-        uses: tj-actions/changed-files@v23
+        uses: tj-actions/changed-files@v44
         with:
           files: |
             *.py

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -79,7 +79,7 @@ jobs:
           echo "PULL_REQUEST_BODY='Tributors update automated pull request.\n\n[skip ci]'" >> $GITHUB_ENV
 
       - name: Open Pull Request
-        uses: vsoch/pull-request-action@1.0.24
+        uses: vsoch/pull-request-action@1.1.1
         if: ${{ env.OPEN_PULL_REQUEST == '1' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This updates the following GitHub actions:

- `actions/checkout` v4 → v5 and `actions/setup-python` v4 → v5, to address warnings (Node.js 16 actions are deprecated) in GitHub which show up in workflow runs
- `tj-actions/changed-files` v23 → v44, to address other warnings which show up in GitHub workflow runs
- `vsoch/pull-request-action` v1.0.24 → v1.1.1 to address workflow ending with an error
