### PR TITLE
fix: handle URLs more gracefully

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -32,6 +32,11 @@
             "orcid": "0000-0001-7628-0801"
         },
         {
+            "affiliation": "Institute of Climate and Energy Systems - Stratosphere (ICE-4), Forschungszentrum Jülich, Jülich, Germany",
+            "name": "Riße, Matthias",
+            "orcid": "0009-0006-6081-9327"
+        },
+        {
             "affiliation": "Institute of Neuroscience and Medicine, Brain & Behaviour (INM-7), Research Centre Jülich, Jülich, Germany",
             "name": "Szczepanik, Michał",
             "orcid": "0000-0002-4028-2087"

--- a/datalad_next/annexremotes/uncurl.py
+++ b/datalad_next/annexremotes/uncurl.py
@@ -528,10 +528,13 @@ class UncurlRemote(SpecialRemote):
                 handler(url)
                 # we succeeded, no need to try again
                 return True
-            except UrlOperationsResourceUnknown:
-                # general system access worked, but at the key location is nothing
-                # to be found
-                return False
+            except (UrlOperationsResourceUnknown, ValueError):
+                # UrlOperationsResourceUnknown: general system access worked, but
+                # at the key location is nothing to be found
+                # ValueError: something else went wrong trying to handle the URL
+                # (e.g. unknown scheme)
+                # -> try the next URL
+                pass
             except UrlOperationsRemoteError as e:
                 # return False only if we could be sure that the remote
                 # system works properly and just the key is not around


### PR DESCRIPTION
Previously an unknown URL (e.g. from a different special remote) would crash the uncurl remote. Additionally, if a key had more than one URL registered only one was tried in some cases.

Now, if the data is not found at one location or the URLs scheme is unsupported, the next URL is tried instead.

Fixes #770.