### PR TITLE
fix: include ZipArchiveOperations in Archivist's handlers

### DIFF
--- a/datalad_next/annexremotes/archivist.py
+++ b/datalad_next/annexremotes/archivist.py
@@ -528,6 +528,12 @@ class _ArchiveHandlers:
                 ainfo.local_path,
                 cfg=self._repo.config,
             )
+        elif ainfo.type == ArchiveType.zip:
+            from datalad_next.archive_operations import ZipArchiveOperations
+            return ZipArchiveOperations(
+                ainfo.local_path,
+                cfg=self._repo.config,
+            )
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
Although `ZipArchiveOperations` have been added in v1.1.0 (gh #578), and the [changelog](https://github.com/datalad/datalad-next/blob/main/CHANGELOG.md#110-2024-01-21----iterate) includes the following:

> A new ZipArchiveOperations class added support for ZIP files, and enables their use together with the archivist git-annex special remote.

...the `ZipArchiveOperations` were not used. Archivist only used `TarArchiveOperations`, and raised a `NotImplementedError` if the archive type was other than tar. This is now addressed.

This change equips the archivist special remote with the ability to oprerate on ZIP files. Now, ZIP is included among the the archive types checked (if/else) when selecting the right archive handler.

---
With thanks to @jsheunis for using zip files with the archivist special remote.