### PR TITLE
fix: use Bearer for token credentials with Basic-only challenge

### DIFF
--- a/datalad_next/utils/requests_auth.py
+++ b/datalad_next/utils/requests_auth.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import logging
 from typing import Dict
 from urllib.parse import urlparse
+
 import requests
 
 from datalad_next.config import ConfigManager
 from datalad_next.credman import CredentialManager
+
 from .http_helpers import get_auth_realm
 
 lgr = logging.getLogger('datalad.ext.next.utils.requests_auth')
@@ -285,13 +287,19 @@ class DataladAuth(requests.auth.AuthBase):
             # if there is no authentication scheme identified, look at the
             # credential, if it knows
             ascheme = cred.get('http_auth_scheme')
-            # if it does not, go with the first supported scheme that matches
-            # the credential type, one is guaranteed to match
-            ascheme = [
+        if ascheme is None:
+            # go with the first supported scheme that matches the credential
+            # type; fall back to 'bearer' for token credentials when the
+            # server advertises only basic (e.g. dCache with empty realm)
+            matching = [
                 c for c in auth_schemes
                 if c in DataladAuth._supported_auth_schemes
                 and cred.get('type') == DataladAuth._supported_auth_schemes[c]
-            ][0]
+            ]
+            if matching:
+                ascheme = matching[0]
+            elif cred.get('type') == 'token':
+                ascheme = 'bearer'
 
         if ascheme == 'basic':
             return self._authenticated_rerequest(

--- a/datalad_next/utils/tests/test_requests_auth.py
+++ b/datalad_next/utils/tests/test_requests_auth.py
@@ -1,0 +1,36 @@
+import requests
+
+from ..requests_auth import DataladAuth
+
+
+def test_token_credential_uses_bearer_with_basic_only_challenge():
+    response = requests.Response()
+    response.status_code = 401
+    response.url = 'https://example.com/file'
+    response.headers['www-authenticate'] = 'Basic realm=""'
+
+    auth = DataladAuth.__new__(DataladAuth)
+
+    def get_credential(url, auth_schemes):
+        assert url == response.url
+        assert auth_schemes == {'basic': {'realm': ''}}
+        return None, 'mytoken', {
+            'type': 'token',
+            'secret': 'sekrit',
+        }
+
+    rerequest = {}
+
+    def authenticated_rerequest(response_, request_auth, **kwargs):
+        rerequest['response'] = response_
+        prep = requests.Request('GET', response_.url).prepare()
+        request_auth(prep)
+        return prep
+
+    auth._get_credential = get_credential
+    auth._authenticated_rerequest = authenticated_rerequest
+
+    renewed_request = auth.handle_401(response)
+
+    assert rerequest['response'] is response
+    assert renewed_request.headers['Authorization'] == 'Bearer sekrit'


### PR DESCRIPTION
## Problem

When a server responds to an unauthenticated request with
`WWW-Authenticate: Basic realm=""` and the stored credential is of type
`token` (Bearer), `handle_401` crashes with `IndexError: list index out of range`.

The root cause is in the `if ascheme is None` block:

```python
ascheme = cred.get('http_auth_scheme')   # set, but immediately overwritten
ascheme = [
    c for c in auth_schemes
    if c in DataladAuth._supported_auth_schemes
    and cred.get('type') == DataladAuth._supported_auth_schemes[c]
][0]   # IndexError when list is empty (Basic != token)
```

Two bugs:
1. The `http_auth_scheme` value from the credential is overwritten
   unconditionally by the list comprehension below it.
2. The list comprehension result is indexed with `[0]` without guarding
   against an empty list.

## Error

```
$ datalad --dbg download --credential mytoken https://example.com/file

download(error): file [download failure] [list index out of range]
...
'exception': list index out of range
  [requests_auth.py:handle_401:290],
```

## Fix

- Split into two separate `if ascheme is None` checks so `http_auth_scheme`
  from the credential is honoured before the list comprehension runs.
- Guard the list comprehension with `if matching:` instead of bare `[0]`.
- Add fallback: if the credential type is `token` and no matching scheme
  was found, try Bearer anyway.

## Steps to reproduce

1. Store a credential of type `token` for an HTTP endpoint:
   ```
   datalad credentials set mytoken type=token \
     realm=https://example.com \
     secret=<some-token>
   ```
2. Download from a server that responds to unauthenticated requests with
   `WWW-Authenticate: Basic realm=""` but accepts Bearer tokens:
   ```
   datalad download --credential mytoken https://example.com/file
   ```
3. → `IndexError: list index out of range` in `handle_401`

This combination occurs with dCache WebDAV endpoints using OIDC
authentication: dCache advertises only Basic in its 401 challenge but
requires a Bearer token.

## TODO

- [x] Add a unit test for the case where a `type=token` credential meets a `Basic`-only `WWW-Authenticate` header
    Tested with
    ```
    uv run --with pytest pytest datalad_next/utils/tests/test_requests_auth.py  datalad_next/utils/tests/test_parse_www_authenticate.py
    ```