### PR TITLE
docs: add note of Git >= v2.31 requirement for next-status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@
   the "monorepo" recursion mode, and single-directory reporting options
   of `iter_gitstatus()`. It is the first command to use `dataclass`
   instances as result types, rather than the traditional dictionaries.
+  Git v2.31 or later is required.
 
 - `SshUrlOperations` now supports non-standard SSH ports, non-default
   user names, and custom identity file specifications.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ package and its commands.
 - A `next-status` command that is A LOT faster than `status`, and offers
   a `mono` recursion mode that shows modifications of nested dataset
   hierarchies relative to the state of the root dataset.
+  Requires Git v2.31 (or later).
 
 ## Summary of additional features for DataLad extension development
 

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -96,6 +96,11 @@ def iter_gitstatus(
       The ``name`` and ``prev_name`` attributes of an item are a ``str`` with
       the corresponding (relative) path, as reported by Git
       (in POSIX conventions).
+
+    .. note::
+
+       The implementation requires `git rev-parse --path-format=relative`
+       that was introduced with Git v2.31.
     """
     path = Path(path)
 


### PR DESCRIPTION
It relies on `rev-parse --path-format=relative`, which has been added in 2.31.

Thanks to @FeHoff for reporting!

Closes: https://github.com/datalad/datalad-next/issues/702