### PR TITLE
Run `update-index` in target path, not PWD

### DIFF
--- a/datalad_next/iter_collections/gitdiff.py
+++ b/datalad_next/iter_collections/gitdiff.py
@@ -228,7 +228,7 @@ def iter_gitdiff(
             # we want to continue the refresh when the index need updating
             '-q',
             '--refresh',
-        ])
+        ], cwd=path)
 
     # when do we need to condense subdir reports into a single dir-report
     reported_dirs: set[str] = set()


### PR DESCRIPTION
This addresses a problem that rendered the recent lstat-related fix for `iter_gitdiff()` in 87f20e1076e70128594f68a8c520fd6311b7e19b ineffective when not running in a repository directly (PWD).
