### PR TITLE
Enable running `iter_annexworktree()` on just-Git repos

### DIFF
--- a/changelog.d/20240426_082448_michael.hanke_bf_670.md
+++ b/changelog.d/20240426_082448_michael.hanke_bf_670.md
@@ -1,0 +1,15 @@
+### 🐛 Bug Fixes
+
+- `iter_annexworktree()` can now also be used on plain Git repos,
+  and would behave exactly as if reporting on non-annexed files
+  in a git-annex repo. Previously, a cryptic `iterable did not yield
+  matching item for route-in item, cardinality mismatch?` error was
+  issued in this case.
+  Fixes https://github.com/datalad/datalad-next/issues/670 via
+  https://github.com/datalad/datalad-next/pull/673 (by @mih)
+
+### 💫 Enhancements and new features
+
+- A new `has_initialized_annex()` helper function is provided to
+  test for a locally initialized annex in a repo.
+  Via https://github.com/datalad/datalad-next/pull/673 (by @mih)

--- a/datalad_next/iter_collections/annexworktree.py
+++ b/datalad_next/iter_collections/annexworktree.py
@@ -25,10 +25,8 @@ from datalad_next.itertools import (
     route_out,
     StoreOnly,
 )
-from datalad_next.runners import (
-    call_git_success,
-    iter_git_subproc,
-)
+from datalad_next.repo_utils import has_initialized_annex
+from datalad_next.runners import iter_git_subproc
 
 from .gitworktree import (
     GitWorktreeItem,
@@ -149,11 +147,7 @@ def iter_annexworktree(
         recursive=recursive,
     )
 
-    if not call_git_success(
-        ['annex', 'info', '--fast', '-q'],
-        cwd=path,
-        capture_output=True,
-    ):
+    if not has_initialized_annex(path):
         # this is not an annex repo.
         # we just yield the items from the gitworktree iterator.
         # we funnel them through the standard result item prep

--- a/datalad_next/iter_collections/tests/test_iterannexworktree.py
+++ b/datalad_next/iter_collections/tests/test_iterannexworktree.py
@@ -7,7 +7,10 @@ from datalad import cfg as dlcfg
 from datalad_next.datasets import Dataset
 from datalad_next.utils import check_symlink_capability
 
-from ..gitworktree import GitTreeItemType
+from ..gitworktree import (
+    GitTreeItemType,
+    iter_gitworktree,
+)
 from ..annexworktree import iter_annexworktree
 
 from .test_itergitworktree import prep_fp_tester
@@ -117,3 +120,13 @@ def test_iter_annexworktree_nonrecursive(existing_dataset):
     dirs = [i for i in all_items if i.gittype == GitTreeItemType.directory]
     assert len(dirs) == 1
     dirs[0].name == PurePath('.datalad')
+
+
+def test_iter_annexworktree_noannex(existing_noannex_dataset):
+    # plain smoke test to ensure this can run on a dataset without an annex
+    all_annex_items = list(
+        iter_annexworktree(existing_noannex_dataset.pathobj))
+    all_git_items = list(iter_gitworktree(existing_noannex_dataset.pathobj))
+    assert len(all_annex_items) == len(all_git_items)
+    for a, g in zip(all_annex_items, all_git_items):
+        assert a.name == g.name

--- a/datalad_next/repo_utils/__init__.py
+++ b/datalad_next/repo_utils/__init__.py
@@ -5,8 +5,12 @@
    :toctree: generated
 
    get_worktree_head
+   has_initialized_annex
 """
 
+from .annex import (
+    has_initialized_annex,
+)
 from .worktree import (
     get_worktree_head,
 )

--- a/datalad_next/repo_utils/annex.py
+++ b/datalad_next/repo_utils/annex.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from datalad_next.runners import call_git_success
+
+
+def has_initialized_annex(
+    path: Path,
+) -> bool:
+    """Return whether there is an initialized annex for ``path``
+
+    The given ``path`` can be any directory, inside or outside a Git
+    repository. ``True`` is returned when the path is found to be
+    within a (locally) initialized git-annex repository.
+
+    When this test returns ``True`` it can be expected that no subsequent
+    call to an annex command fails with
+
+    `git-annex: First run: git-annex init`
+
+    for this ``path``.
+    """
+    return call_git_success(
+        ['annex', 'info', '--fast', '-q'],
+        cwd=path,
+        capture_output=True,
+    )

--- a/datalad_next/repo_utils/annex.py
+++ b/datalad_next/repo_utils/annex.py
@@ -19,8 +19,16 @@ def has_initialized_annex(
 
     for this ``path``.
     """
+    # this test is about 3ms in MIH's test system.
+    # datalad-core tests for a git repo and then for .git/annex, this
+    # achieves both in one step (although the test in datalad-core is
+    # likely still faster, because it only inspects the filesystem
+    # for a few key members of a Git repo. In order for that test to
+    # work, though, it has to traverse the filesystem to find a repo root
+    # -- if there even is any).
+    # also ee https://git-annex.branchable.com/forum/Cheapest_test_for_an_initialized_annex__63__/
     return call_git_success(
-        ['annex', 'info', '--fast', '-q'],
+        ['config', '--local', 'annex.uuid'],
         cwd=path,
         capture_output=True,
     )

--- a/datalad_next/repo_utils/tests/test_annex.py
+++ b/datalad_next/repo_utils/tests/test_annex.py
@@ -1,0 +1,18 @@
+from ..annex import has_initialized_annex
+
+
+def test_has_initialized_annex(existing_dataset):
+    # for the root
+    assert has_initialized_annex(existing_dataset.pathobj)
+    # for a subdir
+    assert has_initialized_annex(existing_dataset.pathobj / '.datalad')
+
+
+def test_no_initialized_annex(existing_noannex_dataset, tmp_path):
+    # for the root
+    assert not has_initialized_annex(existing_noannex_dataset.pathobj)
+    # for a subdir
+    assert not has_initialized_annex(
+        existing_noannex_dataset.pathobj / '.datalad')
+    # for a random directory
+    assert not has_initialized_annex(tmp_path)


### PR DESCRIPTION
This fixes an obscure

`iterable did not yield matching item for route-in item, cardinality mismatch?`

error when attempting such a query before.

This fix is a choice. An alternative could be to error out in this case. I went for this approach, because the test is cheap, and not much more expensive than catching the previous error in a precise manner.

With this change, the items of the underlying `gitworktree` iterator are yielded, after funneling them through the `annexworktree` iteration post-processing to ensure type-alignment and other (future) side-effect. The outcome is therefore identical to items in Git yielded from an annex-enabled repository.

Closes: https://github.com/datalad/datalad-next/issues/670

TODO:
- [x]  Check https://git-annex.branchable.com/forum/Cheapest_test_for_an_initialized_annex__63__/ if the implemented test can be cheaper