### PR TITLE
Fix tests: bring back datalad core wtf-test

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -228,6 +228,7 @@ environment:
 # only run the CI if there are code or tooling changes
 only_commits:
   files:
+    - .appveyor.yml
     - datalad_next/
     - tools/
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -205,8 +205,6 @@ environment:
     - job_name: datalad-core-4
       DTS: >
         datalad.local
-      KEYWORDS: >
-        not test_wtf
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       PY: 3.8
       INSTALL_SYSPKGS:


### PR DESCRIPTION
With datalad release 1.1.1 `test_wtf` will pass and no longer let CI fail.
