### PR TITLE
Support for Git's pathspecs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,7 +53,7 @@ build: off
 
 environment:
   # unless indicated otherwise, we test datalad_next
-  DTS: datalad_next
+  DTS: datalad_next.gitpathspec datalad_next.iter_collections
   # SSH testing is done via a side-loaded container that provides a POSIX/SSHable
   # server environment
   DATALAD_TESTS_DOCKER_SSHD_SECKEY_DOWNLOADURL: https://ci.appveyor.com/api/projects/mih/datalad-ci-docker-containers/artifacts/recipes/sshd/id_rsa?job=sshd
@@ -131,75 +131,75 @@ environment:
       DATALAD_TESTS_SERVER_SSH_PATH: /Users/appveyor/DLTMP/riaroot
       DATALAD_TESTS_SERVER_LOCALPATH: /Users/appveyor/DLTMP/riaroot
 
-    # run a subset of the core tests on the oldest supported Python version
-    - job_name: datalad-core-1
-      DTS: >
-        datalad.cli
-        datalad.core
-      # do not run tests that ensure behavior we intentionally changed
-      # - test_gh1811: is included in next in an alternative implementation
-      # - test_librarymode: assumes that CLI config overrides end up in the
-      #   session `datalad.cfg.overrides`, but -next changes that behavior
-      #   to have `.overrides` be uniformly limited to instance overrides
-      KEYWORDS: not test_gh1811 and not test_librarymode
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-2
-      DTS: >
-        datalad.customremotes
-        datalad.dataset
-        datalad.distributed
-        datalad.downloaders
-        datalad.interface
-      # do not run tests that ensure behavior we intentionally changed
-      # - test_gh1811: is included in next in an alternative implementation
-      # - test_fake_gitlab: we have an updated variant in next
-      # - test_dryrun: we have an updated variant in next; what is disabled is
-      #   the one in test_create_sibling_gitlab.py. However, there is one with
-      #   identical name in test_create_sibling_ghlike.py, now also disabled
-      #   because MIH does not know better
-      KEYWORDS: not test_gh1811 and not test_fake_gitlab and not test_dryrun
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-3
-      DTS: >
-        datalad.distribution
-      KEYWORDS: not test_invalid_args
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-4
-      DTS: >
-        datalad.local
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
-    - job_name: datalad-core-5
-      DTS: >
-        datalad.runner
-        datalad.support
-        datalad.tests
-        datalad.ui
-      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      PY: 3.8
-      INSTALL_SYSPKGS:
-      # datalad-annex git remote needs something after git-annex_8.20211x
-      INSTALL_GITANNEX: git-annex -m snapshot
-      CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    ## run a subset of the core tests on the oldest supported Python version
+    #- job_name: datalad-core-1
+    #  DTS: >
+    #    datalad.cli
+    #    datalad.core
+    #  # do not run tests that ensure behavior we intentionally changed
+    #  # - test_gh1811: is included in next in an alternative implementation
+    #  # - test_librarymode: assumes that CLI config overrides end up in the
+    #  #   session `datalad.cfg.overrides`, but -next changes that behavior
+    #  #   to have `.overrides` be uniformly limited to instance overrides
+    #  KEYWORDS: not test_gh1811 and not test_librarymode
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-2
+    #  DTS: >
+    #    datalad.customremotes
+    #    datalad.dataset
+    #    datalad.distributed
+    #    datalad.downloaders
+    #    datalad.interface
+    #  # do not run tests that ensure behavior we intentionally changed
+    #  # - test_gh1811: is included in next in an alternative implementation
+    #  # - test_fake_gitlab: we have an updated variant in next
+    #  # - test_dryrun: we have an updated variant in next; what is disabled is
+    #  #   the one in test_create_sibling_gitlab.py. However, there is one with
+    #  #   identical name in test_create_sibling_ghlike.py, now also disabled
+    #  #   because MIH does not know better
+    #  KEYWORDS: not test_gh1811 and not test_fake_gitlab and not test_dryrun
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-3
+    #  DTS: >
+    #    datalad.distribution
+    #  KEYWORDS: not test_invalid_args
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-4
+    #  DTS: >
+    #    datalad.local
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
+    #- job_name: datalad-core-5
+    #  DTS: >
+    #    datalad.runner
+    #    datalad.support
+    #    datalad.tests
+    #    datalad.ui
+    #  APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+    #  PY: 3.8
+    #  INSTALL_SYSPKGS:
+    #  # datalad-annex git remote needs something after git-annex_8.20211x
+    #  INSTALL_GITANNEX: git-annex -m snapshot
+    #  CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov
 
 
 # only run the CI if there are code or tooling changes

--- a/datalad_next/constraints/__init__.py
+++ b/datalad_next/constraints/__init__.py
@@ -74,6 +74,7 @@ structured error reporting.
     EnsureURL
     EnsureParsedURL
 
+    EnsureGitPathSpec
     EnsureGitRefName
     EnsureRemoteName
     EnsureSiblingName
@@ -129,6 +130,7 @@ from .formats import (
 from .dataset import EnsureDataset
 
 from .git import (
+    EnsureGitPathSpec,
     EnsureGitRefName,
     EnsureRemoteName,
     EnsureSiblingName,

--- a/datalad_next/constraints/compound.py
+++ b/datalad_next/constraints/compound.py
@@ -80,7 +80,7 @@ class EnsureIterableOf(Constraint):
         except (ConstraintError, TypeError) as e:
             self.raise_for(
                 value,
-                "{itertype} item is not {itype}",
+                "{itertype} item does not match {itype}\n{__itemized_causes__}",
                 itertype=self._iter_type.__name__,
                 itype=self._item_constraint,
                 __caused_by__=e,

--- a/datalad_next/constraints/git.py
+++ b/datalad_next/constraints/git.py
@@ -1,6 +1,7 @@
 """Constraints for Git-related concepts and parameters"""
 from __future__ import annotations
 
+from datalad_next.gitpathspec import GitPathSpec
 from datalad_next.runners import (
     CommandError,
     call_git,
@@ -175,3 +176,23 @@ class EnsureSiblingName(EnsureRemoteName):
     replaced with "sibling".
     """
     _label = 'sibling'
+
+
+class EnsureGitPathSpec(Constraint):
+    """Ensures a Git pathspec"""
+    def __call__(self, value: str) -> GitPathSpec:
+        if not value:
+            # simple, do here
+            self.raise_for(value, 'pathspec must not be empty')
+
+        try:
+            return GitPathSpec.from_pathspec_str(value)
+        except ValueError as e:
+            self.raise_for(
+                value,
+                'is not a valid pathspec\n{__itemized_causes__}',
+                __caused_by__=e,
+            )
+
+    def short_description(self):
+        return 'Git pathspec'

--- a/datalad_next/constraints/git.py
+++ b/datalad_next/constraints/git.py
@@ -118,7 +118,6 @@ class EnsureRemoteName(Constraint):
                 f"Existence check for {self._label} requires dataset " \
                 "specification"
 
-        if self._known:
             # we don't need to check much, only if a remote of this name
             # already exists -- no need to check for syntax compliance
             # again
@@ -143,6 +142,7 @@ class EnsureRemoteName(Constraint):
             # no further check
             return value
 
+        assert self._dsarg
         if self._known is False and any(
             k.startswith(f"remote.{value}.")
             for k in self._dsarg.ds.config.keys()

--- a/datalad_next/gitpathspec/__init__.py
+++ b/datalad_next/gitpathspec/__init__.py
@@ -11,3 +11,4 @@ that rely on Git commands that do not support submodule recursion directly.
 """
 
 from .pathspec import GitPathSpec
+from .pathspecs import GitPathSpecs

--- a/datalad_next/gitpathspec/__init__.py
+++ b/datalad_next/gitpathspec/__init__.py
@@ -1,0 +1,13 @@
+"""Data class for Git's pathspecs with subdirectory mangling support
+
+The main purpose of this functionality is to be able to take a pathspecs that
+is valid in the context of a top-level repository, and translate it such that
+the set of pathspecs given to the same command running on/in a
+submodule/subdirectory gives the same results, as if the initial top-level
+invocation reported them (if it even could).
+
+This functionality can be used to add support for pathspecs to implementation
+that rely on Git commands that do not support submodule recursion directly.
+"""
+
+from .pathspec import GitPathSpec

--- a/datalad_next/gitpathspec/pathspec.py
+++ b/datalad_next/gitpathspec/pathspec.py
@@ -1,0 +1,244 @@
+#
+# Intentionally written without importing datalad code
+#
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fnmatch
+from itertools import chain
+
+
+@dataclass(frozen=True)
+class GitPathSpec:
+    # TODO think about adding support for another magic that represents
+    # the root of a repository hierarchy (amending 'top', which is
+    # the root of the working tree -- but presumably for a single repository
+    spectypes: tuple[str, ...]
+    dirprefix: str
+    pattern: str | None
+
+    def __str__(self) -> str:
+        """Generate normalized (long-form) pathspec"""
+        if not self.spectypes and not self.dirprefix and not self.pattern:
+            return ':'
+        ps = ''
+        if self.spectypes:
+            ps += ':('
+            ps += ','.join(self.spectypes)
+            ps += ')'
+        ps += self._get_joined_pattern()
+        return ps
+
+    def _get_joined_pattern(self):
+        return f'{self.dirprefix if self.dirprefix else ""}' \
+            f'{"/" if self.dirprefix else ""}' \
+            f'{self.pattern if self.pattern else ""}'
+
+    def for_subdir(self, subdir: str) -> list[GitPathSpec]:
+        """
+        The following rules apply to particular magic pathspecs:
+
+        - 'top' are not modified. This makes them essentially
+          relative to the root of the respective repository
+
+        Parameters
+        ----------
+        subdir: str
+          Relative path in POSIX notation
+
+        split into sd_parts
+        split into pattern_parts
+
+        """
+        if not subdir:
+            return [self]
+        elif 'top' in self.spectypes:
+            # no need to mangle, these are treated as absolute to
+            # any repo they are evaluated one -- this means that
+            # they are OK to change their reference when moving
+            # into submodules
+            return [self]
+        elif 'literal' in self.spectypes:
+            testpattern = self._get_joined_pattern()
+            testsubdir = subdir if subdir.endswith('/') else f'{subdir}/'
+            # TODO icase
+            if (
+                ('icase' in self.spectypes
+                 and testpattern.casefold().startswith(testsubdir.casefold()))
+                or testpattern.startswith(testsubdir)
+            ):
+                return [GitPathSpec(
+                    self.spectypes,
+                    *GitPathSpec._split_prefix_pattern(
+                        testpattern[len(testsubdir):])
+                )]
+            else:
+                return []
+        elif str(self) == ':':
+            return []
+        elif 'glob' in self.spectypes:
+            raise NotImplementedError
+        else:
+            # "ordinary" pathspec with fnmatch
+            # we find the shortest and the longest match for the subdir
+            # and report the list of unique results.
+            # we do that, because we only have partial knowledge of a
+            # would-be matching path. Any '*' might potentially match
+            # more than just the subdir, thereby consuming more of the
+            # pathspec than we can know here.
+            #
+            # We report the shortest and longest detectable match -- not
+            # because this is a complete or correct solution, but because it
+            # adds support for relatively common usecases, e.g. `*item*.jpg`
+            # (match any .jpg file with "item" somewhere is its path.
+            # The shortest match for a translation to a "moreitem/" would cause
+            # a translated pathspec of `*item*.jpg` (already the initial '*'
+            # matches the full subdir, hence any FILEname inside that subdir
+            # would now be required to contain "item". The longest match,
+            # however, translates to `*.jpg`, which is more fitting for the
+            # underlying intentions.
+            return list(set(chain(
+                self._find_shortest_subspec_fnmatch(subdir, 'shortest'),
+                self._find_longest_subspec_fnmatch(subdir, 'longest'),
+            )))
+
+    def _find_longest_subspec_fnmatch(self, subdir: str, mode: str):
+        testpattern = self._get_joined_pattern()
+        testsubdir = subdir
+        tp = testpattern
+        if 'icase' in self.spectypes:
+            testsubdir = subdir.casefold()
+            tp = testpattern.casefold()
+        while tp:
+            if fnmatch.fnmatch(testsubdir, tp):
+                # tp is a match for subdir, subtract it from the full pattern.
+                # we do not want to strip a '*', it has the potential to
+                # match more than just the present subdir
+                final = testpattern[len(tp) - (1 if tp.endswith('*') else 0):]
+                # strip initial directory separators, make no sense when
+                # porting to a subdir
+                final = final.lstrip('/')
+                if final:
+                    yield GitPathSpec(
+                        self.spectypes,
+                        *GitPathSpec._split_prefix_pattern(final)
+                    )
+                return
+            # get the next chunk
+            idx = index_any(tp.rindex, ['/', '*'], 0, len(tp))
+            if idx is None:
+                # we scanned the whole pattern and nothing matched
+                return
+            tp = tp[:idx]
+
+    def _find_shortest_subspec_fnmatch(self, subdir: str, mode: str):
+        testpattern = self._get_joined_pattern()
+        # add a trailing directory separator to prevent undesired
+        # matches of partial directory names
+        testsubdir = subdir if subdir.endswith('/') else f'{subdir}/'
+        tp: None | str = None
+        while tp is None or (len(tp) + 1 < len(testpattern)):
+            # get the next chunk
+            idx = index_any(
+                testpattern.index,
+                ['/', '*'],
+                0 if tp is None else (len(tp) + 1),
+                len(testpattern),
+            )
+            if idx is None:
+                # we scanned the whole pattern and nothing matched, use the
+                # full pattern with a trailing / (because we added that to
+                # testsubdir)
+                tp = f'{testpattern}/'
+            else:
+                tp = testpattern[:idx + 1]
+            assert tp is not None
+            if fnmatch.fnmatch(testsubdir, tp):
+                # tp is a match for subdir, subtract it from the full pattern.
+                # we do not want to strip a '*', it has the potential to
+                # match more than just the present subdir
+                final = testpattern[len(tp) - (1 if tp.endswith('*') else 0):]
+                if final:
+                    # do not emit a non-pathspec to avoid any downstream
+                    # processing giving a non-pattern is the same as not
+                    # given one
+                    yield GitPathSpec(
+                        self.spectypes,
+                        *GitPathSpec._split_prefix_pattern(final)
+                    )
+                return
+
+    @classmethod
+    def from_pathspec_str(
+        cls,
+        pathspec: str,
+    ) -> GitPathSpec:
+        spectypes = []
+        dirprefix = None
+        pattern = None
+
+        if pathspec.startswith(':('):
+            # long-form magic
+            magic, pattern = pathspec[2:].split(')', maxsplit=1)
+            spectypes = magic.split(',')
+        elif pathspec.startswith(':'):
+            # short-form magic
+            magic_signatures = {
+                '/': 'top',
+                '!': 'exclude',
+                '^': 'exclude',
+                ':': None,
+            }
+            pattern = pathspec[1:]
+            spectypes = []
+            for i in range(1, len(pathspec)):
+                sig = magic_signatures.get(pathspec[i])
+                if sig is None:
+                    pattern = pathspec[i:]
+                    break
+                spectypes.append(sig)
+        else:
+            pattern = pathspec
+
+        # TODO raise when glob and literal magic markers are present
+        # simultaneously
+        if 'glob' in spectypes and 'literal' in spectypes:
+            raise ValueError("'glob' magic is incompatible with 'literal' magic")
+
+        # split off dirprefix
+        dirprefix, pattern = GitPathSpec._split_prefix_pattern(pattern)
+
+        return cls(
+            spectypes=tuple(spectypes),
+            dirprefix=dirprefix,
+            pattern=pattern,
+        )
+
+    @staticmethod
+    def _split_prefix_pattern(pathspec):
+        # > the pathspec up to the last slash represents a directory prefix.
+        # > The scope of that pathspec is limited to that subtree.
+        try:
+            last_slash_idx = pathspec[::-1].index('/')
+        except ValueError:
+            # everything is the pattern
+            dirprefix = None
+            pattern = pathspec
+        else:
+            dirprefix = pathspec[:-last_slash_idx - 1]
+            pattern = pathspec[-last_slash_idx:] \
+                if last_slash_idx > 0 else None
+        return dirprefix, pattern
+
+
+def index_any(fx, subs: list[str], start: int, end: int) -> int | None:
+    idx = []
+    for sub in subs:
+        try:
+            idx.append(fx(sub, start, end))
+        except ValueError:
+            pass
+    if not idx:
+        return None
+    else:
+        return min(idx)

--- a/datalad_next/gitpathspec/pathspecs.py
+++ b/datalad_next/gitpathspec/pathspecs.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from itertools import chain
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+
+from .pathspec import GitPathSpec
+
+
+class GitPathSpecs:
+    def __init__(
+        self,
+        pathspecs: list[str | GitPathSpec] | GitPathSpecs | None,
+    ):
+        self._pathspecs: list[GitPathSpec] | None = None
+        if isinstance(pathspecs, GitPathSpecs):
+            self._pathspecs = pathspecs._pathspecs
+        else:
+            self._pathspecs = _normalize_gitpathspec(pathspecs)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}([{', '.join(repr(p) for p in self.arglist())}])"
+    def __len__(self) -> int:
+        return len(self._pathspecs) if self._pathspecs is not None else 0
+
+    # TODO lru_cache decorator?
+    # this would prevent repeated conversion cost for the usage pattern of
+    # - test if we would have a match for a subdir
+    # - run code with the matching pathspecs
+    # without having to implement caching logic in client code
+    def for_subdir(
+        self,
+        path: PurePosixPath,
+    ) -> GitPathSpecs:
+        if self._pathspecs is None:
+            return self
+        return GitPathSpecs(chain.from_iterable(
+            ps.for_subdir(str(path))
+            for ps in self._pathspecs
+        ))
+
+    def arglist(self) -> list[str]:
+        if self._pathspecs is None:
+            return []
+        return list(str(ps) for ps in self._pathspecs)
+
+
+def _normalize_gitpathspec(
+    specs: list[str | GitPathSpec] | None,
+) -> list[GitPathSpec] | None:
+    """Normalize path specs to a plain list of GitPathSpec instances"""
+    if not specs:
+        return None
+    else:
+        return [
+            ps if isinstance(ps, GitPathSpec)
+            else GitPathSpec.from_pathspec_str(ps)
+            for ps in specs
+        ]

--- a/datalad_next/gitpathspec/tests/test_gitpathspec.py
+++ b/datalad_next/gitpathspec/tests/test_gitpathspec.py
@@ -1,0 +1,263 @@
+from pathlib import Path
+import pytest
+import subprocess
+
+from .. import (
+    GitPathSpec,
+)
+
+
+def _list_files(path, pathspecs):
+    return [
+        i for i in subprocess.run(
+            ['git', 'ls-files', '-z', '--other', '--', *pathspecs],
+            capture_output=True,
+            cwd=path,
+        ).stdout.decode('utf-8').split('\0')
+        if i
+    ]
+
+
+@pytest.fixture(scope="function")
+def pathspec_match_testground(tmp_path_factory):
+    """Create a Git repo with no commit and many untracked files
+
+    In this playground, `git ls-files --other` can be used to testrun
+    pathspecs.
+
+    See the top item in `testcases` for a summary of the content
+    """
+    p = tmp_path_factory.mktemp('pathspec_match')
+    probe = p / 'pr?be'
+    # check for case insensitive file systems
+    crippled_fs = Path(str(p).upper()).exists()
+    try:
+        probe.touch()
+        probe.unlink()
+    except OSError:
+        crippled_fs = True
+
+    subprocess.run(['git', 'init'], cwd=p, check=True)
+    p_sub = p / 'sub'
+    p_sub.mkdir()
+    for d in (p, p_sub):
+        p_a = d / 'aba'
+        p_b = d / 'a?a'
+        for sp in (p_a,) if crippled_fs else (p_a, p_b):
+            sp.mkdir()
+            for fname in ('a.txt', 'A.txt', 'a.JPG'):
+                (sp / fname).touch()
+    # add something that is unique to sub/
+    (p_sub / 'b.dat').touch()
+
+    testcases = [
+        # valid
+        dict(
+            ps=':',
+            fordir={
+                None: {'specs': [':'],
+                       'match': [
+                           'aba/a.JPG', 'aba/a.txt',
+                           'sub/aba/a.JPG', 'sub/aba/a.txt',
+                           'sub/b.dat'] if crippled_fs else [
+                           'a?a/A.txt', 'a?a/a.JPG', 'a?a/a.txt',
+                           'aba/A.txt', 'aba/a.JPG', 'aba/a.txt',
+                           'sub/a?a/A.txt', 'sub/a?a/a.JPG', 'sub/a?a/a.txt',
+                           'sub/aba/A.txt', 'sub/aba/a.JPG', 'sub/aba/a.txt',
+                           'sub/b.dat'],
+                },
+                'sub': {'specs': [],
+                        'match': [
+                            'aba/a.JPG', 'aba/a.txt',
+                            'b.dat'] if crippled_fs else [
+                            'a?a/A.txt', 'a?a/a.JPG', 'a?a/a.txt',
+                            'aba/A.txt', 'aba/a.JPG', 'aba/a.txt',
+                            'b.dat'],
+                },
+            },
+        ),
+        dict(
+            ps='aba',
+            fordir={
+                None: {'match': [
+                    'aba/a.JPG', 'aba/a.txt',
+                ] if crippled_fs else [
+                    'aba/A.txt', 'aba/a.JPG', 'aba/a.txt'],
+                },
+                'aba': {'specs': [],
+                        'match': [
+                            'a.JPG', 'a.txt'] if crippled_fs else [
+                            'A.txt', 'a.JPG', 'a.txt'],
+                },
+            },
+        ),
+        # same as above, but with a trailing slash
+        dict(
+            ps='aba/',
+            fordir={
+                None: {'match': [
+                    'aba/a.JPG', 'aba/a.txt',
+                ] if crippled_fs else [
+                    'aba/A.txt', 'aba/a.JPG', 'aba/a.txt'],
+                },
+                'aba': {'specs': [],
+                        'match': [
+                            'a.JPG', 'a.txt'] if crippled_fs else [
+                            'A.txt', 'a.JPG', 'a.txt'],
+                },
+            },
+        ),
+        dict(
+            ps=':(glob)aba/*.txt',
+            fordir={
+                None: {'match': [
+                    'aba/a.txt',
+                ] if crippled_fs else ['aba/A.txt', 'aba/a.txt']},
+            },
+        ),
+        dict(
+            ps=':/aba/*.txt',
+            norm=':(top)aba/*.txt',
+            fordir={
+                None: {'match': [
+                    'aba/a.txt',
+                ] if crippled_fs else ['aba/A.txt', 'aba/a.txt']},
+                # for a subdir a keeps matching the exact same items
+                # not only be name, but by location
+                'sub': {'specs': [':(top)aba/*.txt'],
+                        'match': ['../aba/a.txt'] if crippled_fs else [
+                            '../aba/A.txt', '../aba/a.txt']},
+            },
+        ),
+        dict(
+            ps='aba/*.txt',
+            fordir={
+                None: {'match': ['aba/a.txt'] if crippled_fs else [
+                    'aba/A.txt', 'aba/a.txt'],
+                },
+                # not applicable
+                'sub': {'specs': []},
+                # but this is
+                'aba': {'specs': ['*.txt']},
+            },
+        ),
+        dict(
+            ps='sub/aba/*.txt',
+            fordir={
+                None: {'match': ['sub/aba/a.txt'] if crippled_fs else [
+                    'sub/aba/A.txt', 'sub/aba/a.txt']},
+                'sub': {'specs': ['aba/*.txt'],
+                        'match': ['aba/a.txt'] if crippled_fs else [
+                            'aba/A.txt', 'aba/a.txt']},
+            },
+        ),
+        dict(
+            ps='*.JPG',
+            fordir={
+                None: {'match': [
+                    'aba/a.JPG', 'sub/aba/a.JPG'] if crippled_fs else [
+                    'a?a/a.JPG', 'aba/a.JPG', 'sub/a?a/a.JPG',
+                    'sub/aba/a.JPG']},
+                # unchanged
+                'sub': {'specs': ['*.JPG']},
+            },
+        ),
+        dict(
+            ps='*ba*.JPG',
+            fordir={
+                None: {'match': ['aba/a.JPG', 'sub/aba/a.JPG']},
+                'aba': {'specs': ['*ba*.JPG', '*.JPG'],
+                        'match': ['a.JPG']},
+            },
+        ),
+        # invalid
+        #
+        # conceptual conflict and thereby unsupported by Git
+        # makes sense and is easy to catch that
+        dict(ps=':(glob,literal)broken', raises=ValueError),
+    ]
+    if not crippled_fs:
+        testcases.extend([
+            # literal magic is only needed for non-crippled FS
+            dict(
+                ps=':(literal)a?a/a.JPG',
+                fordir={
+                    None: dict(
+                        match=['a?a/a.JPG'],
+                    ),
+                    "a?a": dict(
+                        specs=[':(literal)a.JPG'],
+                        match=['a.JPG'],
+                    ),
+                },
+            ),
+            dict(
+                ps=':(literal,icase)SuB/A?A/a.jpg',
+                fordir={
+                    None: {'match': ['sub/a?a/a.JPG']},
+                    "sub/a?a": {
+                        'specs': [':(literal,icase)a.jpg'],
+                        # given the spec transformation matches
+                        # MIH would really expect to following,
+                        # but it is not coming from Git :(
+                        #'match': ['a.JPG'],
+                        'match': [],
+                    },
+                },
+            ),
+            dict(
+                ps=':(icase)A?A/a.jpg',
+                fordir={
+                    None: {'match': ['a?a/a.JPG', 'aba/a.JPG']},
+                    "aba": {
+                        'specs': [':(icase)a.jpg'],
+                        'match': ['a.JPG'],
+                    },
+                },
+            ),
+            dict(
+                ps=':(literal,icase)A?A/a.jpg',
+                fordir={
+                    None: {'match': ['a?a/a.JPG']},
+                    "a?a": {
+                        'specs': [':(literal,icase)a.jpg'],
+                        'match': ['a.JPG'],
+                    },
+                    # the target subdir does not match the pathspec
+                    "aba": {'specs': set()},
+                },
+            ),
+        ])
+
+    yield p, testcases
+
+
+def test_pathspecs(pathspec_match_testground):
+    tg, testcases = pathspec_match_testground
+
+    for testcase in testcases:
+        if testcase.get('raises'):
+            # test case states how `GitPathSpec` will blow up
+            # on this case. Verify and skip any further testing
+            # on this case
+            with pytest.raises(testcase['raises']):
+                GitPathSpec.from_pathspec_str(testcase['ps'])
+            continue
+        # create the instance
+        ps = GitPathSpec.from_pathspec_str(testcase['ps'])
+        # if no deviating normalized representation is given
+        # it must match the original one
+        assert str(ps) == testcase.get('norm', testcase['ps'])
+        # test translations onto subdirs now
+        # `None` is a special subdir that means "self", i.e.
+        # not translation other than normalization, we can use it
+        # to test matching behavior of the full pathspec
+        for subdir, target in testcase.get('fordir', {}).items():
+            # translate -- a single input pathspec can turn into
+            # multiple translated ones. This is due to
+            subdir_specs = [str(s) for s in ps.for_subdir(subdir)]
+            if 'specs' in target:
+                assert set(subdir_specs) == set(target['specs'])
+            if 'match' in target:
+                tg_subdir = tg / subdir if subdir else tg
+                assert _list_files(tg_subdir, subdir_specs) == target['match']

--- a/datalad_next/iter_collections/gitdiff.py
+++ b/datalad_next/iter_collections/gitdiff.py
@@ -119,7 +119,6 @@ def iter_gitdiff(
     find_renames: int | None = None,
     find_copies: int | None = None,
     yield_tree_items: str | None = None,
-    # TODO add documentation
     eval_submodule_state: str = 'full',
 ) -> Generator[GitDiffItem, None, None]:
     """Report differences between Git tree-ishes or tracked worktree content
@@ -189,6 +188,23 @@ def iter_gitdiff(
       will still be reported whenever there is no recursion into them.
       For example, submodule items are reported when
       ``recursive='repository``, even when ``yield_tree_items=None``.
+    eval_submodule_state: {'no', 'commit', 'full'}
+      Mode with which submodule changes will be investigated. These modes
+      correspond to (some) of the modes offered by the ``--ignore-submodule``
+      option of ``git diff-(tree|index)``.
+      'no' does not inspect submodules (``--ignore-submodules=all``);
+      'commit' ignores all changes to the work tree of submodules
+      (``--ignore-submodules=dirty``);
+      'full' considers a submodule modified when it either contains untracked
+      or modified files or its HEAD differs from the commit recorded in the
+      superproject (``--ignore-submodules=none``).
+      The treatment of untracked files is determined by the ``untracked``
+      parameter.
+      When a git-annex repository in adjusted mode is detected,
+      the reference commit that the worktree is being compared to, with modes
+      ``commit`` and ``full``, is the basis
+      of the adjusted branch (i.e., the corresponding branch).
+
 
     Yields
     ------

--- a/datalad_next/iter_collections/gitdiff.py
+++ b/datalad_next/iter_collections/gitdiff.py
@@ -182,7 +182,7 @@ def iter_gitdiff(
       have not been modified in the same change. This is a very expensive
       operation for large projects, so use it with caution.
     yield_tree_items: {'submodules', 'directories', 'all', None}, optional
-      Whether to yield an item on type of subtree that will also be recursed
+      Whether to yield an item on a type of subtree that will also be recursed
       into. For example, a submodule item, when submodule recursion is
       enabled. When disabled, subtree items (directories, submodules)
       will still be reported whenever there is no recursion into them.

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -81,13 +81,20 @@ def iter_gitstatus(
       any submodule that is present. If ``no``, only direct children
       are reported on.
     eval_submodule_state: {"no", "commit", "full"}, optional
-      If 'full' (default), the state of a submodule is evaluated by
-      considering all modifications, with the treatment of untracked files
-      determined by `untracked`. If 'commit', the modification check is
-      restricted to comparing the submodule's "HEAD" commit to the one
-      recorded in the superdataset. If 'no', the state of the subdataset is
-      not evaluated. When a git-annex repository in adjusted mode is detected,
-      the reference commit that the worktree is being compared to is the basis
+      Mode with which submodule changes will be investigated. These modes
+      correspond to (some) of the modes offered by the ``--ignore-submodule``
+      option of ``git diff-(tree|index)``.
+      'no' does not inspect submodules (``--ignore-submodules=all``);
+      'commit' ignores all changes to the work tree of submodules
+      (``--ignore-submodules=dirty``);
+      'full' considers a submodule modified when it either contains untracked
+      or modified files or its HEAD differs from the commit recorded in the
+      superproject (``--ignore-submodules=none``).
+      The treatment of untracked files is determined by the ``untracked``
+      parameter.
+      When a git-annex repository in adjusted mode is detected,
+      the reference commit that the worktree is being compared to, with modes
+      ``commit`` and ``full``, is the basis
       of the adjusted branch (i.e., the corresponding branch).
 
     Yields

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -5,22 +5,11 @@ The main functionality is provided by the :func:`iter_gitstatus` function.
 from __future__ import annotations
 
 import logging
-from pathlib import (
-    Path,
-    PurePath,
-)
+from pathlib import Path
 from typing import Generator
 
 from datalad_next.consts import PRE_INIT_COMMIT_SHA
-from datalad_next.runners import (
-    CommandError,
-    call_git_lines,
-    iter_git_subproc,
-)
-from datalad_next.itertools import (
-    decode_bytes,
-    itemize,
-)
+from datalad_next.runners import call_git_lines
 from datalad_next.repo_utils import (
     get_worktree_head,
 )
@@ -32,7 +21,6 @@ from .gitdiff import (
     iter_gitdiff,
 )
 from .gitworktree import (
-    GitTreeItem,
     GitTreeItemType,
     iter_gitworktree,
     iter_submodules,

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -242,25 +242,62 @@ def iter_submodules(
     path: Path,
     *,
     pathspecs: list[str | GitPathSpec] | None = None,
+    match_containing: bool = False,
 ) -> Generator[GitTreeItem, None, None]:
     """Given a path, report all submodules of a repository worktree underneath
 
-    This is a thin convenience wrapper around ``iter_gitworktree()``.
+    With ``match_containing`` set to the default ``False``, this is merely a
+    convenience wrapper around ``iter_gitworktree()`` that selectively reports
+    on submodules. With ``match_containing=True`` and ``pathspecs`` given, the
+    yielded items corresponding to submodules where the given ``pathsspecs``
+    *could* match content. This includes submodules that are not available
+    locally, because no actual matching of pathspecs to submodule content is
+    performed -- only an evaluation of the submodule item itself.
     """
+    if not pathspecs:
+        # force flag to be sensible to simplify internal logic
+        match_containing = False
+
     for item in iter_gitworktree(
         path,
         untracked=None,
         link_target=False,
         fp=False,
         recursive='repository',
-        pathspecs=pathspecs,
+        # if we want to match submodules that contain pathspecs matches
+        # we cannot give the job to Git, it won't report anything,
+        # but we need to match manually below
+        pathspecs=None if match_containing else pathspecs,
     ):
         # exclude non-submodules, or a submodule that was found at
         # the root path -- which would indicate that the submodule
         # itself it not around, only its record in the parent
-        if item.gittype == GitTreeItemType.submodule \
-                and item.name != PurePath('.'):
+        if item.gittype != GitTreeItemType.submodule \
+                or item.name == PurePath('.'):
+            continue
+
+        if not match_containing:
             yield item
+            continue
+
+        assert pathspecs is not None
+        # does any pathspec match the "inside" of the current submodule's
+        # path
+        # we are using any() here to return as fast as possible.
+        # theoretically, we could also port all of them and enhance
+        # GitTreeItem to carry them outside, but we have no idea
+        # about the outside use case here, and cannot assume the additional
+        # cost is worth it
+        if any(
+            (ps if isinstance(ps, GitPathSpec)
+             else GitPathSpec.from_pathspec_str(ps)).for_subdir(str(item.name))
+            for ps in pathspecs
+        ):
+            yield item
+            continue
+
+        # no match
+        continue
 
 
 def _get_item(

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -23,6 +23,7 @@ from datalad_next.itertools import (
     decode_bytes,
     itemize,
 )
+from datalad_next.gitpathspec import GitPathSpec
 
 from .utils import (
     FileSystemItem,
@@ -69,6 +70,7 @@ def iter_gitworktree(
     link_target: bool = False,
     fp: bool = False,
     recursive: str = 'repository',
+    pathspecs: list[str | GitPathSpec] | None = None,
 ) -> Generator[GitWorktreeItem | GitWorktreeFileSystemItem, None, None]:
     """Uses ``git ls-files`` to report on a work tree of a Git repository
 
@@ -143,6 +145,9 @@ def iter_gitworktree(
     lsfiles_args = ['--stage', '--cached']
     if untracked:
         lsfiles_args.extend(lsfiles_untracked_args[untracked])
+
+    if pathspecs:
+        lsfiles_args.extend(str(ps) for ps in pathspecs)
 
     # helper to handle multi-stage reports by ls-files
     pending_item: tuple[None | PurePosixPath, None | Dict[str, str]] = (None, None)
@@ -235,6 +240,8 @@ def iter_gitworktree(
 
 def iter_submodules(
     path: Path,
+    *,
+    pathspecs: list[str | GitPathSpec] | None = None,
 ) -> Generator[GitTreeItem, None, None]:
     """Given a path, report all submodules of a repository worktree underneath
 
@@ -246,6 +253,7 @@ def iter_submodules(
         link_target=False,
         fp=False,
         recursive='repository',
+        pathspecs=pathspecs,
     ):
         # exclude non-submodules, or a submodule that was found at
         # the root path -- which would indicate that the submodule

--- a/datalad_next/iter_collections/tests/test_itergitstatus.py
+++ b/datalad_next/iter_collections/tests/test_itergitstatus.py
@@ -253,3 +253,18 @@ def test_status_nohead_staged(tmp_path):
         {i.name: i for i in iter_gitstatus(tmp_path)},
         [{'name': 'probe', 'status': GitDiffStatus.addition}],
     )
+
+
+def test_status_pathspec(modified_dataset):
+    p = modified_dataset.pathobj
+    # look for the deleted files (identified by name, not status)
+    # this checks that we do not rely on the filesystem to have any
+    # info on the query result
+    res = list(iter_gitstatus(p, pathspecs=['*file_d']))
+    # dir_d/file_d, dir_m/file_d, file_d
+    assert len(res) == 3
+    assert all(i.name.endswith('file_d') for i in res)
+    # glob pathspec variant (* does not match /)
+    res = list(iter_gitstatus(p, pathspecs=[':(glob)*file_d']))
+    assert len(res) == 1
+    assert res[0].name == 'file_d'

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -274,3 +274,19 @@ def test_iter_submodules(modified_dataset):
     res = list(iter_submodules(p, pathspecs=[':(exclude)*/sm_c']))
     assert len(res) == len(all_sm) - 1
     assert not any(r.name == PurePath('dir_sm', 'sm_c') for r in res)
+
+    # test pathspecs matching inside submodules
+    # baseline, pointing inside a submodule gives no matching results
+    assert not list(iter_submodules(p, pathspecs=['dir_sm/sm_c/.datalad']))
+    # we can discover the submodule that could have content that matches
+    # the pathspec
+    res = list(iter_submodules(p, pathspecs=['dir_sm/sm_c/.datalad'],
+                               match_containing=True))
+    assert len(res) == 1
+    assert res[0].name == PurePath('dir_sm', 'sm_c')
+    # if we use a wildcard that matches any submodule, we also get all of them
+    # and this includes the dropped submodule, because iter_submodules()
+    # make no assumptions on what this information will be used for
+    res = list(iter_submodules(p, pathspecs=['*/.datalad'],
+                               match_containing=True))
+    assert len(res) == len(all_sm)


### PR DESCRIPTION
Eventually replaces #588

- [x] Move `GitPathSpec` out of `__init__.py` and only import that one symbol
- [ ] Add documentation to `GitPathSpec`
- [x] Fix up type annotation of `GitPathSpec`
- [ ] Test subdir propagation of `:attr` type pathspecs (they are like regular globs, but the prefix needs to be maintained)
- [x] Add `EnsurePathSpec` constraint
- [ ] Make pathspecs an orthogonal constraint to any other behavior switch, as described in https://github.com/datalad/datalad-next/issues/598#issuecomment-2134416441
- Closes: #598 
- Closes: #587