### PR TITLE
Rename test helper class to avoid confusion with test class

### DIFF
--- a/datalad_next/archive_operations/tests/test_tarfile.py
+++ b/datalad_next/archive_operations/tests/test_tarfile.py
@@ -16,7 +16,7 @@ from ..tarfile import TarArchiveOperations
 
 
 @dataclass
-class TestArchive:
+class _TestArchive:
     path: Path
     item_count: int
     content: bytes
@@ -26,8 +26,8 @@ class TestArchive:
 @pytest.fixture(scope='session')
 def structured_sample_tar_xz(
     sample_tar_xz
-) -> Generator[TestArchive, None, None]:
-    yield TestArchive(
+) -> Generator[_TestArchive, None, None]:
+    yield _TestArchive(
         path=sample_tar_xz,
         item_count=6,
         content=b'123\n',
@@ -39,7 +39,7 @@ def structured_sample_tar_xz(
 
 
 @skipif_no_network
-def test_tararchive_basics(structured_sample_tar_xz: TestArchive):
+def test_tararchive_basics(structured_sample_tar_xz: _TestArchive):
     spec = structured_sample_tar_xz
     # this is intentionally a hard-coded POSIX relpath
     member_name = 'test-archive/onetwothree.txt'
@@ -51,7 +51,7 @@ def test_tararchive_basics(structured_sample_tar_xz: TestArchive):
 
 
 @skipif_no_network
-def test_tararchive_contain(structured_sample_tar_xz: TestArchive):
+def test_tararchive_contain(structured_sample_tar_xz: _TestArchive):
     # this is intentionally a hard-coded POSIX relpath
     member_name = 'test-archive/onetwothree.txt'
     archive_ops = TarArchiveOperations(structured_sample_tar_xz.path)
@@ -63,7 +63,7 @@ def test_tararchive_contain(structured_sample_tar_xz: TestArchive):
 
 
 @skipif_no_network
-def test_tararchive_iterator(structured_sample_tar_xz: TestArchive):
+def test_tararchive_iterator(structured_sample_tar_xz: _TestArchive):
     spec = structured_sample_tar_xz
     with TarArchiveOperations(spec.path) as archive_ops:
         items = list(archive_ops)
@@ -73,7 +73,7 @@ def test_tararchive_iterator(structured_sample_tar_xz: TestArchive):
 
 
 @skipif_no_network
-def test_open(structured_sample_tar_xz: TestArchive):
+def test_open(structured_sample_tar_xz: _TestArchive):
     spec = structured_sample_tar_xz
     file_pointer = set()
     with TarArchiveOperations(spec.path) as tf:

--- a/datalad_next/archive_operations/tests/test_zipfile.py
+++ b/datalad_next/archive_operations/tests/test_zipfile.py
@@ -15,7 +15,7 @@ from ..zipfile import ZipArchiveOperations
 
 
 @dataclass
-class TestArchive:
+class _TestArchive:
     path: Path
     item_count: int
     content: bytes
@@ -23,8 +23,8 @@ class TestArchive:
 
 
 @pytest.fixture(scope='session')
-def structured_sample_zip(sample_zip) -> Generator[TestArchive, None, None]:
-    yield TestArchive(
+def structured_sample_zip(sample_zip) -> Generator[_TestArchive, None, None]:
+    yield _TestArchive(
         path=sample_zip,
         item_count=4,
         content=b'zip-123\n',
@@ -35,7 +35,7 @@ def structured_sample_zip(sample_zip) -> Generator[TestArchive, None, None]:
     )
 
 
-def test_ziparchive_basics(structured_sample_zip: TestArchive):
+def test_ziparchive_basics(structured_sample_zip: _TestArchive):
     spec = structured_sample_zip
     # this is intentionally a hard-coded POSIX relpath
     member_name = 'test-archive/onetwothree.txt'
@@ -46,7 +46,7 @@ def test_ziparchive_basics(structured_sample_zip: TestArchive):
             assert member.read() == spec.content
 
 
-def test_ziparchive_contain(structured_sample_zip: TestArchive):
+def test_ziparchive_contain(structured_sample_zip: _TestArchive):
     # this is intentionally a hard-coded POSIX relpath
     member_name = 'test-archive/onetwothree.txt'
     with ZipArchiveOperations(structured_sample_zip.path) as archive_ops:
@@ -55,7 +55,7 @@ def test_ziparchive_contain(structured_sample_zip: TestArchive):
         assert 'bogus' not in archive_ops
 
 
-def test_ziparchive_iterator(structured_sample_zip: TestArchive):
+def test_ziparchive_iterator(structured_sample_zip: _TestArchive):
     spec = structured_sample_zip
     with ZipArchiveOperations(spec.path) as archive_ops:
         items = list(archive_ops)
@@ -64,7 +64,7 @@ def test_ziparchive_iterator(structured_sample_zip: TestArchive):
             assert item.name in archive_ops
 
 
-def test_open(structured_sample_zip: TestArchive):
+def test_open(structured_sample_zip: _TestArchive):
     spec = structured_sample_zip
     file_pointer = set()
     with ZipArchiveOperations(spec.path) as zf:
@@ -78,7 +78,7 @@ def test_open(structured_sample_zip: TestArchive):
             assert fp.closed is True
 
 
-def test_open_zipinfo(structured_sample_zip: TestArchive):
+def test_open_zipinfo(structured_sample_zip: _TestArchive):
     spec = structured_sample_zip
     with ZipArchiveOperations(spec.path) as zf:
         # get zipfile-native ZipInfo items
@@ -90,7 +90,7 @@ def test_open_zipinfo(structured_sample_zip: TestArchive):
                 assert fp.read(len(spec.content)) == spec.content
 
 
-def test_ziparchive_noncontext(structured_sample_zip: TestArchive):
+def test_ziparchive_noncontext(structured_sample_zip: _TestArchive):
     spec = structured_sample_zip
     zip = ZipArchiveOperations(spec.path)
     assert zip.zipfile.filename == str(spec.path)


### PR DESCRIPTION
Discovered by Debian maintainer.

- Closes #691 

This patch is part of Debian's 1.4.0-1