### PR TITLE
test: fix test_tree_with_broken_symlinks on Python 3.13

### DIFF
--- a/datalad_next/commands/tests/test_tree.py
+++ b/datalad_next/commands/tests/test_tree.py
@@ -786,7 +786,7 @@ class TestTreeFilesystemIssues:
         link_to_self.symlink_to(link_to_self)
         with assert_raises((RuntimeError, OSError)):  # OSError on Windows
             # resolution should fail because of infinite loop
-            link_to_self.resolve()
+            link_to_self.resolve(strict=True)
 
         # 3. good symlink pointing to existing directory
         link_to_dir1 = tmp_path / 'links' / '3_link_to_dir1'


### PR DESCRIPTION
https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve says:

  _Changed in version 3.13:_ Symlink loops are treated like other
  errors: `OSError` is raised in strict mode, and no exception is raised
  in non-strict mode. In previous versions, `RuntimeError` is raised no
  matter the value of _strict_.

Adjust a test to take account of this.