### PR TITLE
Fix no-HEAD handling in `iter_gitstatus()`

### DIFF
--- a/changelog.d/20240514_071318_michael.hanke_bf_680.md
+++ b/changelog.d/20240514_071318_michael.hanke_bf_680.md
@@ -1,0 +1,6 @@
+### 🐛 Bug Fixes
+
+- `next-status` now detects staged changes in repositories with no
+  commit.
+  Fixes https://github.com/datalad/datalad-next/issues/680 via
+  https://github.com/datalad/datalad-next/pull/681 (by @mih)

--- a/datalad_next/iter_collections/tests/test_itergitstatus.py
+++ b/datalad_next/iter_collections/tests/test_itergitstatus.py
@@ -241,3 +241,15 @@ def test_status_gitinit(tmp_path):
         assert len(res) == 1
         assert res[0].name == 'untracked'
         assert res[0].status == GitDiffStatus.other
+
+
+def test_status_nohead_staged(tmp_path):
+    # initialize a fresh git repo, but make no commits
+    assert call_git_success(['init'], cwd=tmp_path)
+    # stage a file
+    (tmp_path / 'probe').write_text('tostage')
+    assert call_git_success(['add', 'probe'], cwd=tmp_path)
+    _assert_testcases(
+        {i.name: i for i in iter_gitstatus(tmp_path)},
+        [{'name': 'probe', 'status': GitDiffStatus.addition}],
+    )

--- a/datalad_next/repo_utils/worktree.py
+++ b/datalad_next/repo_utils/worktree.py
@@ -12,6 +12,16 @@ from datalad_next.runners import (
 def get_worktree_head(
     path: Path,
 ) -> tuple[str | None, str | None]:
+    """Returns the symbolic name of the worktree `HEAD` at the given path
+
+    Returns
+    -------
+    tuple
+      The first item is the symbolic name of the worktree `HEAD`, or `None`
+      if there is no commit.
+      The second item is the symbolic name of the "corresponding branch" in
+      an adjusted-mode git-annex repository, or `None`.
+    """
     try:
         HEAD = call_git_lines(
             # we add the pathspec disambiguator to get cleaner error messages


### PR DESCRIPTION
Previously, the implementation would only report on untracked content in work trees of repositories with no HEAD commit. This led to staged changes not being reported.

The new implementation detects a no-HEAD situation and compares to the PRE_INIT_COMMIT_SHA.

A test is added.

Closes #680