### PR TITLE
rf(EnsureRemoteName): satisfy type-annotation checker

### DIFF
--- a/datalad_next/constraints/git.py
+++ b/datalad_next/constraints/git.py
@@ -117,7 +117,8 @@ class EnsureRemoteName(Constraint):
                 f"Existence check for {self._label} requires dataset " \
                 "specification"
 
-        if self._known:
+        # second conditional only to reassert type
+        if self._known and self._dsarg is not None:
             # we don't need to check much, only if a remote of this name
             # already exists -- no need to check for syntax compliance
             # again
@@ -142,6 +143,7 @@ class EnsureRemoteName(Constraint):
             # no further check
             return value
 
+        assert self._dsarg
         if self._known is False and any(
             k.startswith(f"remote.{value}.")
             for k in self._dsarg.ds.config.keys()


### PR DESCRIPTION
There should be no functional change, just `assert` statements in strategic places that help `mypy` infer that things are correct the way they are.