### PR TITLE
docs: remove unused intersphinx extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',


### PR DESCRIPTION
I saw a deprecation warning in a recent doc build (https://github.com/datalad/datalad-next/actions/runs/10028357984/job/27715183098), but did not find the intersphinx mapping that was complained about anymore, so I assume it was removed. Thus, as far as I can see, this extension isn't used anymore