### PR TITLE
Fix type annotation of exception arguments

### DIFF
--- a/datalad_next/url_operations/file.py
+++ b/datalad_next/url_operations/file.py
@@ -175,11 +175,11 @@ class FileUrlOperations(UrlOperations):
                 ))
                 return props
         except FileNotFoundError as e:
-            raise UrlOperationsResourceUnknown(url) from e
+            raise UrlOperationsResourceUnknown(from_path) from e
         except Exception as e:
             # wrap this into the datalad-standard, but keep the
             # original exception linked
-            raise UrlOperationsRemoteError(from_url, message=str(e)) from e
+            raise UrlOperationsRemoteError(to_url, message=str(e)) from e
         finally:
             if src_fp and from_path is not None:
                 src_fp.close()

--- a/datalad_next/url_operations/tests/test_file.py
+++ b/datalad_next/url_operations/tests/test_file.py
@@ -1,8 +1,8 @@
 import io
-import locale
 import pytest
 import sys
 
+from datalad_next.tests import skip_if_on_windows
 from datalad_next.utils import on_linux
 
 from ..file import (
@@ -100,3 +100,12 @@ def test_file_url_delete(tmp_path):
         assert not list(test_path.parent.iterdir())
         ops.delete(test_path.parent.as_uri())
         assert not test_path.parent.exists()
+
+
+@skip_if_on_windows
+def test_file_url_upload_errors(tmp_path):
+    source = tmp_path / 'source'
+    source.write_text('Some content\n')
+    fops = FileUrlOperations()
+    with pytest.raises(UrlOperationsRemoteError) as e:
+        fops.upload(source, 'file:///tmp//')


### PR DESCRIPTION
This PR fixes the type annotations of the arguments to `UrlOperationsRessourceUnknown` and `UrlOperationsRemoteError` in `FileUrlOperations.upload()`. and add A regression test for `UrlOperationsRemoteError`.
