### PR TITLE
Increase FS for crippled test runs to 750MB

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -287,8 +287,8 @@ for:
       - |
         set -e
         if [ "$APPVEYOR_JOB_NAME" = "test-linux-crippled" ]; then
-          # 500 MB VFAT FS in a box
-          sudo dd if=/dev/zero of=/crippledfs.img count=500 bs=1M
+          # 750 MB VFAT FS in a box
+          sudo dd if=/dev/zero of=/crippledfs.img count=750 bs=1M
           sudo mkfs.vfat /crippledfs.img
           sudo mkdir /crippledfs
           sudo mount -o "uid=$(id -u),gid=$(id -g)" /crippledfs.img /crippledfs


### PR DESCRIPTION
Test size started to outgrow it. Eventually, we want to look at what is consuming all that space and start cleaning things up better.

Closes: https://github.com/datalad/datalad-next/issues/674