### PR TITLE
fix(`decode_bytes`): always backslashreplace when asked to

### DIFF
--- a/datalad_next/itertools/decode_bytes.py
+++ b/datalad_next/itertools/decode_bytes.py
@@ -103,11 +103,8 @@ def decode_bytes(
         else:
             return (
                 position + exc.end,
-                joined_data[:position + exc.start].decode(encoding)
-                + joined_data[position + exc.start:position + exc.end].decode(
-                    encoding,
-                    errors='backslashreplace'
-                ),
+                joined_data[:position + exc.end].decode(
+                    encoding, errors='backslashreplace')
             )
 
     joined_data = b''

--- a/datalad_next/itertools/decode_bytes.py
+++ b/datalad_next/itertools/decode_bytes.py
@@ -103,8 +103,11 @@ def decode_bytes(
         else:
             return (
                 position + exc.end,
-                joined_data[:position + exc.end].decode(
-                    encoding, errors='backslashreplace')
+                joined_data[position:position + exc.start].decode(encoding)
+                + joined_data[position + exc.start:position + exc.end].decode(
+                    encoding,
+                    errors='backslashreplace'
+                ),
             )
 
     joined_data = b''

--- a/datalad_next/itertools/tests/test_decode_bytes.py
+++ b/datalad_next/itertools/tests/test_decode_bytes.py
@@ -35,3 +35,8 @@ def test_no_empty_strings():
     # check that empty strings are not yielded
     r = tuple(decode_bytes([b'\xc3', b'\xb6']))
     assert r == ('ö',)
+
+
+def test_multiple_errors():
+    r = ''.join(decode_bytes([b'08 War \xaf No \xaf More \xaf Trouble.shn.mp3']))
+    assert r == '08 War \\xaf No \\xaf More \\xaf Trouble.shn.mp3'


### PR DESCRIPTION
The previous implementation enabled error handling in decoding only for the segment of a bytestring that an exception was raised for.

However, it may well be that more decoding errors exist in other parts of the bytestring. I have a complicated real-world case where this happens, i.e. raising `UnicodeDecodeError` again, even though `decode_bytes` was called with `backslash_replace=True`.  Unfortunately the data is so large that I did not manage to catch the condition exactly.

It seems to be a needless sophistication to decode some part of the bytestring with error handling, but not another.

There is a good chance that this patch is badly interacting with the logic to obtain the next chunk before attempting a decoding again.