### PR TITLE
Fix `CreateSiblingRia` code in `replace_create_sibling_ria.py`

### DIFF
--- a/datalad_next/patches/replace_create_sibling_ria.py
+++ b/datalad_next/patches/replace_create_sibling_ria.py
@@ -344,7 +344,7 @@ class CreateSiblingRia(Interface):
         # be different for subdatasets.
         # PATCH: use canonified representation of `url` and `push_url`
         url = canonify_url(url)
-        push_url = canonify_url(url)
+        push_url = canonify_url(push_url)
 
         try:
             ssh_host, url_base_path_str, rewritten_url = \


### PR DESCRIPTION
This PR fixes a bug where the canonified ria-store URL was assigned to `push_url` instead of the
canonified ria-store **push-URL**.
