### PR TITLE
doc: trim module API documentation to an overview table of content

### DIFF
--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -17,7 +17,4 @@
 {{ underline }}
 
 .. automodule:: {{ fullname }}
-   :members:
-   :undoc-members:
-   :show-inheritance:
 {% endif %}


### PR DESCRIPTION
Previously, the setup was confusing. Every symbol imported to module level was documented directly. If a ToC was added, sphinx would fail due to documentation generated twice for the same symbol.

The new setup **requires** a dedicated autosummary selection of documented content.

I think this is better. Often modules provide a lot of stuff, and direct documentation rendering on a single page is overwhelming. The explicit selection also allows for items to be excluded that are only there for technical or historical reasons. This allows for an overall more accessible documentation.