### PR TITLE
`set_gitconfig_items_in_env()`: treat `None` as empty string

### DIFF
--- a/datalad_next/config/utils.py
+++ b/datalad_next/config/utils.py
@@ -73,6 +73,12 @@ def set_gitconfig_items_in_env(items: Mapping[str, str | Tuple[str, ...]]):
 
     Multi-value configuration keys are supported (values provided as a tuple).
 
+    Any item with a value of ``None`` will be posted into the ENV with an
+    empty string as value, i.e. the corresponding ``GIT_CONFIG_VALUE_{count}``
+    variable will be an empty string. ``None`` item values indicate that the
+    configuration key was unset on the command line, via the global option
+    ``-c``.
+
     No verification (e.g., of syntax compliance) is performed.
     """
     _clean_env_from_gitconfig_items()
@@ -83,7 +89,10 @@ def set_gitconfig_items_in_env(items: Mapping[str, str | Tuple[str, ...]]):
         values = value if isinstance(value, tuple) else (value,)
         for v in values:
             environ[f'GIT_CONFIG_KEY_{count}'] = key
-            environ[f'GIT_CONFIG_VALUE_{count}'] = v
+            # we support None even though not an allowed input type, because
+            # of https://github.com/datalad/datalad/issues/7589
+            # this can be removed, when that issue is resolved.
+            environ[f'GIT_CONFIG_VALUE_{count}'] = '' if v is None else str(v)
             count += 1
     if count:
         environ['GIT_CONFIG_COUNT'] = str(count)


### PR DESCRIPTION
This violates the promises made in the type annotation of this function. However, it is necessary (at least for now) in order to regain compatibility with an (anti-)feature of the DataLad CLI.

The underlying issue is documented in
https://github.com/datalad/datalad/issues/7589

TL;DR: DataLad promises to be able to unset a git config item -- but this is not supported by Git, and also DataLad can only achieve this within a single, top-level process.

With this commit `None` value (e.g. coming from the CLI) is treated as an empty string. It also ensures that all values are strings instead of, for example,
`int`.

It adds a paragraph to the doc-string of
`datalad_next.config.utils.set_gitconfig_items_in_env` to document its behavior if a configuration item
has a `None`-value.

This isssue has been present since the introduction of this function, but has only been discovered now, because test setup did not reliably load extensions, hence this datalad-next code did not always run.

Ping https://github.com/datalad/datalad-next/issues/677