### PR TITLE
fix(dependencies): limit test patch import to test runs

### DIFF
--- a/datalad_next/patches/patch_ria_ora.py
+++ b/datalad_next/patches/patch_ria_ora.py
@@ -7,6 +7,7 @@ The patches have to goals:
 
 2. Improve ORA/RIA-related code so that it also works on Windows.
 """
+from os import environ
 
 from . import (
     add_method_url2transport_path,
@@ -15,7 +16,15 @@ from . import (
     # The following patches add Windows-support to ORA/RIA code
     ria_utils,
     replace_ora_remote,
-    fix_ria_ora_tests,
+)
+
+# we only want to import the patches for the tests when actually running
+# under pytest. this prevents inflating the runtime dependency with
+# test-only dependencies -- which would be needed for the necessary imports
+if environ.get("PYTEST_VERSION"):
+    from . import fix_ria_ora_tests
+
+from . import (
     # `replace_create_sibling_ria` be imported after `replace_sshremoteio`
     # and `ria_utils`.
     replace_create_sibling_ria,


### PR DESCRIPTION
Since 1.4.0 a plain `datalad_next` import required `pytest`. This was due to the datalad-core patch `fix_ria_ora_tests` added in #669, and was discovered by Debian's CI

Thanks to @aqw for the recommendation.

Closes: https://github.com/datalad/datalad-next/issues/698
Refs: https://github.com/datalad/datalad-next/pull/669, https://ci.debian.net/packages/d/datalad-next/testing/amd64/46884776/