### PR TITLE
Add missing import (for non-WebDAV fallback)

### DIFF
--- a/datalad_next/tests/utils.py
+++ b/datalad_next/tests/utils.py
@@ -7,6 +7,7 @@ from functools import wraps
 import os
 from os import environ
 from pathlib import Path
+import pytest
 import subprocess
 from typing import Any
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,37 @@ addopts = "--strict-markers"
 markers = [
     # datalad-next custom markers
     "skip_if_no_network",
-    # (implicitly) used markers from datalad-core, which are not declared there
+    # (implicitly) used markers from datalad-core, which are only declared
+    # in its tox.ini (inaccessible to pytest here)
+    "fail_slow",
+    "githubci_osx",
+    "githubci_win",
     "integration",
+    "known_failure",
+    "known_failure_githubci_osx",
+    "known_failure_githubci_win",
+    "known_failure_osx",
+    "known_failure_windows",
     "network",
+    "osx",
+    "probe_known_failure",
     "serve_path_via_http",
     "skip_if_adjusted_branch",
+    "skip_if_no_network",
     "skip_if_on_windows",
     "skip_if_root",
+    "skip_known_failure",
+    "skip_nomultiplex_ssh",
     "skip_ssh",
     "skip_wo_symlink_capability",
     "slow",
+    "turtle",
+    "usecase",
+    "windows",
+    "with_config",
+    "with_fake_cookies_db",
+    "with_memory_keyring",
+    "with_sameas_remotes",
+    "with_testrepos",
+    "without_http_proxy",
 ]


### PR DESCRIPTION
Discovered by Debian maintainer.

This patch is part of Debian's 1.4.0-1