### PR TITLE
test(markers): add missing datalad-core marker "integration"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,13 @@ version_provider = "scm"
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
 markers = [
+    # datalad-next custom markers
+    "skip_if_no_network",
+    # (implicitly) used markers from datalad-core, which are not declared there
+    "integration",
     "network",
     "serve_path_via_http",
     "skip_if_adjusted_branch",
-    "skip_if_no_network",
     "skip_if_on_windows",
     "skip_if_root",
     "skip_ssh",


### PR DESCRIPTION
Tests are executed with `pytest --strict-marker` now to catch undesired situations due to mistyped markers. DataLad (core) implements many of its old test decorators as markers, but does not declare them. This change add a missing one.

Refs: https://github.com/datalad/datalad-next/pull/692