### PR TITLE
Test: disable `datalad.locals.test.test_wtf.test_wtf`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -205,6 +205,8 @@ environment:
     - job_name: datalad-core-4
       DTS: >
         datalad.local
+      KEYWORDS: >
+        not test_wtf
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       PY: 3.8
       INSTALL_SYSPKGS:


### PR DESCRIPTION
This PR disables the test `datalad.locals.tests.test_wtf.test_wtf`. The test fails due to an error in datalad's test code and leads to failing `datalad-next`-CI runs.

A fix has been proposed in datalad, see
[issue datalad #7627](https://github.com/datalad/datalad/issues/7627) and the corresponding [PR datalad #7628](https://github.com/datalad/datalad/pull/7628).

Once [PR datalad #7628](https://github.com/datalad/datalad/pull/7628) is merged the commit in this PR can be reverted.
