### PR TITLE
fix(`gitworktree`): decode bytes before itemization

### DIFF
--- a/datalad_next/iter_collections/gitworktree.py
+++ b/datalad_next/iter_collections/gitworktree.py
@@ -530,12 +530,10 @@ def _git_ls_files(path: Path, *args) -> Iterator[str]:
             ],
             cwd=path,
     ) as r:
-        yield from decode_bytes(
-            itemize(
-                r,
-                sep=b'\0',
-                keep_ends=False,
-            )
+        yield from itemize(
+            decode_bytes(r, backslash_replace=True),
+            sep='\0',
+            keep_ends=False,
         )
 
 


### PR DESCRIPTION
`decode_bytes()` can yield multiple output chunks for one input chunk (in the case of decoding errors). This implies that it cannot be meaningfully used after `itemize()` without threatening the semantics of the items (i.e., with split-by-line items are no longer unique lines).

For this reason, this commit changes the order of these helpers in the `gitworktree()` implementation.

Refs: https://github.com/datalad/datalad-next/issues/740