### PR TITLE
Remove non-asserting test from align_pattern tests

### DIFF
--- a/datalad_next/itertools/tests/test_align_pattern.py
+++ b/datalad_next/itertools/tests/test_align_pattern.py
@@ -26,25 +26,6 @@ def test_pattern_processor(data_chunks, pattern, expected):
     assert expected == list(align_pattern(data_chunks, pattern=pattern))
 
 
-def test_performance():
-    # Ensure that the performance of align_pattern is acceptable for large
-    # data chunks and patterns.
-    number = 10
-    pattern = b'01234'
-    data_chunks = [b'a' * 1000 for _ in range(100 * 1000)] + [pattern]
-
-    result_base = timeit.timeit(
-        lambda: tuple(data_chunks),
-        number=number,
-    )
-    result_iter = timeit.timeit(
-        lambda: tuple(align_pattern(data_chunks, pattern=pattern)),
-        number=number,
-    )
-
-    print(result_base, result_iter, result_iter / result_base)
-
-
 def test_newline_matches():
     pattern = b'----datalad-end-marker-3654137433-rekram-dne-dalatad----\n'
     chunk1 =  b'Have a lot of fun...\n----datalad-end-marker-3654137433-r'


### PR DESCRIPTION
This PR deletes the test `datalad_next.itertools.tests.test_align_pattern.test_performance`, which did not assert any properties, but just printed some performance measurements.
