### PR TITLE
Include a link to documentation page in project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/datalad/datalad-next"
-Documentation = "https://github.com/datalad/datalad-next#readme"
+Documentation = "https://docs.datalad.org/projects/next/en/latest/"
 Issues = "https://github.com/datalad/datalad-next/issues"
 Source = "https://github.com/datalad/datalad-next"
 Changelog = "https://github.com/datalad/datalad-next/blob/main/CHANGELOG.md"


### PR DESCRIPTION
The project.urls are picked up and displayed (with matching icons, if
possible) by pypi.org. DataLad-next has its online documentation under
docs.datalad.org and it is pretty good. Given that we already include
a GitHub link in project.urls anyway (twice, in fact), it could be
better to point Documentation to the online docs, rather than the
GitHub README.

What do you think?

Side note: I would even be tempted to remove the Homepage link and
only keep Source (currently they are the same and point to the GitHub
project), but I wasn't sure if the Homepage is considered necessary or
not, and hence didn't include it in the original proposal.