### PR TITLE
Git pathspecs and submodule recursion for `iter_gitworkstree()` with pathspec support

### DIFF
--- a/datalad_next/gitpathspec/__init__.py
+++ b/datalad_next/gitpathspec/__init__.py
@@ -8,3 +8,4 @@ that rely on Git commands that do not support submodule recursion directly.
 __all__ = ['GitPathSpec', 'GitPathSpecs']
 
 from .pathspec import GitPathSpec
+from .pathspecs import GitPathSpecs

--- a/datalad_next/gitpathspec/__init__.py
+++ b/datalad_next/gitpathspec/__init__.py
@@ -1,13 +1,10 @@
-"""Data class for Git's pathspecs with subdirectory mangling support
+"""Handling of Git's pathspecs with subdirectory mangling support
 
-The main purpose of this functionality is to be able to take a pathspecs that
-is valid in the context of a top-level repository, and translate it such that
-the set of pathspecs given to the same command running on/in a
-submodule/subdirectory gives the same results, as if the initial top-level
-invocation reported them (if it even could).
-
-This functionality can be used to add support for pathspecs to implementation
+This functionality can be used to add support for pathspecs to implementations
 that rely on Git commands that do not support submodule recursion directly.
+
 """
+
+__all__ = ['GitPathSpec', 'GitPathSpecs']
 
 from .pathspec import GitPathSpec

--- a/datalad_next/gitpathspec/__init__.py
+++ b/datalad_next/gitpathspec/__init__.py
@@ -1,0 +1,13 @@
+"""Data class for Git's pathspecs with subdirectory mangling support
+
+The main purpose of this functionality is to be able to take a pathspecs that
+is valid in the context of a top-level repository, and translate it such that
+the set of pathspecs given to the same command running on/in a
+submodule/subdirectory gives the same results, as if the initial top-level
+invocation reported them (if it even could).
+
+This functionality can be used to add support for pathspecs to implementation
+that rely on Git commands that do not support submodule recursion directly.
+"""
+
+from .pathspec import GitPathSpec

--- a/datalad_next/gitpathspec/pathspec.py
+++ b/datalad_next/gitpathspec/pathspec.py
@@ -1,0 +1,322 @@
+#
+# Intentionally written without importing datalad code
+#
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatch
+import posixpath
+from typing import Generator
+
+
+@dataclass(frozen=True)
+class GitPathSpec:
+    """Support class for patterns used to limit paths in Git commands
+
+    From the Git documentation:
+
+      Pathspecs are used on the command line of "git ls-files", "git ls-tree",
+      "git add", "git grep", "git diff", "git checkout", and many other
+      commands to limit the scope of operations to some subset of the tree
+      or working tree.
+
+    Apart from providing a dedicated type for a pathspec, the main purpose
+    of this functionality is to take a pathspec that is valid in the context
+    of one (top-level) repository, and translate it such that the set of
+    pathspecs given to the same command running on/in a submodule/subdirectory
+    gives the same results, as if the initial top-level invocation reported
+    them (if it even could). See the ``for_subdir()`` method for more.
+
+    >>> # simple stripping of leading directory
+    >>> ps = GitPathSpec.from_pathspec_str('dir/*.jpg')
+    >>> [str(i) for i in ps.for_subdir('dir')]
+    ['*.jpg']
+    >>> # match against magic pathspecs
+    >>> ps = GitPathSpec.from_pathspec_str(':(glob)**r/*.jpg')
+    >>> # longest and shortest match are produced
+    >>> [str(i) for i in ps.for_subdir('dir')]
+    [':(glob)**r/*.jpg', ':(glob)*.jpg']
+    >>> [str(i) for i in ps.for_subdir('root/some/dir')]
+    [':(glob)**r/*.jpg', ':(glob)*.jpg']
+    >>> # support for special 'no-pathspec' pathspec
+    >>> ps = GitPathSpec.from_pathspec_str(':')
+    >>> ps.is_nopathspecs
+    True
+
+    .. seealso::
+
+      - Entry in the Git glossary:
+        https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+      - Informative, more elaborate description of pathspecs:
+        https://css-tricks.com/git-pathspecs-and-how-to-use-them/
+    """
+    # TODO think about adding support for another magic that represents
+    # the root of a repository hierarchy (amending 'top', which is
+    # the root of the working tree -- but presumably for a single repository
+    spectypes: tuple[str, ...]
+    """Long-form pathspec type identifiers"""
+    dirprefix: str
+    """Directory prefix (pathspec up to the last slash) limiting the scope"""
+    pattern: str | None
+    """Pattern to match paths against using ``fnmatch``"""
+
+    @property
+    def is_nopathspecs(self) -> bool:
+        """Whether this pathspec is the "no pathspecs" pathspec, AKA ``':'``"""
+        return not self.spectypes and not self.dirprefix and not self.pattern
+
+    def __str__(self) -> str:
+        """Generate normalized (long-form) pathspec"""
+        if self.is_nopathspecs:
+            return ':'
+        ps = ''
+        if self.spectypes:
+            ps += ':('
+            ps += ','.join(self.spectypes)
+            ps += ')'
+        ps += self._get_joined_pattern()
+        return ps
+
+    def _get_joined_pattern(self):
+        return f'{self.dirprefix if self.dirprefix else ""}' \
+            f'{"/" if self.dirprefix else ""}' \
+            f'{self.pattern if self.pattern else ""}'
+
+    def for_subdir(self, subdir: str) -> list[GitPathSpec]:
+        """Translate a pathspec into the scope of a subdirectory.
+
+        The processing implemented here is purely lexical. This means that it
+        works without matching against actual file system (or Git tree)
+        content. Consequently, to some degree, overly broad results are
+        produced, but at the same time use cases are supported where there
+        is nothing (yet) to match against (e.g., a not-yet-cloned submodule).
+
+        A pathspec with a ``top`` magic is produced unmodified, as there are
+        defined relative to the root of a repository, not relative to a base
+        directory. As a consequence, such pathspecs will automatically
+        refer to a submodule root when the target directory is contained in
+        one.
+
+        Parameters
+        ----------
+        subdir: str
+          Relative path in POSIX notation
+
+        Returns
+        -------
+        list
+          When an empty list is returned, this indicates that the pathsspec
+          cannot be translated to the given ``subdir``, because it does
+          not match the ``subdir`` itself. If a pathspec translates to
+          "no pathspecs" (``':'``), a list with a dedicated ':' pathspec is
+          returned.
+        """
+        # special case of a non-translation (pretty much only here to
+        # make some test implementations simpler
+        if not subdir:
+            return [self]
+
+        return list(yield_subdir_match_remainder_pathspecs(subdir, self))
+
+    @classmethod
+    def from_pathspec_str(
+        cls,
+        pathspec: str,
+    ) -> GitPathSpec:
+        """Parse a string-form pathspec into types, prefix, and pattern"""
+        spectypes = []
+        dirprefix = None
+        pattern = None
+
+        if pathspec == ':':
+            # shortcut for the special no-path-spec pathspec
+            return GitPathSpec(tuple(), '', None)
+        elif pathspec.startswith(':('):
+            # long-form magic
+            magic, pattern = pathspec[2:].split(')', maxsplit=1)
+            spectypes = magic.split(',')
+        elif pathspec.startswith(':'):
+            # short-form magic
+            magic_signatures = {
+                '/': 'top',
+                '!': 'exclude',
+                '^': 'exclude',
+                ':': None,
+            }
+            pattern = pathspec[1:]
+            spectypes = []
+            for i in range(1, len(pathspec)):
+                sig = magic_signatures.get(pathspec[i])
+                if sig is None:
+                    pattern = pathspec[i:]
+                    break
+                spectypes.append(sig)
+        else:
+            pattern = pathspec
+
+        # raise when glob and literal magic markers are present
+        # simultaneously
+        if 'glob' in spectypes and 'literal' in spectypes:
+            raise ValueError(
+                "'glob' magic is incompatible with 'literal' magic")
+
+        # split off dirprefix
+        dirprefix, pattern = GitPathSpec._split_prefix_pattern(pattern)
+
+        return cls(
+            spectypes=tuple(spectypes),
+            dirprefix=dirprefix,
+            pattern=pattern,
+        )
+
+    @staticmethod
+    def _split_prefix_pattern(pathspec):
+        # > the pathspec up to the last slash represents a directory prefix.
+        # > The scope of that pathspec is limited to that subtree.
+        try:
+            last_slash_idx = pathspec[::-1].index('/')
+        except ValueError:
+            # everything is the pattern
+            dirprefix = None
+            pattern = pathspec
+        else:
+            dirprefix = pathspec[:-last_slash_idx - 1]
+            pattern = pathspec[-last_slash_idx:] \
+                if last_slash_idx > 0 else None
+        return dirprefix, pattern
+
+
+def yield_subdir_match_remainder_pathspecs(
+    subdir: str,
+    pathspec: GitPathSpec,
+) -> Generator[GitPathSpec, None, None]:
+    """Translate a pathspec into a set of possible subdirectory pathspecs
+
+    The processing implemented here is purely lexical. This means that it
+    works without matching against actual file system (or Git tree) content.
+    This means that it yields, to some degree, overly broad results, but also
+    that it works in cases where there is nothing (yet) to match against.
+    For example, a not-yet-cloned submodule.
+
+    This function does not perform any validatity checking of pathspecs. Only
+    valid pathspecs and well-formed paths are supported.
+
+    A pathspec with the ``top`` magic is returned immediately and as-is. These
+    pathspecs have an absolute reference and do not require a translation into
+    a subdirectory namespace.
+
+    Parameters
+    ----------
+    subdir: str
+      POSIX-notation relative path of a subdirectory. The reference directory
+      match be the same as that of the pathspec to be translated.
+    pathspec: GitPathSpec
+      To-be-translated pathspec
+
+    Yields
+    ------
+    GitPathSpec
+      Any number of pathspecs that an input pathspec decomposed into upon
+      translation into the namespace of a subdirectory.
+    """
+    if 'top' in pathspec.spectypes or pathspec.is_nopathspecs:
+        # pathspec with an absolute reference, or "no pathspecs"
+        # no translation needed
+        yield pathspec
+        return
+
+    # add a trailing directory separator to prevent undesired
+    # matches of partial directory names
+    subdir = subdir \
+        if subdir.endswith('/') \
+        else f'{subdir}/'
+    tp = pathspec._get_joined_pattern()
+
+    if 'icase' in pathspec.spectypes:
+        subdir = subdir.casefold()
+        tp = tp.casefold()
+
+    # literal pathspecs
+    if 'literal' in pathspec.spectypes:
+        # append a trailing slash to allow for full matches
+        tp_endslash = f'{tp}/'
+        if not tp_endslash.startswith(subdir):
+            # no match
+            # BUT
+            # we might have a multi-level subdir, and we might match an
+            # intermediate subdir and could still yield a 'no pathspec'
+            # result
+            while subdir := posixpath.split(subdir)[0]:
+                if tp_endslash.startswith(subdir):
+                    yield GitPathSpec.from_pathspec_str(':')
+                    return
+            return
+
+        remainder = tp[len(subdir):]
+        if not remainder:
+            # full match
+            yield GitPathSpec.from_pathspec_str(':')
+        else:
+            yield GitPathSpec(
+                pathspec.spectypes,
+                *GitPathSpec._split_prefix_pattern(remainder)
+            )
+        return
+
+    # tokenize the testpattern using the wildcard that also matches
+    # directories
+    token_delim = '**' if 'glob' in pathspec.spectypes else '*'
+    tp_chunks = tp.split(token_delim)
+    prefix_match = ''
+    yielded = set()
+    for i, chunk in enumerate(tp_chunks):
+        last_chunk = i + 1 == len(tp_chunks)
+        if last_chunk:
+            trymatch = \
+                f'{prefix_match}{chunk}{"" if chunk.endswith("/") else "/"}'
+        else:
+            trymatch = f'{prefix_match}{chunk}*'
+        if not fnmatch(subdir, f'{trymatch}'):
+            # each chunk needs match in order, first non-match ends the
+            # algorithm
+            # BUT
+            # we have an (initial) chunk that points already
+            # inside the target subdir
+            submatch = trymatch
+            while submatch := posixpath.split(submatch)[0]:
+                if fnmatch(f'{subdir}', f'{submatch}/'):
+                    ps = GitPathSpec(
+                        pathspec.spectypes,
+                        *GitPathSpec._split_prefix_pattern(
+                            # +1 for trailing slash
+                            tp[len(submatch) + 1:])
+                    )
+                    if ps not in yielded:
+                        yield ps
+                    return
+            # OR
+            # we might have a multi-level subdir, and we might match an
+            # intermediate subdir and could still yield a 'no pathspec'
+            # result
+            while subdir := posixpath.split(subdir)[0]:
+                if fnmatch(f'{subdir}/', trymatch):
+                    yield GitPathSpec.from_pathspec_str(':')
+                    return
+            return
+
+        remainder = tp_chunks[i + 1:]
+        if all(not c for c in remainder):
+            # direct hit, no pathspecs after translation
+            yield GitPathSpec.from_pathspec_str(':')
+            return
+        else:
+            ps = GitPathSpec(
+                pathspec.spectypes,
+                *GitPathSpec._split_prefix_pattern(
+                    f'{token_delim}{token_delim.join(remainder)}',
+                )
+            )
+            yield ps
+            yielded.add(ps)
+        # extend prefix for the next round
+        prefix_match = trymatch

--- a/datalad_next/gitpathspec/pathspecs.py
+++ b/datalad_next/gitpathspec/pathspecs.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from itertools import chain
+from pathlib import (
+    PurePosixPath,
+)
+
+from .pathspec import GitPathSpec
+
+
+class GitPathSpecs:
+    """Convenience container for any number of pathspecs (or none)
+
+    This class can facilitate implementing support for pathspec-constraints,
+    including scenarios involving submodule recursion.
+
+    >>> # can except a "default" argument for no pathspecs
+    >>> ps = GitPathSpecs(None)
+    >>> not ps
+    True
+    >>> ps.arglist()
+    []
+    >>> # deal with any number of pathspecs
+    >>> ps = GitPathSpecs(['*.jpg', 'dir/*.png'])
+    >>> ps.any_match_subdir(PurePosixPath('dummy'))
+    True
+    >>> ps.for_subdir(PurePosixPath('dir'))
+    GitPathSpecs(['*.jpg', '*.png'])
+    """
+    def __init__(
+        self,
+        pathspecs: Iterable[str | GitPathSpec] | GitPathSpecs | None,
+    ):
+        """Pathspecs can be given as an iterable (string-form and/or
+        ``GitPathSpec``), another ``GitPathSpecs`` instance, or ``None``.
+        ``None``, or empty iterable indicate a 'no constraint' scenario,
+        equivalent to a single ``':'`` pathspec.
+        """
+        self._pathspecs: list[GitPathSpec] | None = None
+        if pathspecs is None:
+            return
+        elif isinstance(pathspecs, GitPathSpecs):
+            self._pathspecs = list(pathspecs._pathspecs) \
+                if pathspecs._pathspecs else None
+        else:
+            self._pathspecs = _normalize_gitpathspec(pathspecs)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}([{', '.join(repr(p) for p in self.arglist())}])"
+    def __len__(self) -> int:
+        return len(self._pathspecs) if self._pathspecs is not None else 0
+
+    # TODO lru_cache decorator?
+    # this would prevent repeated conversion cost for the usage pattern of
+    # - test if we would have a match for a subdir
+    # - run code with the matching pathspecs
+    # without having to implement caching logic in client code
+    def for_subdir(
+        self,
+        path: PurePosixPath,
+    ) -> GitPathSpecs:
+        if self._pathspecs is None:
+            return self
+        return GitPathSpecs(chain.from_iterable(
+            ps.for_subdir(str(path))
+            for ps in self._pathspecs
+        ))
+
+    def arglist(self) -> list[str]:
+        """Convert pathspecs to a CLI argument list
+
+        This list is suitable for use with any Git command that supports
+        pathspecs, after a ``--`` (that disables the interpretation of further
+        arguments as options).
+
+        When no pathspecs are present an empty list is returned.
+        """
+        if self._pathspecs is None:
+            return []
+        return list(str(ps) for ps in self._pathspecs)
+
+
+def _normalize_gitpathspec(
+    specs: Iterable[str | GitPathSpec] | None,
+) -> list[GitPathSpec] | None:
+    """Normalize path specs to a plain list of GitPathSpec instances"""
+    if not specs:
+        return None
+    else:
+        return [
+            ps if isinstance(ps, GitPathSpec)
+            else GitPathSpec.from_pathspec_str(ps)
+            for ps in specs
+        ]

--- a/datalad_next/gitpathspec/pathspecs.py
+++ b/datalad_next/gitpathspec/pathspecs.py
@@ -48,8 +48,12 @@ class GitPathSpecs:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}([{', '.join(repr(p) for p in self.arglist())}])"
+
     def __len__(self) -> int:
         return len(self._pathspecs) if self._pathspecs is not None else 0
+
+    def __eq__(self, obj):
+        return self._pathspecs == obj._pathspecs
 
     # TODO lru_cache decorator?
     # this would prevent repeated conversion cost for the usage pattern of
@@ -66,6 +70,28 @@ class GitPathSpecs:
             ps.for_subdir(str(path))
             for ps in self._pathspecs
         ))
+
+    def any_match_subdir(
+        self,
+        path: PurePosixPath,
+    ) -> bool:
+        """Returns whether any pathspec could match subdirectory content
+
+        Parameters
+        ----------
+        path: PurePosixPath
+          Relative path in POSIX notation of the subdirectory to run the
+          test for.
+        """
+        if self._pathspecs is None:
+            return False
+        path_s = str(path)
+        for ps in self._pathspecs:
+            if ps.for_subdir(path_s):
+                # any match is sufficient for a decision
+                return True
+        # nothing matches
+        return False
 
     def arglist(self) -> list[str]:
         """Convert pathspecs to a CLI argument list

--- a/datalad_next/gitpathspec/tests/test_gitpathspec.py
+++ b/datalad_next/gitpathspec/tests/test_gitpathspec.py
@@ -1,0 +1,349 @@
+from pathlib import Path
+import pytest
+import subprocess
+import sys
+
+from .. import (
+    GitPathSpec,
+)
+from ..pathspec import yield_subdir_match_remainder_pathspecs
+
+
+def _list_files(path, pathspecs):
+    return [
+        i for i in subprocess.run(
+            ['git', 'ls-files', '-z', '--other', '--', *pathspecs],
+            capture_output=True,
+            cwd=path,
+        ).stdout.decode('utf-8').split('\0')
+        if i
+    ]
+
+
+@pytest.fixture(scope="function")
+def pathspec_match_testground(tmp_path_factory):
+    """Create a Git repo with no commit and many untracked files
+
+    In this playground, `git ls-files --other` can be used to testrun
+    pathspecs.
+
+    See the top item in `testcases` for a summary of the content
+    """
+    p = tmp_path_factory.mktemp('pathspec_match')
+    probe = p / 'pr?be'
+    # check for case insensitive file systems
+    crippled_fs = Path(str(p).upper()).exists()
+    try:
+        probe.touch()
+        probe.unlink()
+    except OSError:
+        crippled_fs = True
+
+    subprocess.run(['git', 'init'], cwd=p, check=True)
+    p_sub = p / 'sub'
+    p_sub.mkdir()
+    for d in (p, p_sub):
+        p_a = d / 'aba'
+        p_b = d / 'a?a'
+        for sp in (p_a,) if crippled_fs else (p_a, p_b):
+            sp.mkdir()
+            for fname in ('a.txt', 'A.txt', 'a.JPG'):
+                (sp / fname).touch()
+    # add something that is unique to sub/
+    (p_sub / 'b.dat').touch()
+
+    testcases = [
+        # valid
+        dict(
+            ps=':',
+            fordir={
+                None: {'specs': [':'],
+                       'match': [
+                           'aba/a.JPG', 'aba/a.txt',
+                           'sub/aba/a.JPG', 'sub/aba/a.txt',
+                           'sub/b.dat'] if crippled_fs else [
+                           'a?a/A.txt', 'a?a/a.JPG', 'a?a/a.txt',
+                           'aba/A.txt', 'aba/a.JPG', 'aba/a.txt',
+                           'sub/a?a/A.txt', 'sub/a?a/a.JPG', 'sub/a?a/a.txt',
+                           'sub/aba/A.txt', 'sub/aba/a.JPG', 'sub/aba/a.txt',
+                           'sub/b.dat'],
+                },
+                'sub': {'specs': [':'],
+                        'match': [
+                            'aba/a.JPG', 'aba/a.txt',
+                            'b.dat'] if crippled_fs else [
+                            'a?a/A.txt', 'a?a/a.JPG', 'a?a/a.txt',
+                            'aba/A.txt', 'aba/a.JPG', 'aba/a.txt',
+                            'b.dat'],
+                },
+            },
+        ),
+        dict(
+            ps='aba',
+            fordir={
+                None: {'match': [
+                    'aba/a.JPG', 'aba/a.txt',
+                ] if crippled_fs else [
+                    'aba/A.txt', 'aba/a.JPG', 'aba/a.txt'],
+                },
+                'aba': {'specs': [':'],
+                        'match': [
+                            'a.JPG', 'a.txt'] if crippled_fs else [
+                            'A.txt', 'a.JPG', 'a.txt'],
+                },
+            },
+        ),
+        # same as above, but with a trailing slash
+        dict(
+            ps='aba/',
+            fordir={
+                None: {'match': [
+                    'aba/a.JPG', 'aba/a.txt',
+                ] if crippled_fs else [
+                    'aba/A.txt', 'aba/a.JPG', 'aba/a.txt'],
+                },
+                'aba': {'specs': [':'],
+                        'match': [
+                            'a.JPG', 'a.txt'] if crippled_fs else [
+                            'A.txt', 'a.JPG', 'a.txt'],
+                },
+            },
+        ),
+        # TODO same as above, but as a literal
+
+        dict(
+            ps=':(glob)aba/*.txt',
+            fordir={
+                None: {'match': [
+                    'aba/a.txt',
+                ] if crippled_fs else ['aba/A.txt', 'aba/a.txt']},
+                'sub': {'specs': []},
+            },
+        ),
+        dict(
+            ps=':/aba/*.txt',
+            norm=':(top)aba/*.txt',
+            fordir={
+                None: {'match': [
+                    'aba/a.txt',
+                ] if crippled_fs else ['aba/A.txt', 'aba/a.txt']},
+                # for a subdir a keeps matching the exact same items
+                # not only be name, but by location
+                'sub': {'specs': [':(top)aba/*.txt'],
+                        'match': ['../aba/a.txt'] if crippled_fs else [
+                            '../aba/A.txt', '../aba/a.txt']},
+            },
+        ),
+        dict(
+            ps='aba/*.txt',
+            fordir={
+                None: {'match': ['aba/a.txt'] if crippled_fs else [
+                    'aba/A.txt', 'aba/a.txt'],
+                },
+                # not applicable
+                'sub': {'specs': []},
+                # but this is
+                'aba': {'specs': ['*.txt']},
+            },
+        ),
+        dict(
+            ps='sub/aba/*.txt',
+            fordir={
+                None: {'match': ['sub/aba/a.txt'] if crippled_fs else [
+                    'sub/aba/A.txt', 'sub/aba/a.txt']},
+                'sub': {'specs': ['aba/*.txt'],
+                        'match': ['aba/a.txt'] if crippled_fs else [
+                            'aba/A.txt', 'aba/a.txt']},
+            },
+        ),
+        dict(
+            ps='*.JPG',
+            fordir={
+                None: {'match': [
+                    'aba/a.JPG', 'sub/aba/a.JPG'] if crippled_fs else [
+                    'a?a/a.JPG', 'aba/a.JPG', 'sub/a?a/a.JPG',
+                    'sub/aba/a.JPG']},
+                # unchanged
+                'sub': {'specs': ['*.JPG']},
+            },
+        ),
+        dict(
+            ps='*ba*.JPG',
+            fordir={
+                None: {'match': ['aba/a.JPG', 'sub/aba/a.JPG']},
+                'aba': {'specs': ['*ba*.JPG', '*.JPG'],
+                        'match': ['a.JPG']},
+            },
+        ),
+        # invalid
+        #
+        # conceptual conflict and thereby unsupported by Git
+        # makes sense and is easy to catch that
+        dict(ps=':(glob,literal)broken', raises=ValueError),
+    ]
+    if not crippled_fs:
+        testcases.extend([
+            # literal magic is only needed for non-crippled FS
+            dict(
+                ps=':(literal)a?a/a.JPG',
+                fordir={
+                    None: dict(
+                        match=['a?a/a.JPG'],
+                    ),
+                    "a?a": dict(
+                        specs=[':(literal)a.JPG'],
+                        match=['a.JPG'],
+                    ),
+                },
+            ),
+            dict(
+                ps=':(literal,icase)SuB/A?A/a.jpg',
+                fordir={
+                    None: {'match': ['sub/a?a/a.JPG']},
+                    "sub/a?a": {
+                        'specs': [':(literal,icase)a.jpg'],
+                        # given the spec transformation matches
+                        # MIH would really expect to following,
+                        # but it is not coming from Git :(
+                        #'match': ['a.JPG'],
+                        'match': [],
+                    },
+                },
+            ),
+            dict(
+                ps=':(icase)A?A/a.jpg',
+                fordir={
+                    None: {'match': ['a?a/a.JPG', 'aba/a.JPG']},
+                    "aba": {
+                        'specs': [':(icase)a.jpg'],
+                        'match': ['a.JPG'],
+                    },
+                },
+            ),
+            dict(
+                ps=':(literal,icase)A?A/a.jpg',
+                fordir={
+                    None: {'match': ['a?a/a.JPG']},
+                    "a?a": {
+                        'specs': [':(literal,icase)a.jpg'],
+                        'match': ['a.JPG'],
+                    },
+                    # the target subdir does not match the pathspec
+                    "aba": {'specs': set()},
+                },
+            ),
+        ])
+
+    yield p, testcases
+
+
+def test_pathspecs(pathspec_match_testground):
+    tg, testcases = pathspec_match_testground
+
+    for testcase in testcases:
+        if testcase.get('raises'):
+            # test case states how `GitPathSpec` will blow up
+            # on this case. Verify and skip any further testing
+            # on this case
+            with pytest.raises(testcase['raises']):
+                GitPathSpec.from_pathspec_str(testcase['ps'])
+            continue
+        # create the instance
+        ps = GitPathSpec.from_pathspec_str(testcase['ps'])
+        # if no deviating normalized representation is given
+        # it must match the original one
+        assert str(ps) == testcase.get('norm', testcase['ps'])
+        # test translations onto subdirs now
+        # `None` is a special subdir that means "self", i.e.
+        # not translation other than normalization, we can use it
+        # to test matching behavior of the full pathspec
+        for subdir, target in testcase.get('fordir', {}).items():
+            # translate -- a single input pathspec can turn into
+            # multiple translated ones. This is due to
+            subdir_specs = [str(s) for s in ps.for_subdir(subdir)]
+            if 'specs' in target:
+                assert set(subdir_specs) == set(target['specs']), \
+                    f'Mismatch for {testcase["ps"]!r} -> subdir {subdir!r} {target}'
+            if subdir and not target.get('specs') and 'match' in target:
+                raise ValueError(
+                    'invalid test specification: no subdir specs expected, '
+                    f'but match declared: {testcase!r}')
+            if subdir_specs and 'match' in target:
+                tg_subdir = tg / subdir if subdir else tg
+                assert _list_files(tg_subdir, subdir_specs) == target['match']
+
+
+def test_yield_subdir_match_remainder_pathspecs():
+    testcases = [
+        # FORMAT: target path, pathspec, subdir pathspecs
+        ('abc', ':', [':']),
+        # top-magic is returned as-is
+        ('murks', ':(top)crazy*^#', [':(top)crazy*^#']),
+        # no match
+        ('abc', 'not', []),
+        ('abc', 'ABC', [':'] if sys.platform.startswith('win') else []),
+        # direct hits, resolve to "no pathspecs"
+        ('abc', 'a?c', [':']),
+        ('abc', 'abc', [':']),
+        ('abc', 'abc/', [':']),
+        # icase-magic
+        ('abc', ':(icase)ABC', [':']),
+        ('ABC', ':(icase)abc', [':']),
+        # some fairly common fnmatch-style pathspec
+        ('abc', 'abc/*.jpg', ['*.jpg']),
+        ('abc', '*.jpg', ['*.jpg']),
+        ('abc', '*/*.jpg', ['*/*.jpg', '*.jpg']),
+        ('abc', '*/*.jpg', ['*/*.jpg', '*.jpg']),
+        ('abc', '*bc*.jpg', ['*bc*.jpg', '*.jpg']),
+        # adding an glob-unrelated magic does not impact the result
+        ('abc', ':(exclude)*/*.jpg', [':(exclude)*/*.jpg', ':(exclude)*.jpg']),
+        ('abc', ':(attr:export-subst)*/*.jpg',
+         [':(attr:export-subst)*/*.jpg', ':(attr:export-subst)*.jpg']),
+        ('abc', ':(icase,exclude)*/*.jpg',
+         [':(icase,exclude)*/*.jpg', ':(icase,exclude)*.jpg']),
+        # glob-magic
+        ('abc', ':(glob)*bc*.jpg', []),
+        ('abc', ':(glob)*bc**.jpg', [':(glob)**.jpg']),
+        # 2nd-level subdir
+        ('abc/123', 'some.jpg', []),
+        ('abc/123', '*.jpg', ['*.jpg']),
+        ('abc/123', 'abc/*', [':']),
+        ('abc/123', 'abc', [':']),
+        ('abc/123', ':(glob)abc', [':']),
+        ('abc/123', '*123', ['*123', ':']),
+        ('abc/123', '*/123', ['*/123', ':']),
+        ('abc/123', ':(glob)*/123', [':']),
+        # literal-magic
+        ('abc', ':(literal)a?c', []),
+        ('a?c', ':(literal)a?c', [':']),
+        ('a?c', ':(literal)a?c/*?ab*', [':(literal)*?ab*']),
+        ('a?c/123', ':(literal)a?c', [':']),
+        # more complex cases
+        ('abc/123/ABC', 'a*/1?3/*.jpg',
+         ['*/1?3/*.jpg', '*.jpg', '1?3/*.jpg']),
+        # exclude-magic
+        ('abc', ':(exclude)abc', [':']),
+        ('abc/123', ':(exclude)abc', [':']),
+        ('a?c', ':(exclude,literal)a?c', [':']),
+        # stuff that was problematic at some point
+        # initial, non-wildcard part already points inside the
+        # target directory
+        ('sub', 'sub/aba/*.txt', ['aba/*.txt']),
+        # no directory-greedy wildcard whatsoever
+        ('abc', ':(icase)A?C/a.jpg', [':(icase)a.jpg']),
+        # no directory-greedy wildcard in later chunk
+        ('nope/abc', 'no*/a?c/a.jpg', ['*/a?c/a.jpg', 'a.jpg']),
+    ]
+    for ts in testcases:
+        # always test against the given subdir, and also against the subdir
+        # given with a trailing slash
+        for target_path in (ts[0], f'{ts[0]}/'):
+            tsps = GitPathSpec.from_pathspec_str(ts[1])
+            remainders = list(
+                yield_subdir_match_remainder_pathspecs(
+                    target_path,
+                    tsps,
+                )
+            )
+            assert [str(ps) for ps in remainders] == ts[2], \
+                f'Mismatch for {ts}'

--- a/datalad_next/gitpathspec/tests/test_gitpathspec.py
+++ b/datalad_next/gitpathspec/tests/test_gitpathspec.py
@@ -5,6 +5,7 @@ import sys
 
 from .. import (
     GitPathSpec,
+    GitPathSpecs,
 )
 from ..pathspec import yield_subdir_match_remainder_pathspecs
 
@@ -347,3 +348,32 @@ def test_yield_subdir_match_remainder_pathspecs():
             )
             assert [str(ps) for ps in remainders] == ts[2], \
                 f'Mismatch for {ts}'
+            # arglist processing of the GitPathSpecs container comes to the
+            # same result
+            assert GitPathSpecs(remainders).arglist() == ts[2]
+            # now we produce the same result with the GitPathSpecs handler
+            assert GitPathSpecs([ts[1]]).for_subdir(target_path).arglist() \
+                == [str(ps) for ps in remainders]
+            # if we are supposed to get any remainder out, the test for a
+            # subdir match also gives an analog result
+            if ts[2]:
+                assert GitPathSpecs([tsps]).any_match_subdir(target_path)
+            else:
+                assert not GitPathSpecs([tsps]).any_match_subdir(target_path)
+
+
+def test_GitPathSpecs():
+    ps = GitPathSpecs(['mike/*', '*.jpg'])
+    # we can create a GitPathSpecs object from another
+    assert GitPathSpecs(ps).arglist() == ps.arglist()
+
+    # going over the properties
+    assert repr(ps) == "GitPathSpecs(['mike/*', '*.jpg'])"
+    assert len(ps) == 2
+
+    # we can have "no pathspecs"
+    # TODO shouldn't this be ':'?
+    # TODO how about the semantic distinction between None and []?
+    nops = GitPathSpecs(None)
+    assert GitPathSpecs(None).for_subdir('doesntmatter') == nops
+    assert GitPathSpecs(None).any_match_subdir('doesntmatter') is False

--- a/datalad_next/gitpathspec/tests/test_gitpathspec.py
+++ b/datalad_next/gitpathspec/tests/test_gitpathspec.py
@@ -352,8 +352,13 @@ def test_yield_subdir_match_remainder_pathspecs():
             # same result
             assert GitPathSpecs(remainders).arglist() == ts[2]
             # now we produce the same result with the GitPathSpecs handler
-            assert GitPathSpecs([ts[1]]).for_subdir(target_path).arglist() \
-                == [str(ps) for ps in remainders]
+            try:
+                assert \
+                    GitPathSpecs([ts[1]]).for_subdir(target_path).arglist() \
+                    == [str(ps) for ps in remainders]
+            except ValueError:
+                # translation must raise when there would not be a remainder
+                assert not remainders
             # if we are supposed to get any remainder out, the test for a
             # subdir match also gives an analog result
             if ts[2]:

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -388,7 +388,10 @@ def _yield_repo_untracked(
         return
     for uf in _git_ls_files(
         path,
-        *lsfiles_untracked_args[untracked],
+        *(a for a in lsfiles_untracked_args[untracked]
+          # temporarily filter this, thew entire function will soon be
+          # obsolete
+          if a not in ('--stage', '--cached')),
     ):
         yield GitDiffItem(
             name=uf,

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -152,7 +152,7 @@ def _yield_dir_items(
         GitTreeItemType.directory,
         GitTreeItemType.submodule,
     )
-    if untracked == 'no':
+    if untracked is None:
         # no need to look at anything other than the diff report
         dir_items = {}
     else:
@@ -191,7 +191,7 @@ def _yield_dir_items(
                 if dir_path.exists():
                     item.add_modification_type(
                         GitContainerModificationType.modified_content)
-                    if untracked != 'no' \
+                    if untracked is not None \
                             and _path_has_untracked(path / item.path):
                         item.add_modification_type(
                             GitContainerModificationType.untracked_content)
@@ -204,7 +204,7 @@ def _yield_dir_items(
         if item.status:
             yield item
 
-    if untracked == 'no':
+    if untracked is None:
         return
 
     # yield anything untracked, and inspect remaining containers
@@ -302,7 +302,7 @@ def _yield_repo_items(
         if item.status:
             yield item
 
-    if untracked == 'no':
+    if untracked is None:
         return
 
     # lastly untracked files of this repo

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -7,19 +7,12 @@ from __future__ import annotations
 import logging
 from pathlib import (
     Path,
-    PurePath,
 )
 from typing import Generator
 
 from datalad_next.consts import PRE_INIT_COMMIT_SHA
 from datalad_next.runners import (
-    CommandError,
     call_git_lines,
-    iter_git_subproc,
-)
-from datalad_next.itertools import (
-    decode_bytes,
-    itemize,
 )
 from datalad_next.repo_utils import (
     get_worktree_head,
@@ -32,15 +25,20 @@ from .gitdiff import (
     iter_gitdiff,
 )
 from .gitworktree import (
-    GitTreeItem,
     GitTreeItemType,
     iter_gitworktree,
     iter_submodules,
-    lsfiles_untracked_args,
-    _git_ls_files,
 )
 
 lgr = logging.getLogger('datalad.ext.next.iter_collections.gitstatus')
+
+# map untracked modes given to iter_gitstatus() to those that need to be
+# passed to iter_gitworktree() for getting untracked content only
+_untracked_mode_map = {
+    'all': 'only',
+    'whole-dir': 'only-whole-dir',
+    'no-empty-dir': 'only-no-empty-dir',
+}
 
 
 def iter_gitstatus(
@@ -164,7 +162,7 @@ def _yield_dir_items(
         # gather all dierectory items upfront, we subtract the ones reported
         # modified later and lastly yield all untracked content from them
         dir_items = {
-            str(item.name): item
+            item.name.as_posix(): item
             for item in iter_gitworktree(
                 path,
                 untracked=untracked,
@@ -308,7 +306,18 @@ def _yield_repo_items(
         return
 
     # lastly untracked files of this repo
-    yield from _yield_repo_untracked(path, untracked)
+    for item in iter_gitworktree(
+        path=path,
+        untracked=_untracked_mode_map[untracked],
+        link_target=False,
+        fp=False,
+        recursive='repository',
+    ):
+        yield GitDiffItem(
+            name=item.name.as_posix(),
+            status=GitDiffStatus.other,
+            gittype=item.gittype,
+        )
 
 
 def _yield_hierarchy_items(
@@ -379,38 +388,16 @@ def _yield_hierarchy_items(
 #
 
 
-def _yield_repo_untracked(
-        path: Path,
-        untracked: str | None,
-) -> Generator[GitDiffItem, None, None]:
-    """Yield items on all untracked content in a repository"""
-    if untracked is None:
-        return
-    for uf in _git_ls_files(
-        path,
-        *(a for a in lsfiles_untracked_args[untracked]
-          # temporarily filter this, thew entire function will soon be
-          # obsolete
-          if a not in ('--stage', '--cached')),
-    ):
-        yield GitDiffItem(
-            name=uf,
-            status=GitDiffStatus.other,
-            # it is cheap to discriminate between a directory and anything
-            # else. So let's do that, but not spend the cost of deciding
-            # between files and symlinks
-            gittype=GitTreeItemType.directory if uf.endswith('/') else None
-        )
-
-
 def _path_has_untracked(path: Path) -> bool:
     """Recursively check for any untracked content (except empty dirs)"""
     if not path.exists():
         # cannot possibly have untracked
         return False
-    for ut in _yield_repo_untracked(
-        path,
-        'no-empty-dir',
+    for ut in iter_gitworktree(
+        path=path,
+        untracked='only-no-empty-dir',
+        link_target=False,
+        fp=False,
     ):
         # fast exit on the first detection
         return True

--- a/datalad_next/iter_collections/gitstatus.py
+++ b/datalad_next/iter_collections/gitstatus.py
@@ -159,7 +159,7 @@ def _yield_dir_items(
         # there is no recursion, avoid wasting cycles on listing individual
         # files in subdirectories
         untracked = 'whole-dir' if untracked == 'all' else untracked
-        # gather all dierectory items upfront, we subtract the ones reported
+        # gather all directory items upfront, we subtract the ones reported
         # modified later and lastly yield all untracked content from them
         dir_items = {
             item.name.as_posix(): item
@@ -192,7 +192,7 @@ def _yield_dir_items(
                     item.add_modification_type(
                         GitContainerModificationType.modified_content)
                     if untracked is not None \
-                            and _path_has_untracked(path / item.path):
+                            and _path_has_untracked(dir_path):
                         item.add_modification_type(
                             GitContainerModificationType.untracked_content)
                 else:
@@ -236,6 +236,7 @@ def _yield_dir_items(
             else:
                 # this is on a directory. if it appears here, it has
                 # no modified content
+                testpath = path / dir_item.path
                 if _path_has_untracked(path / dir_item.path):
                     item.status = GitDiffStatus.modification
                     item.add_modification_type(
@@ -398,16 +399,10 @@ def _path_has_untracked(path: Path) -> bool:
         untracked='only-no-empty-dir',
         link_target=False,
         fp=False,
+        recursive='submodules',
     ):
         # fast exit on the first detection
         return True
-    # we need to find all submodules, regardless of mode.
-    # untracked content can also be in a submodule underneath
-    # a directory
-    for subm in iter_submodules(path):
-        if _path_has_untracked(path / subm.path):
-            # fast exit on the first detection
-            return True
     # only after we saw everything we can say there is nothing
     return False
 

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -23,10 +23,7 @@ from datalad_next.itertools import (
     decode_bytes,
     itemize,
 )
-from datalad_next.gitpathspec import (
-    GitPathSpec,
-    GitPathSpecs,
-)
+from datalad_next.gitpathspec import GitPathSpecs
 from .utils import (
     FileSystemItem,
     FileSystemItemType,

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -286,14 +286,22 @@ def _yield_from_submodule(
     if not subm_path.exists():
         # no point in trying to list a submodule that is not around
         return
+    subm_pathspecs = pathspecs
+    if pathspecs:
+        # recode pathspecs to match the submodule scope
+        try:
+            subm_pathspecs = pathspecs.for_subdir(subm_name)
+        except ValueError:
+            # not a single pathspec could be translated, there is
+            # no chance for a match, we can stop here
+            return
     for item in iter_gitworktree(
         path=subm_path,
         untracked=untracked,
         link_target=link_target,
         fp=fp,
         recursive=recursive,
-        # recode pathspecs to match the submodule
-        pathspecs=pathspecs.for_subdir(subm_name),
+        pathspecs=subm_pathspecs,
     ):
         # recode path/name
         item.name = subm.name / item.name

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -54,6 +54,34 @@ class GitWorktreeFileSystemItem(FileSystemItem):
     gitsha: str | None = None
     gittype: GitTreeItemType | None = None
 
+    @classmethod
+    def from_worktreeitem(
+        cls,
+        basepath: Path,
+        item: GitWorktreeItem,
+        link_target: bool = True,
+    ):
+        """Create GitWorktreeFileSystemItem from corresponding GitWorktreeItem
+
+        Parameters
+        ----------
+        basepath: Path
+          Reference path to convert the ``GitWorktreeItem``'s path into a
+          path on the file system.
+        item: GitWorktreeItem
+          Item to create matching ``GitWorktreeFileSystemItem`` for.
+        link_target: bool
+          Flag whether to read out a link-target for an item that is a symlink.
+        """
+        fsitem = GitWorktreeFileSystemItem.from_path(
+            path=item.path(),
+            link_target=link_target,
+        )
+        fsitem.name = item.name
+        fsitem.gitsha = item.gitsha
+        fsitem.gittype = item.gittype
+        return fsitem
+
 
 lsfiles_untracked_args = {
     'all':

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -93,6 +93,13 @@ lsfiles_untracked_args = {
     'no-empty-dir':
     ('--stage', '--cached', '--exclude-standard',
      '--others', '--directory', '--no-empty-directory'),
+    'only':
+    ('--exclude-standard', '--others'),
+    'only-whole-dir':
+    ('--exclude-standard', '--others', '--directory'),
+    'only-no-empty-dir':
+    ('--exclude-standard',
+     '--others', '--directory', '--no-empty-directory'),
 }
 
 
@@ -132,12 +139,15 @@ def iter_gitworktree(
       Path of a directory in a Git repository to report on. This directory
       need not be the root directory of the repository, but must be part of
       the repository's work tree.
-    untracked: {'all', 'whole-dir', 'no-empty-dir'} or None, optional
+    untracked: {'all', 'whole-dir', 'no-empty-dir', 'only', 'only-whole-dir', 'only-no-empty-dir'} or None, optional
       If not ``None``, also reports on untracked work tree content.
       ``all`` reports on any untracked file; ``whole-dir`` yields a single
       report for a directory that is entirely untracked, and not individual
       untracked files in it; ``no-empty-dir`` skips any reports on
-      untracked empty directories.
+      untracked empty directories. The modes starting with 'only' offer the
+      same untracked content reporting styles, but only untracked and no
+      tracked content is reported. For example, 'only' is the corresponding
+      mode to 'all' with no tracked content being reported.
     link_target: bool, optional
       If ``True``, information matching a
       :class:`~datalad_next.iter_collections.utils.FileSystemItem`

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -353,16 +353,7 @@ def iter_submodules(
         assert pathspecs is not None
         # does any pathspec match the "inside" of the current submodule's
         # path
-        # we are using any() here to return as fast as possible.
-        # theoretically, we could also port all of them and enhance
-        # GitTreeItem to carry them outside, but we have no idea
-        # about the outside use case here, and cannot assume the additional
-        # cost is worth it
-        if any(
-            (ps if isinstance(ps, GitPathSpec)
-             else GitPathSpec.from_pathspec_str(ps)).for_subdir(str(item.name))
-            for ps in pathspecs
-        ):
+        if _pathspecs.any_match_subdir(PurePosixPath(item.name)):
             yield item
             continue
 

--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -84,12 +84,15 @@ class GitWorktreeFileSystemItem(FileSystemItem):
 
 
 lsfiles_untracked_args = {
+    None:
+    ('--stage', '--cached'),
     'all':
-    ('--exclude-standard', '--others'),
+    ('--stage', '--cached', '--exclude-standard', '--others'),
     'whole-dir':
-    ('--exclude-standard', '--others', '--directory'),
+    ('--stage', '--cached', '--exclude-standard', '--others', '--directory'),
     'no-empty-dir':
-    ('--exclude-standard', '--others', '--directory', '--no-empty-directory'),
+    ('--stage', '--cached', '--exclude-standard',
+     '--others', '--directory', '--no-empty-directory'),
 }
 
 
@@ -213,9 +216,8 @@ def _iter_gitworktree(
 ) -> Generator[GitWorktreeItem, None, None]:
     """Internal helper for iter_gitworktree() tp support recursion"""
 
-    lsfiles_args = ['--stage', '--cached']
-    if untracked:
-        lsfiles_args.extend(lsfiles_untracked_args[untracked])
+    # perform an implicit test of whether the `untracked` mode is known
+    lsfiles_args = list(lsfiles_untracked_args[untracked])
 
     if pathspecs:
         lsfiles_args.extend(pathspecs.arglist())

--- a/datalad_next/iter_collections/tests/test_itergitstatus.py
+++ b/datalad_next/iter_collections/tests/test_itergitstatus.py
@@ -146,7 +146,8 @@ def _assert_testcases(st, tc):
         assert st[c['name']].status == c['status']
         mod_types = st[c['name']].modification_types
         if 'qual' in c:
-            assert set(mod_types) == set(c['qual'])
+            assert set(mod_types) == set(c['qual']), \
+                f'Mismatch for {c=!r}'
         else:
             assert mod_types is None
 

--- a/datalad_next/iter_collections/tests/test_itergitstatus.py
+++ b/datalad_next/iter_collections/tests/test_itergitstatus.py
@@ -38,9 +38,9 @@ def test_status_homogeneity(modified_dataset):
         dict(path=ds.pathobj, eval_submodule_state='commit', recursive='repository'),
         dict(path=ds.pathobj, eval_submodule_state='commit', recursive='submodules'),
         # without untracked
-        dict(path=ds.pathobj, untracked='no', recursive='no'),
-        dict(path=ds.pathobj, untracked='no', recursive='repository'),
-        dict(path=ds.pathobj, untracked='no', recursive='submodules'),
+        dict(path=ds.pathobj, untracked=None, recursive='no'),
+        dict(path=ds.pathobj, untracked=None, recursive='repository'),
+        dict(path=ds.pathobj, untracked=None, recursive='submodules'),
         # special untracked modes
         dict(path=ds.pathobj, untracked='whole-dir', recursive='no'),
         dict(path=ds.pathobj, untracked='whole-dir', recursive='repository'),

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -239,6 +239,28 @@ def test_iter_gitworktree_basic_fp(existing_dataset, no_result_rendering):
     assert not fcount
 
 
+def test_iter_gitworktree_untracked_only(modified_dataset):
+    p = modified_dataset.pathobj
+    # only untracked files
+    repo_items = list(iter_gitworktree(p, untracked='only'))
+    assert all(f.name.name == 'file_u' for f in repo_items)
+    # same report, but compressed to immediate directory children
+    dir_items = list(iter_gitworktree(p, untracked='only', recursive='no'))
+    assert set(f.name.parts[0] for f in repo_items) == \
+        set(f.name.name for f in dir_items)
+    # no wholly untracked directories in standard report
+    assert not any(f.name.name == 'dir_u'
+                   for f in iter_gitworktree(p, untracked='only'))
+    # but this can be requested
+    wholedir_items = list(iter_gitworktree(p, untracked='only-whole-dir'))
+    assert any(f.name.name == 'dir_u' for f in wholedir_items)
+    # smoke test remaining mode, test case doesn't cause difference
+    assert any(f.name.name == 'dirempty_u' for f in wholedir_items)
+    assert not any(f.name.name == 'dirempty_u'
+                   for f in iter_gitworktree(p, untracked='only-no-empty-dir'))
+
+
+
 def test_iter_gitworktree_pathspec(modified_dataset):
     p = modified_dataset.pathobj
     # query for any files that are set to go straight to Git. these are just

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -241,7 +241,7 @@ def test_iter_gitworktree_basic_fp(existing_dataset, no_result_rendering):
 
 def test_iter_gitworktree_pathspec(modified_dataset):
     p = modified_dataset.pathobj
-    # query for any files that a set to go straight to Git. these are just
+    # query for any files that are set to go straight to Git. these are just
     # dotfiles in the default config
     items = list(iter_gitworktree(
         p,

--- a/datalad_next/iter_collections/tests/test_itergitworktree.py
+++ b/datalad_next/iter_collections/tests/test_itergitworktree.py
@@ -274,3 +274,19 @@ def test_iter_submodules(modified_dataset):
     res = list(iter_submodules(p, pathspecs=[':(exclude)*/sm_c']))
     assert len(res) == len(all_sm) - 1
     assert not any(r.name == PurePath('dir_sm', 'sm_c') for r in res)
+
+    # test pathspecs matching inside submodules
+    # baseline, pointing inside a submodule gives no matching results
+    assert not list(iter_submodules(p, pathspecs=['dir_sm/sm_c/.datalad']))
+    # we can discover the submodule that could have content that matches
+    # the pathspec
+    res = list(iter_submodules(p, pathspecs=['dir_sm/sm_c/.datalad'],
+                               match_containing=True))
+    assert len(res) == 1
+    assert res[0].name == PurePath('dir_sm', 'sm_c')
+    # if we use a wildcard that matches any submodule, we also get all of them
+    # and this includes the dropped submodule, because iter_submodules()
+    # make no assumptions on what this information will be used for
+    res = list(iter_submodules(p, pathspecs=['*/.datalad'],
+                               match_containing=True))
+    assert len(res) == len(all_sm)

--- a/docs/source/pyutils.rst
+++ b/docs/source/pyutils.rst
@@ -23,6 +23,7 @@ packages.
    credman
    datasets
    exceptions
+   gitpathspec
    iterable_subprocess
    itertools
    iter_collections


### PR DESCRIPTION
This is yet another attempt towards pathspecs. It replaces #714 with something even more low-level and lightweight.

- Closes: #587

TODO

- [x] Clarify `None` vs `[]` for `GitPathSpecs`