### PR TITLE
Relax type assertion from PurePosixPath to PosixPath in RIA patches

### DIFF
--- a/datalad_next/patches/add_method_url2transport_path.py
+++ b/datalad_next/patches/add_method_url2transport_path.py
@@ -46,7 +46,7 @@ def local_io_url2transport_path(
         self,
         url_path: PurePosixPath
 ) -> Path | PurePosixPath:
-    assert url_path.__class__ is PurePosixPath
+    assert isinstance(url_path, PurePosixPath)
     if on_windows:
         return str2windows_path(url_path)
     else:
@@ -57,7 +57,7 @@ def http_remote_io_url2transport_path(
         self,
         url_path: PurePosixPath
 ) -> Path | PurePosixPath:
-    assert url_path.__class__ is PurePosixPath
+    assert isinstance(url_path, PurePosixPath)
     return url_path
 
 

--- a/datalad_next/patches/replace_ora_remote.py
+++ b/datalad_next/patches/replace_ora_remote.py
@@ -167,7 +167,7 @@ class ORARemote(SpecialRemote):
     # PATCH: add a helper to assert the type of a path.
     @staticmethod
     def _assert_pure_posix_path(path):
-        assert path.__class__ is PurePosixPath
+        assert isinstance(path, PurePosixPath)
 
     # PATCH: add a close function to ensure that all IO-abstraction objects are
     # closed.

--- a/datalad_next/patches/ria_utils.py
+++ b/datalad_next/patches/ria_utils.py
@@ -45,7 +45,7 @@ def ria_utils__ensure_version(io, base_path, version):
       target layout version of the store (dataset tree)
     """
     # PATCH: ensure that `base_path` is an instance of `PurePosixPath`.
-    assert base_path.__class__ is PurePosixPath
+    assert isinstance(base_path, PurePosixPath)
 
     # PATCH: convert abstract `ria-layout-version`-path to concrete IO-specific
     # path
@@ -137,7 +137,7 @@ def ria_utils_create_ds_in_store(io,
       'annex/objects')
     """
     # PATCH: ensure that `base_path` is an instance of `PurePosixPath`.
-    assert base_path.__class__ is PurePosixPath
+    assert isinstance(base_path, PurePosixPath)
 
     # TODO: Note for RF'ing, that this is about setting up a valid target
     #       for the special remote not a replacement for create-sibling-ria.


### PR DESCRIPTION
The patched code is new patch-code, introduced in
https://github.com/datalad/datalad-next/pull/669

The assertions were added to make sure that no platform paths are passed around. The Debian maintainer observed non-pure paths coming in. This may need an investigation, but this changeset maintains the spirit of the assertions while relaxing them enough to let the tests pass in a Debian build environment.

Ping @christian-monch WDYT?

This patch is part of Debian's 1.4.0-1