### PR TITLE
Custom changelog

### DIFF
--- a/.changelog.md.j2
+++ b/.changelog.md.j2
@@ -1,0 +1,19 @@
+{% for entry in tree %}
+
+## {{ entry.version }}{% if entry.date %} ({{ entry.date }}){% endif %}
+
+{% for change_key, changes in entry.changes.items() %}
+
+{% if change_key %}
+### {{ change_key }}
+{% endif %}
+
+{% for change in changes %}
+{% if change.scope %}
+- {{ change.scope }}: {{ change.message }} [{{ change.sha1 | truncate(8, true, '') }}]
+{% elif change.message %}
+- {{ change.message }} [{{ change.sha1 | truncate(8, true, '') }}]
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.4.1 (2024-05-22)
+
+### 🐛 Bug Fixes
+
+- dependencies: limit test patch import to test runs [905b99bd]
+
+### 📝 Documentation
+
+- add note of Git >= v2.31 requirement for next-status [093575d8]
+- state conventional-commits requirement [a9180fc0]
+
+### 🛡 Tests
+
+- fixture: add missing import (for non-WebDAV fallback) [ddd66799]
+
 # 1.4.0 (2024-05-17)
 
 ## 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,36 @@
 requires = ["setuptools >= 43.0.0", "wheel"]
 
 [tool.commitizen]
-name = "cz_conventional_commits"
+name = "cz_customize"
 tag_format = "$version"
 version_scheme = "pep440"
 version_provider = "scm"
+changelog_incremental = true
+template = ".changelog.md.j2"
+gpg_sign = true
+
+[tool.commitizen.customize]
+commit_parser = "^((?P<change_type>feat|fix|rf|perf|test|docs|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?(?P<body>.*)?"
+change_type_order = ["BREAKING CHANGE", "feat", "fix", "rf", "perf", "docs", "test"]
+changelog_pattern = "^((BREAKING[\\-\\ ]CHANGE|\\w+)(\\(.+\\))?!?):"
+bump_pattern = "^((BREAKING[\\-\\ ]CHANGE|\\w+)(\\(.+\\))?!?):"
+schema_pattern = "(?s)(ci|docs|feat|fix|perf|rf|style|test|chore|revert|bump)(\\(\\S+\\))?!?:( [^\\n\\r]+)((\\n\\n.*)|(\\s*))?$"
+
+[tool.commitizen.customize.bump_map]
+"^\\w+!" = "MAJOR"
+"^BREAKING" = "MAJOR"
+"^feat" = "MINOR"
+"^fix" = "PATCH"
+
+[tool.commitizen.customize.change_type_map]
+"BREAKING CHANGE" = "Breaking changes"
+docs = "📝 Documentation"
+feat = "💫 New features"
+fix = "🐛 Bug Fixes"
+test = "🛡 Tests"
+rf = "Refactorings"
+perf = "Performance improvements"
+
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers"


### PR DESCRIPTION
Changelog generated via `cz bump --changelog`

Applied manual edits afterwards, and redid tag.