### PR TITLE
Consistent shell command quoting

### DIFF
--- a/datalad_next/shell/shell.py
+++ b/datalad_next/shell/shell.py
@@ -572,7 +572,6 @@ class ShellCommandExecutor:
             self.process_inputs.put(stdin)
         return response_generator
 
-
     def __repr__(self):
         return f'{self.__class__.__name__}({self.shell_cmd!r})'
 


### PR DESCRIPTION
Fixes issue #661 

This PR automatically quotes all path parameters provided as `Path` or `PurePosixPath`-instances to `shell.posix`-functions via `shlex.quote`.

Byte-parameter like the `command`-parameter of `ShellCommandExecutor.__call__()` are never quoted. The caller has to ensure that file names are properly quoted. The are a number of reasons for this policy:

1. It is not clear which syntax is used by the shell-program, for example, it could be: `bash`, `PowerShell`, `Python`, etc.
2. Even if the shell-program was known, e.g. `bash`, there is no way to generally determine whether a path is contained in the command-argument.




