### PR TITLE
ci: give SSH daemon some time to start

### DIFF
--- a/tools/appveyor/setup-sshd
+++ b/tools/appveyor/setup-sshd
@@ -41,6 +41,9 @@ ssh-keygen \
 # establish expected permission setup for SSH key
 chmod 600 "${DATALAD_TESTS_SERVER_SSH_SECKEY}"
 
+# give the service some time to start
+sleep 10
+
 # ingest actual host key
 ssh-keyscan \
   -t ecdsa \


### PR DESCRIPTION
This attempts to address the failing appveyor test setup that shows itself like

```
+ ssh-keyscan -t ecdsa -p 2222 -H datalad-test-sshd
datalad-test-sshd: Connection closed by remote host
[ "$DATALAD_TESTS_SSH" = 1 ] && tools/appveyor/verify-ssh-access || true
The authenticity of host '[datalad-test-sshd]:2222 ([127.0.0.1]:2222)' can't be established.
ED25519 key fingerprint is SHA256:vhHUUr5S6k9yLh3G/XuaKqHVSYNc7st4uqzTGRWQRow.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])?
```